### PR TITLE
fix: Add ENV=production and data sync to Docker entrypoint (#142, #143)

### DIFF
--- a/.env.docker.template
+++ b/.env.docker.template
@@ -46,6 +46,19 @@ NPM_SHARED_NETWORK_NAME=npm_default
 # Logging level for API (DEBUG, INFO, WARNING, ERROR, CRITICAL)
 LOG_LEVEL_API=INFO
 
+# Environment indicator for version info endpoint (Issue #143)
+# Values: production, staging, development
+# Default: production (for docker-compose deployments)
+ENV=production
+
+# Data sync configuration (Issue #142)
+# When deploying with volume mounts, the entrypoint script compares embedded
+# data version with mounted data and syncs if versions differ.
+# PHENTRIEVE_DATA_SYNC: Enable/disable automatic data sync (default: true)
+# PHENTRIEVE_DATA_FORCE_SYNC: Force sync even if versions match (default: false)
+PHENTRIEVE_DATA_SYNC=true
+PHENTRIEVE_DATA_FORCE_SYNC=false
+
 # CORS: Add production frontend URLs (comma-separated, appends to defaults)
 # This allows production deployments without modifying api.yaml
 # Example: CORS_EXTRA_ORIGINS=https://phentrieve.example.com,https://app.example.com

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -335,14 +335,20 @@ COPY --chmod=755 api/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN mkdir -p /phentrieve_data_mount && \
     chown -R phentrieve:phentrieve /phentrieve_data_mount
 
-# Copy pre-built data bundle if BUNDLE_URL was provided (Issue #117)
-# This enables building images with embedded HPO data for faster cold starts
-# The bundle includes: hpo_data.db, indexes/, and manifest.json
+# Copy pre-built data bundle to TWO locations (Issue #117, Issue #142):
+# 1. /phentrieve_data_mount/ - Default data location (may be overwritten by volume mount)
+# 2. /app/embedded_data/ - Embedded copy for entrypoint data sync feature
+#
+# The entrypoint script compares manifest.json versions and syncs embedded data
+# to the mounted volume when versions differ. This ensures data format changes
+# (like adding hpo_data.db) are automatically applied on container startup.
+#
 # Using --link for independent layer rebasing (2025 best practice)
 # NOTE: Must use numeric UID:GID (10001:10001) instead of names (phentrieve:phentrieve)
 # because --link creates independent layers that can't resolve named users.
 # See: https://github.com/docker/buildx/issues/1526
 COPY --link --from=data-bundle --chown=10001:10001 /data/ /phentrieve_data_mount/
+COPY --link --from=data-bundle --chown=10001:10001 /data/ /app/embedded_data/
 
 # Create cache directory for HuggingFace models
 RUN mkdir -p /app/.cache && \

--- a/api/docker-entrypoint.sh
+++ b/api/docker-entrypoint.sh
@@ -2,13 +2,18 @@
 # =============================================================================
 # Docker Entrypoint Script for Phentrieve API
 # =============================================================================
-# This script handles runtime permission management for non-root containers
-# following Docker best practices:
+# This script handles runtime permission management and data synchronization
+# for non-root containers following Docker best practices:
 # - https://www.docker.com/blog/understanding-the-docker-user-instruction/
 # - https://denibertovic.com/posts/handling-permissions-with-docker-volumes/
 #
-# The script starts as root, fixes volume permissions, then drops to non-root
-# user (phentrieve:10001) before running the application using gosu.
+# The script starts as root, syncs embedded data if needed, fixes volume
+# permissions, then drops to non-root user (phentrieve:10001) using gosu.
+#
+# Data Sync Feature (Issue #142):
+# When deployed with volume mounts, the embedded data bundle may be newer than
+# mounted data. This script detects version mismatches via manifest.json and
+# automatically syncs embedded data to the mounted volume.
 # =============================================================================
 
 set -e
@@ -18,11 +23,19 @@ PHENTRIEVE_UID="${PHENTRIEVE_UID:-10001}"
 PHENTRIEVE_GID="${PHENTRIEVE_GID:-10001}"
 DATA_DIR="${PHENTRIEVE_DATA_ROOT_DIR:-/phentrieve_data_mount}"
 CACHE_DIR="${HF_HOME:-/app/.cache/huggingface}"
+EMBEDDED_DATA_DIR="/app/embedded_data"
+
+# Data sync behavior configuration
+# Set PHENTRIEVE_DATA_SYNC=false to disable automatic data sync
+DATA_SYNC_ENABLED="${PHENTRIEVE_DATA_SYNC:-true}"
+# Set PHENTRIEVE_DATA_FORCE_SYNC=true to always sync (useful for debugging)
+DATA_FORCE_SYNC="${PHENTRIEVE_DATA_FORCE_SYNC:-false}"
 
 # Color codes for logging
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 log_info() {
@@ -35,6 +48,155 @@ log_warn() {
 
 log_error() {
     echo -e "${RED}[entrypoint]${NC} $1"
+}
+
+log_debug() {
+    echo -e "${BLUE}[entrypoint]${NC} $1"
+}
+
+# Function to extract version from manifest.json
+# Uses Python's json module for reliable parsing (no jq dependency)
+get_manifest_version() {
+    local manifest_path="$1"
+    if [ -f "$manifest_path" ]; then
+        python3 -c "
+import json
+import sys
+try:
+    with open('$manifest_path', 'r') as f:
+        data = json.load(f)
+    # Prefer hpo_version, fallback to phentrieve_version
+    version = data.get('hpo_version', data.get('phentrieve_version', 'unknown'))
+    print(version)
+except Exception as e:
+    print('unknown', file=sys.stderr)
+    sys.exit(1)
+" 2>/dev/null || echo "unknown"
+    else
+        echo "missing"
+    fi
+}
+
+# Function to get full manifest info for logging
+get_manifest_info() {
+    local manifest_path="$1"
+    if [ -f "$manifest_path" ]; then
+        python3 -c "
+import json
+try:
+    with open('$manifest_path', 'r') as f:
+        data = json.load(f)
+    hpo_ver = data.get('hpo_version', 'unknown')
+    phentrieve_ver = data.get('phentrieve_version', 'unknown')
+    created = data.get('created_at', 'unknown')
+    print(f'HPO: {hpo_ver}, Phentrieve: {phentrieve_ver}, Created: {created}')
+except:
+    print('Unable to parse manifest')
+" 2>/dev/null || echo "Unable to read manifest"
+    else
+        echo "Manifest not found"
+    fi
+}
+
+# Function to sync embedded data to mounted volume
+sync_embedded_data() {
+    log_info "Syncing embedded data to mounted volume..."
+
+    # Ensure embedded data exists
+    if [ ! -d "$EMBEDDED_DATA_DIR" ] || [ ! -f "$EMBEDDED_DATA_DIR/manifest.json" ]; then
+        log_warn "No embedded data found at $EMBEDDED_DATA_DIR - skipping sync"
+        return 1
+    fi
+
+    # Create target directory if needed
+    mkdir -p "$DATA_DIR"
+
+    # Copy all embedded data to mounted volume
+    # Using cp -a to preserve permissions and timestamps
+    # Using rsync-like approach with cp for atomic updates
+    log_info "Copying data files..."
+
+    # Copy manifest first
+    cp -a "$EMBEDDED_DATA_DIR/manifest.json" "$DATA_DIR/manifest.json"
+
+    # Copy HPO database if exists
+    if [ -f "$EMBEDDED_DATA_DIR/hpo_data.db" ]; then
+        log_info "  - Copying hpo_data.db..."
+        cp -a "$EMBEDDED_DATA_DIR/hpo_data.db" "$DATA_DIR/hpo_data.db"
+    fi
+
+    # Copy hp.json if exists
+    if [ -f "$EMBEDDED_DATA_DIR/hp.json" ]; then
+        log_info "  - Copying hp.json..."
+        cp -a "$EMBEDDED_DATA_DIR/hp.json" "$DATA_DIR/hp.json"
+    fi
+
+    # Copy indexes directory if exists
+    if [ -d "$EMBEDDED_DATA_DIR/indexes" ]; then
+        log_info "  - Copying indexes/..."
+        rm -rf "$DATA_DIR/indexes" 2>/dev/null || true
+        cp -a "$EMBEDDED_DATA_DIR/indexes" "$DATA_DIR/indexes"
+    fi
+
+    log_info "Data sync completed successfully!"
+    return 0
+}
+
+# Function to check if data sync is needed
+check_data_sync() {
+    # Skip if sync is disabled
+    if [ "$DATA_SYNC_ENABLED" != "true" ]; then
+        log_info "Data sync disabled (PHENTRIEVE_DATA_SYNC=false)"
+        return 1
+    fi
+
+    # Force sync if requested
+    if [ "$DATA_FORCE_SYNC" = "true" ]; then
+        log_info "Force sync enabled (PHENTRIEVE_DATA_FORCE_SYNC=true)"
+        return 0
+    fi
+
+    # Check for embedded data
+    local embedded_manifest="$EMBEDDED_DATA_DIR/manifest.json"
+    local mounted_manifest="$DATA_DIR/manifest.json"
+
+    if [ ! -f "$embedded_manifest" ]; then
+        log_debug "No embedded data manifest found - sync not needed"
+        return 1
+    fi
+
+    # Get versions
+    local embedded_version
+    local mounted_version
+    embedded_version=$(get_manifest_version "$embedded_manifest")
+    mounted_version=$(get_manifest_version "$mounted_manifest")
+
+    log_info "Checking data versions:"
+    log_info "  Embedded: $(get_manifest_info "$embedded_manifest")"
+    log_info "  Mounted:  $(get_manifest_info "$mounted_manifest")"
+
+    # Sync needed if:
+    # 1. Mounted data is missing (no manifest)
+    # 2. Mounted data version is different from embedded
+    # 3. Mounted data has no HPO database
+
+    if [ "$mounted_version" = "missing" ]; then
+        log_info "Mounted data not found - sync needed"
+        return 0
+    fi
+
+    if [ ! -f "$DATA_DIR/hpo_data.db" ]; then
+        log_info "HPO database missing in mounted volume - sync needed"
+        return 0
+    fi
+
+    if [ "$embedded_version" != "$mounted_version" ]; then
+        log_info "Version mismatch detected (embedded: $embedded_version, mounted: $mounted_version) - sync needed"
+        return 0
+    fi
+
+    log_info "Data versions match - no sync needed"
+    return 1
 }
 
 # Function to fix permissions on a directory
@@ -88,9 +250,16 @@ main() {
     log_info "Starting Phentrieve API entrypoint..."
     log_info "Running as: $(id)"
 
-    # If running as root, fix permissions and switch to phentrieve user
+    # If running as root, handle data sync, fix permissions, and switch to phentrieve user
     if [ "$(id -u)" = "0" ]; then
-        log_info "Running as root - fixing permissions before dropping privileges..."
+        log_info "Running as root - handling data sync and permissions..."
+
+        # Check if data sync is needed and perform sync
+        if check_data_sync; then
+            if ! sync_embedded_data; then
+                log_warn "Data sync failed - continuing with existing data"
+            fi
+        fi
 
         # Fix permissions on data directory
         fix_permissions "$DATA_DIR" "data directory"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,14 @@ services:
       # CORS: Add production frontend URLs (appends to defaults, comma-separated)
       # Example: CORS_EXTRA_ORIGINS=https://phentrieve.example.com,https://app.example.com
       - CORS_EXTRA_ORIGINS=${CORS_EXTRA_ORIGINS:-}
+      # Environment indicator for version info endpoint (Issue #143)
+      # Values: production, staging, development
+      - ENV=${ENV:-production}
+      # Data sync configuration (Issue #142)
+      # PHENTRIEVE_DATA_SYNC: Enable/disable automatic data sync (default: true)
+      # PHENTRIEVE_DATA_FORCE_SYNC: Force sync even if versions match (default: false)
+      - PHENTRIEVE_DATA_SYNC=${PHENTRIEVE_DATA_SYNC:-true}
+      - PHENTRIEVE_DATA_FORCE_SYNC=${PHENTRIEVE_DATA_FORCE_SYNC:-false}
 
     # Enhanced health check with longer start period for model loading
     healthcheck:


### PR DESCRIPTION
## Summary

- **Issue #143**: Fix production deployment showing "development" environment in version info
- **Issue #142**: Add automatic data sync when embedded data format changes

## Changes

### Issue #143 - Environment Variable Fix
- Added `ENV=${ENV:-production}` to docker-compose.yml environment section
- Added `ENV=production` to `.env.docker.template` with documentation
- Docker Compose deployments now default to "production" environment

### Issue #142 - Data Sync Feature
- Enhanced `docker-entrypoint.sh` with data version comparison logic
- Compares `manifest.json` versions between embedded and mounted data
- Automatically syncs embedded data to mounted volume when:
  - Version mismatch detected (e.g., `v2025-11-24` vs older version)
  - Manifest is missing in mounted volume
  - HPO database (`hpo_data.db`) is missing
- Added `/app/embedded_data/` copy in Dockerfile as sync source
- New environment variables for configuration:
  - `PHENTRIEVE_DATA_SYNC`: Enable/disable auto-sync (default: `true`)
  - `PHENTRIEVE_DATA_FORCE_SYNC`: Force sync even if versions match (default: `false`)

## Docker Best Practices Applied

- Uses Python's `json` module for manifest parsing (no `jq` dependency needed)
- Preserves permissions during data copy with `cp -a`
- Graceful fallback if sync fails (continues with existing data)
- Detailed logging for debugging startup issues
- Configuration via environment variables for flexibility

## Test plan

- [x] `make check` - Format and lint checks pass
- [x] `make typecheck-fast` - Type checking passes (0 errors)
- [x] `make test` - All 791 tests pass
- [x] Bash syntax validation for entrypoint script
- [ ] Docker build test (CI will verify)
- [ ] Deploy to test environment and verify version info shows "production"
- [ ] Test data sync with volume mount containing older data version

## Related Issues

Closes #142
Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)