### PR TITLE
fix: Allow benchmark command to use default model from config

### DIFF
--- a/phentrieve/cli/benchmark_commands.py
+++ b/phentrieve/cli/benchmark_commands.py
@@ -92,23 +92,32 @@ def run_benchmarks(
 
     typer.echo("Starting benchmark evaluation...")
 
-    results = orchestrate_benchmark(
-        test_file=test_file or "",
-        model_name=model_name or "",
-        model_list=model_list or "",
-        all_models=all_models,
-        similarity_threshold=similarity_threshold,
-        cpu=cpu,
-        detailed=detailed,
-        output=output or "",
-        debug=debug,
-        create_sample=create_sample,
-        trust_remote_code=trust_remote_code,
-        enable_reranker=enable_reranker,
-        reranker_model=reranker_model,
-        rerank_count=rerank_count,
-        similarity_formula=similarity_formula,
-    )
+    # Build kwargs with only non-None optional values to allow orchestrator defaults
+    kwargs: dict = {
+        "all_models": all_models,
+        "similarity_threshold": similarity_threshold,
+        "cpu": cpu,
+        "detailed": detailed,
+        "debug": debug,
+        "create_sample": create_sample,
+        "trust_remote_code": trust_remote_code,
+        "enable_reranker": enable_reranker,
+        "rerank_count": rerank_count,
+        "similarity_formula": similarity_formula,
+    }
+    # Only add optional string params when provided (allows orchestrator defaults)
+    if test_file is not None:
+        kwargs["test_file"] = test_file
+    if model_name is not None:
+        kwargs["model_name"] = model_name
+    if model_list is not None:
+        kwargs["model_list"] = model_list
+    if output is not None:
+        kwargs["output"] = output
+    if reranker_model is not None:
+        kwargs["reranker_model"] = reranker_model
+
+    results = orchestrate_benchmark(**kwargs)
 
     if results:
         if isinstance(results, list):


### PR DESCRIPTION
## Summary

- Fixes CLI passing empty strings that override config defaults when `--model-name` not specified
- Only pass optional string params (`test_file`, `model_name`, `model_list`, `output`, `reranker_model`) when explicitly provided
- Allows `orchestrate_benchmark` to use `DEFAULT_MODEL` from `phentrieve.yaml`

## Test plan

- [x] `make check` - 0 lint/format errors
- [x] `make typecheck-fast` - 0 type errors
- [x] `make test` - 672 tests pass
- [x] New regression test `test_benchmark_passes_explicit_model_name` added
- [x] Updated `test_benchmark_with_default_parameters` to verify correct behavior

Fixes #122