### PR TITLE
fix: restore docs deploy and bump cli to 0.15.0

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.9' # Adjust to match Phentrieve's Python version
+          python-version: '3.11'
 
       - name: Install MkDocs and dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ together:
 
 ---
 
+## [0.15.0] — 2026-04-17
+
+**Component versions**: phentrieve `0.15.0`, phentrieve-api `0.8.2`, phentrieve-frontend `0.7.3`
+
+Post-merge stabilization and release follow-up.
+
+### Fixed
+
+- repaired the GitHub Pages documentation deployment by aligning the docs
+  workflow Python version with the project baseline and fixing a strict MkDocs
+  warning caused by an invalid repository-root link in the test documentation
+
+### Release
+
+- bumped the Phentrieve CLI/library minor version to `0.15.0`
+
 ## [0.14.0] — 2026-04-17
 
 **Component versions**: phentrieve `0.14.0`, phentrieve-api `0.8.2`, phentrieve-frontend `0.7.0`

--- a/docs/development/running-tests.md
+++ b/docs/development/running-tests.md
@@ -118,7 +118,7 @@ def test_with_fixture(test_model):
 
 ## Test Configuration
 
-Tests are configured in [pyproject.toml](../../pyproject.toml):
+Tests are configured in the repository root `pyproject.toml` file:
 
 ```toml
 [tool.pytest.ini_options]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,7 +29,7 @@
       "url": "https://phentrieve.kidney-genetics.org/",
       "description": "AI-powered tool for accurately mapping clinical text to Human Phenotype Ontology (HPO) terms to streamline phenotype annotation for research and diagnostics.",
       "applicationCategory": "HealthcareApplication",
-      "softwareVersion": "0.14.0",
+      "softwareVersion": "0.15.0",
       "keywords": "HPO, Human Phenotype Ontology, clinical text mapping, phenotype annotation, medical AI, bioinformatics",
       "offers": {
         "@type": "Offer",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "phentrieve"
-version = "0.14.0"
+version = "0.15.0"
 description = "A CLI tool for retrieving Human Phenotype Ontology (HPO) terms from clinical text using multilingual embeddings."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2630,7 +2630,7 @@ wheels = [
 
 [[package]]
 name = "phentrieve"
-version = "0.14.0"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Summary
- fix the GitHub Pages docs workflow by aligning it with the project Python baseline
- remove the strict MkDocs warning caused by an invalid repository-root docs link
- bump the CLI/library minor version to 0.15.0 and update release metadata

## Verification
- mkdocs build --clean --strict (fresh venv with workflow dependencies)
- make check
- make typecheck-fast
- CUDA_VISIBLE_DEVICES="" make test
- make frontend-test
- make frontend-lint (existing warnings only)
