### PR TITLE
feat(api,cli): expose HPO version from database (#116)

### DIFF
--- a/api/routers/config_info_router.py
+++ b/api/routers/config_info_router.py
@@ -6,6 +6,8 @@ default settings, and system status to clients (e.g., frontend applications).
 """
 
 import logging
+from pathlib import Path
+from typing import Optional
 
 from fastapi import APIRouter, HTTPException
 
@@ -23,6 +25,48 @@ from phentrieve.evaluation.metrics import load_hpo_graph_data
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["Configuration & Information"])
+
+
+def _get_hpo_metadata() -> dict[str, Optional[str | int]]:
+    """Load HPO metadata from database.
+
+    Returns:
+        Dictionary with version, download_date, and term_count.
+        Values are None if database is unavailable.
+    """
+    result: dict[str, Optional[str | int]] = {
+        "version": None,
+        "download_date": None,
+        "term_count": None,
+    }
+
+    try:
+        from phentrieve.config import DEFAULT_HPO_DB_FILENAME
+        from phentrieve.data_processing.hpo_database import HPODatabase
+        from phentrieve.utils import get_default_data_dir
+
+        # Try to find HPO database
+        db_path = get_default_data_dir() / DEFAULT_HPO_DB_FILENAME
+        if not db_path.exists():
+            # Fallback to relative path for Docker/dev environments
+            db_path = Path("data") / DEFAULT_HPO_DB_FILENAME
+
+        if not db_path.exists():
+            logger.debug("HPO database not found at %s", db_path)
+            return result
+
+        db = HPODatabase(db_path)
+        try:
+            result["version"] = db.get_metadata("hpo_version")
+            result["download_date"] = db.get_metadata("hpo_download_date")
+            result["term_count"] = db.get_term_count()
+        finally:
+            db.close()
+
+    except Exception as e:
+        logger.warning("Failed to load HPO metadata: %s", e)
+
+    return result
 
 
 @router.get(
@@ -100,14 +144,20 @@ async def get_phentrieve_info():
             default_strategy="sliding_window_punct_conj_cleaned",  # Updated default strategy
         )
 
-        # HPO Data Status
-        hpo_data_status_dict = {"ancestors_loaded": False, "depths_loaded": False}
+        # HPO Data Status - load graph data and metadata
+        hpo_data_status_dict: dict = {"ancestors_loaded": False, "depths_loaded": False}
         try:
             ancestors, depths = load_hpo_graph_data()
             hpo_data_status_dict["ancestors_loaded"] = bool(ancestors)
             hpo_data_status_dict["depths_loaded"] = bool(depths)
         except Exception as e:
-            logger.warning(f"API: Unable to check HPO data status: {e}")
+            logger.warning(f"API: Unable to check HPO graph data status: {e}")
+
+        # Load HPO metadata from database
+        hpo_metadata = _get_hpo_metadata()
+        hpo_data_status_dict["version"] = hpo_metadata["version"]
+        hpo_data_status_dict["download_date"] = hpo_metadata["download_date"]
+        hpo_data_status_dict["term_count"] = hpo_metadata["term_count"]
 
         hpo_data_status = HPODataStatusAPI(**hpo_data_status_dict)
         logger.info(f"API: HPO data status: {hpo_data_status_dict}")

--- a/api/schemas/config_info_schemas.py
+++ b/api/schemas/config_info_schemas.py
@@ -5,6 +5,8 @@ This module defines the data structures used for the configuration/info API
 endpoint responses, ensuring consistent and well-documented API contracts.
 """
 
+from typing import Optional
+
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -80,11 +82,19 @@ class ChunkingConfig(BaseModel):
 
 
 class HPODataStatusAPI(BaseModel):
-    """Status of HPO data files."""
+    """Status and metadata of HPO data."""
 
     model_config = ConfigDict(
         json_schema_extra={
-            "examples": [{"ancestors_loaded": True, "depths_loaded": True}]
+            "examples": [
+                {
+                    "ancestors_loaded": True,
+                    "depths_loaded": True,
+                    "version": "v2025-03-03",
+                    "download_date": "2025-12-08T10:12:25+00:00",
+                    "term_count": 19534,
+                }
+            ]
         }
     )
 
@@ -92,6 +102,15 @@ class HPODataStatusAPI(BaseModel):
         description="Whether the HPO ancestor data is loaded"
     )
     depths_loaded: bool = Field(description="Whether the HPO depth data is loaded")
+    version: Optional[str] = Field(
+        default=None, description="HPO ontology version (e.g., 'v2025-03-03')"
+    )
+    download_date: Optional[str] = Field(
+        default=None, description="ISO timestamp when HPO data was downloaded"
+    )
+    term_count: Optional[int] = Field(
+        default=None, description="Total number of HPO terms in the database"
+    )
 
 
 class PhentrieveConfigInfoResponseAPI(BaseModel):
@@ -137,6 +156,9 @@ class PhentrieveConfigInfoResponseAPI(BaseModel):
                     "hpo_data_status": {
                         "ancestors_loaded": True,
                         "depths_loaded": True,
+                        "version": "v2025-03-03",
+                        "download_date": "2025-12-08T10:12:25+00:00",
+                        "term_count": 19534,
                     },
                 }
             ]


### PR DESCRIPTION
## Summary
- Expose HPO metadata (version, download_date, term_count) via API `/api/v1/info` endpoint
- Show HPO version and term count in CLI `--version` output
- All values loaded dynamically from `hpo_data.db` SQLite database

## Changes

### API (`/api/v1/info`)
- Extended `HPODataStatusAPI` schema with `version`, `download_date`, `term_count` fields
- Added `_get_hpo_metadata()` helper to load from database

### CLI (`--version`)
- Added `_get_hpo_info()` helper to load from database
- Enhanced version output with HPO data info
- Graceful fallback when database not available

## Example Output

**CLI:**
```
$ phentrieve --version
Phentrieve CLI version: 0.5.0
HPO Data: v2025-03-03 (19,534 terms)
```

**API:**
```json
"hpo_data_status": {
  "ancestors_loaded": true,
  "depths_loaded": true,
  "version": "v2025-03-03",
  "download_date": "2025-12-08T10:12:25+00:00",
  "term_count": 19534
}
```

## Test plan
- [x] All 589 tests pass
- [x] Lint checks pass (ruff format, ruff check)
- [x] Type checks pass (mypy)
- [x] Manual CLI verification
- [x] New test for HPO data not loaded scenario

Closes #116