### PR TITLE
fix(codeql): Add missing exports to phentrieve/config.py __all__

### DIFF
--- a/phentrieve/config.py
+++ b/phentrieve/config.py
@@ -25,10 +25,15 @@ __all__ = [
     "DEFAULT_BENCHMARK_FILE",
     "DEFAULT_HPO_FILENAME",
     "DEFAULT_HPO_DB_FILENAME",
+    # Benchmark result subdirectories
+    "DEFAULT_SUMMARIES_SUBDIR",
+    "DEFAULT_DETAILED_SUBDIR",
+    "DEFAULT_VISUALIZATIONS_SUBDIR",
     # Models
     "DEFAULT_MODEL",
     "DEFAULT_BIOLORD_MODEL",
     "JINA_MODEL_ID",
+    "BENCHMARK_MODELS",
     # Retrieval settings
     "DEFAULT_TOP_K",
     "DEFAULT_K_VALUES",
@@ -45,6 +50,11 @@ __all__ = [
     "DEFAULT_LANGUAGE",
     # HPO ontology
     "PHENOTYPE_ROOT",
+    # HPO data configuration
+    "HPO_VERSION",
+    "HPO_BASE_URL",
+    "HPO_DOWNLOAD_TIMEOUT",
+    "HPO_CHUNK_SIZE",
     # Chunking configurations
     "DEFAULT_CHUNK_PIPELINE_CONFIG",
     "SIMPLE_CHUNKING_CONFIG",


### PR DESCRIPTION
## Summary

- Add 9 global variables to `__all__` in `phentrieve/config.py` to mark them as public API exports
- Resolves all 9 remaining CodeQL `py/unused-global-variable` alerts

## Variables Added to `__all__`

- `DEFAULT_SUMMARIES_SUBDIR`, `DEFAULT_DETAILED_SUBDIR`, `DEFAULT_VISUALIZATIONS_SUBDIR` (benchmark result subdirectories)
- `BENCHMARK_MODELS` (list of models for benchmarking)
- `HPO_VERSION`, `HPO_BASE_URL`, `HPO_DOWNLOAD_TIMEOUT`, `HPO_CHUNK_SIZE` (HPO data configuration)

## Test Plan

- [x] Lint check passes (`make check`)
- [x] Type check passes (`make typecheck-fast`)
- [ ] CI passes