### PR TITLE
feat(analysis): ontology-embedding fidelity analysis script (closes #34)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ site/
 # Claude Code files
 .claude/
 .worktrees/
+.superpowers/
 
 # serena MCP files
 SERENA.md

--- a/.planning/active/2026-04-17-ontology-embedding-fidelity-implementation-plan.md
+++ b/.planning/active/2026-04-17-ontology-embedding-fidelity-implementation-plan.md
@@ -1,0 +1,2962 @@
+# Ontology–Embedding Fidelity Analysis — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** [`.planning/specs/2026-04-17-ontology-embedding-fidelity-design.md`](../specs/2026-04-17-ontology-embedding-fidelity-design.md) (commit `1bb3326`)
+**Issue:** [#34](https://github.com/berntpopp/phentrieve/issues/34)
+**Branch:** `feat/ontology-embedding-fidelity` (in a git worktree at `~/worktrees/phentrieve-ontology-fidelity/`)
+
+**Goal:** Ship a standalone Python script (`scripts/analyze_embedding_ontology.py`) that loads BioLORD-2023-M embeddings for indexed HPO terms, computes four ontology-fidelity metrics, and writes a timestamped directory of correlation results + five plots, answering whether the language model recapitulates the curated HPO DAG.
+
+**Architecture:** A new pure-function library module `phentrieve/analysis/ontology_fidelity.py` holds the testable math (graph distances, Resnik similarity, per-term fidelity, distance correlation). A thin cache module `phentrieve/analysis/embedding_cache.py` reads embeddings from the existing ChromaDB collection on first use and writes `.npy`/`.json` to a per-model cache directory. The orchestrating `scripts/analyze_embedding_ontology.py` wires them together and handles UMAP + plotting.
+
+**Tech Stack:** Python 3.10+, numpy, scikit-learn, scipy (transitive), matplotlib, umap-learn (new, optional extra), plotly (new, optional extra), pytest, uv.
+
+---
+
+## File Structure
+
+**Create:**
+- `phentrieve/analysis/__init__.py` — empty package marker
+- `phentrieve/analysis/ontology_fidelity.py` — pure math (descendants, IC, shortest-path, Resnik, top-level branch, sampling, correlations, fidelity, purity, depth corr)
+- `phentrieve/analysis/embedding_cache.py` — ChromaDB → `.npy` + `hpo_ids.json` cache
+- `scripts/analyze_embedding_ontology.py` — orchestrator (arg parsing, HPO DB access, cache call, metrics assembly, UMAP, plotting, writers)
+- `tests/unit/analysis/__init__.py` — empty package marker
+- `tests/unit/analysis/test_ontology_fidelity.py` — unit tests for math module
+- `tests/unit/analysis/test_embedding_cache.py` — unit tests for cache module
+- `tests/integration/analysis/__init__.py` — empty package marker
+- `tests/integration/analysis/test_analyze_script_smoke.py` — end-to-end smoke test on 200-term subset
+
+**Modify:**
+- `pyproject.toml` — add `[project.optional-dependencies]` group `analysis` with `umap-learn>=0.5.6` and `plotly>=5.22.0`
+- `scripts/README.md` — document the script (invocation + outputs)
+
+**Not modified:** `phentrieve/config.py`, `phentrieve/utils.py`, `phentrieve/data_processing/*`, any CLI command module. This feature intentionally sits outside the CLI surface.
+
+---
+
+## Task 0: Worktree setup
+
+**Files:**
+- Operates on the parent repo, not the worktree yet.
+
+- [ ] **Step 1: Create the worktree and branch**
+
+```bash
+cd /home/bernt-popp/development/phentrieve
+git fetch origin
+git worktree add -b feat/ontology-embedding-fidelity ~/worktrees/phentrieve-ontology-fidelity main
+```
+
+Expected: `Preparing worktree (new branch 'feat/ontology-embedding-fidelity')` and `HEAD is now at <sha> ...`.
+
+- [ ] **Step 2: Switch into the worktree and verify branch**
+
+```bash
+cd ~/worktrees/phentrieve-ontology-fidelity
+git status
+git branch --show-current
+```
+
+Expected: clean working tree on `feat/ontology-embedding-fidelity`.
+
+- [ ] **Step 3: Install dev dependencies in the worktree**
+
+```bash
+make install-dev
+```
+
+Expected: `uv sync` completes without errors. **All subsequent commands run from `~/worktrees/phentrieve-ontology-fidelity`** unless stated otherwise.
+
+- [ ] **Step 4: Confirm existing test suite is green on the base branch**
+
+```bash
+make check && make typecheck-fast && make test
+```
+
+Expected: all three pass. If any fail, stop — do not begin implementation on an already-broken base.
+
+---
+
+## Task 1: Scaffold `phentrieve/analysis` package
+
+**Files:**
+- Create: `phentrieve/analysis/__init__.py`
+- Create: `tests/unit/analysis/__init__.py`
+- Create: `tests/integration/analysis/__init__.py`
+
+- [ ] **Step 1: Create the package markers**
+
+```bash
+mkdir -p phentrieve/analysis tests/unit/analysis tests/integration/analysis
+```
+
+Write `phentrieve/analysis/__init__.py`:
+
+```python
+"""Analysis helpers for ontology/embedding correlation."""
+```
+
+Write `tests/unit/analysis/__init__.py` and `tests/integration/analysis/__init__.py`: each is a single empty line (or just `""`). Keep them minimal.
+
+- [ ] **Step 2: Verify import works**
+
+```bash
+uv run python -c "import phentrieve.analysis; print(phentrieve.analysis.__doc__)"
+```
+
+Expected: prints `Analysis helpers for ontology/embedding correlation.`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add phentrieve/analysis/__init__.py tests/unit/analysis/__init__.py tests/integration/analysis/__init__.py
+git commit -m "feat(analysis): scaffold analysis package"
+```
+
+---
+
+## Task 2: `information_content` + `build_descendants_index` (TDD)
+
+**Files:**
+- Create: `phentrieve/analysis/ontology_fidelity.py`
+- Create: `tests/unit/analysis/test_ontology_fidelity.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Write `tests/unit/analysis/test_ontology_fidelity.py`:
+
+```python
+"""Unit tests for phentrieve.analysis.ontology_fidelity."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+
+# ------------------------------------------------------------
+# Shared tiny DAG used across tests.
+#
+#            HP:0000001  (root, depth 0)
+#              /      \
+#        HP:0001      HP:0002         (depth 1; top-level branches)
+#          /  \          |
+#     HP:0010 HP:0011  HP:0020        (depth 2)
+#                        |
+#                     HP:0030         (depth 3)
+#
+# HP:0011 has two parents: HP:0001 AND HP:0002  (multi-parent case).
+# ------------------------------------------------------------
+
+
+@pytest.fixture
+def tiny_dag() -> tuple[dict[str, set[str]], dict[str, int]]:
+    """Return (ancestors, depths) for the fixture DAG above.
+
+    Convention matches HPODatabase.load_graph_data: ancestors[t] does NOT
+    include t itself.
+    """
+    ancestors = {
+        "HP:0000001": set(),
+        "HP:0001": {"HP:0000001"},
+        "HP:0002": {"HP:0000001"},
+        "HP:0010": {"HP:0000001", "HP:0001"},
+        "HP:0011": {"HP:0000001", "HP:0001", "HP:0002"},
+        "HP:0020": {"HP:0000001", "HP:0002"},
+        "HP:0030": {"HP:0000001", "HP:0002", "HP:0020"},
+    }
+    depths = {
+        "HP:0000001": 0,
+        "HP:0001": 1,
+        "HP:0002": 1,
+        "HP:0010": 2,
+        "HP:0011": 2,
+        "HP:0020": 2,
+        "HP:0030": 3,
+    }
+    return ancestors, depths
+
+
+def test_build_descendants_index_matches_manual_inverse(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import build_descendants_index
+
+    ancestors, _ = tiny_dag
+    descendants = build_descendants_index(ancestors)
+
+    # Each term is its own descendant by our convention.
+    assert descendants["HP:0030"] == {"HP:0030"}
+    assert descendants["HP:0020"] == {"HP:0020", "HP:0030"}
+    assert descendants["HP:0002"] == {"HP:0002", "HP:0011", "HP:0020", "HP:0030"}
+    assert descendants["HP:0001"] == {"HP:0001", "HP:0010", "HP:0011"}
+    assert descendants["HP:0000001"] == set(ancestors.keys())
+
+
+def test_information_content_root_is_zero(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import (
+        build_descendants_index,
+        information_content,
+    )
+
+    ancestors, _ = tiny_dag
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants, root="HP:0000001")
+
+    assert ic["HP:0000001"] == pytest.approx(0.0)
+
+
+def test_information_content_leaf_is_log_n(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import (
+        build_descendants_index,
+        information_content,
+    )
+
+    ancestors, _ = tiny_dag
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants, root="HP:0000001")
+
+    n_total = len(ancestors)
+    # HP:0030 is a leaf: |descendants|=1, IC = -log(1/N) = log(N)
+    assert ic["HP:0030"] == pytest.approx(math.log(n_total))
+
+
+def test_information_content_monotone_with_depth(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import (
+        build_descendants_index,
+        information_content,
+    )
+
+    ancestors, _ = tiny_dag
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants, root="HP:0000001")
+
+    # A descendant must have IC >= its ancestor.
+    assert ic["HP:0030"] >= ic["HP:0020"] >= ic["HP:0002"] >= ic["HP:0000001"]
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+```bash
+uv run pytest tests/unit/analysis/test_ontology_fidelity.py -v
+```
+
+Expected: 4 failures with `ModuleNotFoundError: No module named 'phentrieve.analysis.ontology_fidelity'` (or `ImportError`).
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Write `phentrieve/analysis/ontology_fidelity.py`:
+
+```python
+"""Pure functions for ontology/embedding fidelity analysis.
+
+No I/O, no matplotlib, no ChromaDB. Inputs are plain dicts and numpy arrays.
+
+Conventions
+-----------
+- ancestors[t] does NOT include t itself (matches HPODatabase.load_graph_data).
+- descendants[t] DOES include t itself (so |descendants| >= 1 always, IC
+  is always well-defined).
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable
+
+
+def build_descendants_index(
+    ancestors: dict[str, set[str]],
+) -> dict[str, set[str]]:
+    """Invert an ancestors map into a descendants map.
+
+    Each term is defined as its own descendant, so |descendants(t)| >= 1
+    for every term.
+    """
+    descendants: dict[str, set[str]] = {t: {t} for t in ancestors}
+    for term, anc_set in ancestors.items():
+        for anc in anc_set:
+            # anc may be outside the ancestors map only if the DAG is malformed;
+            # ignore silently rather than crash — correlates with DB integrity.
+            if anc in descendants:
+                descendants[anc].add(term)
+    return descendants
+
+
+def information_content(
+    descendants: dict[str, set[str]],
+    root: str = "HP:0000001",
+) -> dict[str, float]:
+    """Resnik information content: IC(t) = -log(|descendants(t)| / |descendants(root)|).
+
+    IC(root) == 0 exactly. Leaves have max IC.
+    """
+    if root not in descendants:
+        raise KeyError(f"Root {root!r} not in descendants map")
+    root_count = len(descendants[root])
+    if root_count <= 0:
+        raise ValueError("Root has zero descendants; descendants map is empty.")
+    return {
+        term: -math.log(len(desc) / root_count)
+        for term, desc in descendants.items()
+    }
+```
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+```bash
+uv run pytest tests/unit/analysis/test_ontology_fidelity.py -v
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Run lint and format**
+
+```bash
+make lint-fix && make format
+```
+
+Expected: no errors (formatters may touch files; review with `git diff`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add phentrieve/analysis/ontology_fidelity.py tests/unit/analysis/test_ontology_fidelity.py
+git commit -m "feat(analysis): add descendants index and information content"
+```
+
+---
+
+## Task 3: `graph_shortest_path` (TDD)
+
+**Files:**
+- Modify: `phentrieve/analysis/ontology_fidelity.py`
+- Modify: `tests/unit/analysis/test_ontology_fidelity.py`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `tests/unit/analysis/test_ontology_fidelity.py`:
+
+```python
+def test_graph_shortest_path_identical_terms_is_zero(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import graph_shortest_path
+
+    ancestors, depths = tiny_dag
+    assert graph_shortest_path("HP:0030", "HP:0030", ancestors, depths) == 0
+
+
+def test_graph_shortest_path_known_pairs(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import graph_shortest_path
+
+    ancestors, depths = tiny_dag
+
+    # HP:0010 -> HP:0001 -> HP:0011 : distance 2
+    assert graph_shortest_path("HP:0010", "HP:0011", ancestors, depths) == 2
+    # HP:0030 -> HP:0020 -> HP:0002 : distance 2
+    assert graph_shortest_path("HP:0030", "HP:0002", ancestors, depths) == 2
+    # HP:0010 (branch 1) and HP:0020 (branch 2): LCA is root (depth 0).
+    # distance = 2 + 2 - 0 = 4
+    assert graph_shortest_path("HP:0010", "HP:0020", ancestors, depths) == 4
+    # Multi-parent: HP:0011 has two parents; LCA with HP:0020 is HP:0002 (depth 1).
+    # depths: HP:0011=2, HP:0020=2; distance = 2 + 2 - 2*1 = 2
+    assert graph_shortest_path("HP:0011", "HP:0020", ancestors, depths) == 2
+```
+
+- [ ] **Step 2: Run and confirm failure**
+
+```bash
+uv run pytest tests/unit/analysis/test_ontology_fidelity.py::test_graph_shortest_path_known_pairs -v
+```
+
+Expected: `ImportError: cannot import name 'graph_shortest_path' ...`.
+
+- [ ] **Step 3: Implement**
+
+Append to `phentrieve/analysis/ontology_fidelity.py`:
+
+```python
+def _include_self(ancestors_of_t: set[str], t: str) -> set[str]:
+    """Return ancestors(t) ∪ {t}. Useful for LCA computation."""
+    return ancestors_of_t | {t}
+
+
+def graph_shortest_path(
+    u: str,
+    v: str,
+    ancestors: dict[str, set[str]],
+    depths: dict[str, int],
+) -> int:
+    """Shortest-path distance on the HPO is_a DAG.
+
+    dist(u, v) = depth(u) + depth(v) - 2 * depth(LCA(u, v))
+
+    LCA is chosen as the common (ancestor-or-self) term with maximum depth.
+    Ties between equal-depth common ancestors are irrelevant for the distance
+    formula, so we do not break them deterministically.
+    """
+    if u == v:
+        return 0
+    common = _include_self(ancestors[u], u) & _include_self(ancestors[v], v)
+    if not common:
+        raise ValueError(
+            f"No common ancestor between {u!r} and {v!r}; "
+            "graph is disconnected or root not reachable."
+        )
+    lca_depth = max(depths[c] for c in common)
+    return depths[u] + depths[v] - 2 * lca_depth
+```
+
+- [ ] **Step 4: Run tests and confirm pass**
+
+```bash
+uv run pytest tests/unit/analysis/test_ontology_fidelity.py -v
+```
+
+Expected: all existing tests still pass, plus 2 new.
+
+- [ ] **Step 5: Commit**
+
+```bash
+make lint-fix && make format
+git add phentrieve/analysis/ontology_fidelity.py tests/unit/analysis/test_ontology_fidelity.py
+git commit -m "feat(analysis): add graph_shortest_path via LCA"
+```
+
+---
+
+## Task 4: `resnik_similarity` (TDD)
+
+**Files:**
+- Modify: `phentrieve/analysis/ontology_fidelity.py`
+- Modify: `tests/unit/analysis/test_ontology_fidelity.py`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `tests/unit/analysis/test_ontology_fidelity.py`:
+
+```python
+def test_resnik_similarity_identical_terms_equals_own_ic(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import (
+        build_descendants_index,
+        information_content,
+        resnik_similarity,
+    )
+
+    ancestors, _ = tiny_dag
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants)
+
+    assert resnik_similarity("HP:0030", "HP:0030", ancestors, ic) == pytest.approx(
+        ic["HP:0030"]
+    )
+
+
+def test_resnik_similarity_siblings_is_ic_of_parent(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import (
+        build_descendants_index,
+        information_content,
+        resnik_similarity,
+    )
+
+    ancestors, _ = tiny_dag
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants)
+
+    # HP:0010 and HP:0011 share HP:0001 as a parent; HP:0001 is also their
+    # most-informative common ancestor in the tiny DAG (higher IC than root,
+    # and HP:0011 shares HP:0002 with HP:0010 only via root).
+    got = resnik_similarity("HP:0010", "HP:0011", ancestors, ic)
+    assert got == pytest.approx(ic["HP:0001"])
+
+
+def test_resnik_similarity_cross_branch_is_root_ic(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import (
+        build_descendants_index,
+        information_content,
+        resnik_similarity,
+    )
+
+    ancestors, _ = tiny_dag
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants)
+
+    # HP:0010 is only under HP:0001. HP:0020 is only under HP:0002. The only
+    # common ancestor is the root, so Resnik = IC(root) = 0.
+    assert resnik_similarity("HP:0010", "HP:0020", ancestors, ic) == pytest.approx(0.0)
+```
+
+- [ ] **Step 2: Confirm failure**
+
+```bash
+uv run pytest tests/unit/analysis/test_ontology_fidelity.py -v -k resnik
+```
+
+Expected: 3 failures on `ImportError`.
+
+- [ ] **Step 3: Implement**
+
+Append to `phentrieve/analysis/ontology_fidelity.py`:
+
+```python
+def resnik_similarity(
+    u: str,
+    v: str,
+    ancestors: dict[str, set[str]],
+    ic: dict[str, float],
+) -> float:
+    """Resnik similarity: IC of the most-informative common ancestor.
+
+    Returns 0.0 when the only common ancestor is the root (IC(root) == 0).
+    """
+    if u == v:
+        return ic[u]
+    common = _include_self(ancestors[u], u) & _include_self(ancestors[v], v)
+    if not common:
+        raise ValueError(
+            f"No common ancestor between {u!r} and {v!r}; "
+            "graph is disconnected or root not reachable."
+        )
+    return max(ic[c] for c in common)
+```
+
+- [ ] **Step 4: Run and confirm pass**
+
+```bash
+uv run pytest tests/unit/analysis/test_ontology_fidelity.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+make lint-fix && make format
+git add phentrieve/analysis/ontology_fidelity.py tests/unit/analysis/test_ontology_fidelity.py
+git commit -m "feat(analysis): add resnik_similarity"
+```
+
+---
+
+## Task 5: `top_level_branch` with multi-parent determinism (TDD)
+
+**Files:**
+- Modify: `phentrieve/analysis/ontology_fidelity.py`
+- Modify: `tests/unit/analysis/test_ontology_fidelity.py`
+
+- [ ] **Step 1: Add failing tests**
+
+Append:
+
+```python
+def test_top_level_branch_for_depth_0_term_is_none(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import top_level_branch
+
+    ancestors, depths = tiny_dag
+    assert top_level_branch("HP:0000001", ancestors, depths) == (None, frozenset())
+
+
+def test_top_level_branch_for_depth_1_term_is_self(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import top_level_branch
+
+    ancestors, depths = tiny_dag
+    branch, all_branches = top_level_branch("HP:0001", ancestors, depths)
+    assert branch == "HP:0001"
+    assert all_branches == frozenset({"HP:0001"})
+
+
+def test_top_level_branch_single_parent_chain(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import top_level_branch
+
+    ancestors, depths = tiny_dag
+    branch, all_branches = top_level_branch("HP:0030", ancestors, depths)
+    assert branch == "HP:0002"
+    assert all_branches == frozenset({"HP:0002"})
+
+
+def test_top_level_branch_multi_parent_picks_lex_smallest(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import top_level_branch
+
+    ancestors, depths = tiny_dag
+    # HP:0011 has depth-1 ancestors HP:0001 and HP:0002; "HP:0001" < "HP:0002".
+    branch, all_branches = top_level_branch("HP:0011", ancestors, depths)
+    assert branch == "HP:0001"
+    assert all_branches == frozenset({"HP:0001", "HP:0002"})
+```
+
+- [ ] **Step 2: Confirm failure**
+
+```bash
+uv run pytest tests/unit/analysis/test_ontology_fidelity.py -v -k top_level_branch
+```
+
+Expected: 4 failures.
+
+- [ ] **Step 3: Implement**
+
+Append:
+
+```python
+def top_level_branch(
+    term_id: str,
+    ancestors: dict[str, set[str]],
+    depths: dict[str, int],
+) -> tuple[str | None, frozenset[str]]:
+    """Return (deterministic_branch, all_depth_1_ancestors_including_self_if_depth1).
+
+    Rules (from spec's determinism section):
+    - depth 0 (the root): returns (None, empty frozenset).
+    - depth 1: returns (term_id, {term_id}).
+    - depth > 1: collect all depth-1 ancestors of term_id; the deterministic
+      branch is the lexicographically smallest HPO ID in that set.
+    """
+    d = depths.get(term_id)
+    if d is None:
+        raise KeyError(f"Unknown term {term_id!r}")
+    if d == 0:
+        return None, frozenset()
+    if d == 1:
+        return term_id, frozenset({term_id})
+
+    depth_one_ancs = {a for a in ancestors[term_id] if depths.get(a) == 1}
+    if not depth_one_ancs:
+        # Should not happen in a well-formed HPO DAG, but guard anyway.
+        return None, frozenset()
+    return min(depth_one_ancs), frozenset(depth_one_ancs)
+```
+
+- [ ] **Step 4: Run and confirm pass**
+
+```bash
+uv run pytest tests/unit/analysis/test_ontology_fidelity.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+make lint-fix && make format
+git add phentrieve/analysis/ontology_fidelity.py tests/unit/analysis/test_ontology_fidelity.py
+git commit -m "feat(analysis): add top_level_branch with multi-parent tiebreak"
+```
+
+---
+
+## Task 6: `sample_pairs` (TDD)
+
+**Files:**
+- Modify: `phentrieve/analysis/ontology_fidelity.py`
+- Modify: `tests/unit/analysis/test_ontology_fidelity.py`
+
+- [ ] **Step 1: Add failing tests**
+
+Append:
+
+```python
+def test_sample_pairs_shape_and_bounds():
+    import numpy as np
+
+    from phentrieve.analysis.ontology_fidelity import sample_pairs
+
+    rng = np.random.default_rng(42)
+    pairs = sample_pairs(n_terms=100, n_pairs=500, rng=rng)
+    assert pairs.shape == (500, 2)
+    assert pairs.min() >= 0
+    assert pairs.max() < 100
+    # No self-pairs.
+    assert (pairs[:, 0] != pairs[:, 1]).all()
+
+
+def test_sample_pairs_deterministic_given_seed():
+    import numpy as np
+
+    from phentrieve.analysis.ontology_fidelity import sample_pairs
+
+    a = sample_pairs(1000, 200, np.random.default_rng(7))
+    b = sample_pairs(1000, 200, np.random.default_rng(7))
+    np.testing.assert_array_equal(a, b)
+
+
+def test_sample_pairs_clamps_when_requested_exceeds_available():
+    import numpy as np
+
+    from phentrieve.analysis.ontology_fidelity import sample_pairs
+
+    # For 5 terms there are only 5*4/2 = 10 unordered distinct pairs.
+    pairs = sample_pairs(5, 100, np.random.default_rng(0))
+    assert pairs.shape[0] <= 10
+    assert (pairs[:, 0] != pairs[:, 1]).all()
+```
+
+- [ ] **Step 2: Confirm failure**
+
+```bash
+uv run pytest tests/unit/analysis/test_ontology_fidelity.py -v -k sample_pairs
+```
+
+Expected: 3 failures on `ImportError`.
+
+- [ ] **Step 3: Implement**
+
+Append to `phentrieve/analysis/ontology_fidelity.py`:
+
+```python
+import numpy as np  # noqa: E402 — kept near use-sites for readers
+
+
+def sample_pairs(
+    n_terms: int,
+    n_pairs: int,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    """Return `n_pairs` distinct unordered index pairs in [0, n_terms), as (n_pairs, 2) int64.
+
+    - No self-pairs ((i, i) excluded).
+    - If n_pairs exceeds the total number of distinct unordered pairs, the
+      result is clamped to the maximum available (len <= n_terms*(n_terms-1)/2).
+    - Deterministic given the same rng state.
+    """
+    if n_terms < 2:
+        return np.empty((0, 2), dtype=np.int64)
+
+    max_pairs = n_terms * (n_terms - 1) // 2
+    target = min(n_pairs, max_pairs)
+
+    # Sample with rejection — simpler and faster than enumerating pairs for
+    # realistic n_terms (~18k) and target (~50k). Fall back to exhaustive
+    # enumeration when target is close to max_pairs.
+    if target >= max_pairs * 0.5:
+        rows, cols = np.triu_indices(n_terms, k=1)
+        all_pairs = np.stack([rows, cols], axis=1)
+        idx = rng.choice(len(all_pairs), size=target, replace=False)
+        return all_pairs[idx].astype(np.int64)
+
+    seen: set[tuple[int, int]] = set()
+    out: list[tuple[int, int]] = []
+    attempts = 0
+    max_attempts = max(target * 10, 1000)
+    while len(out) < target and attempts < max_attempts:
+        attempts += 1
+        a, b = rng.integers(0, n_terms, size=2)
+        if a == b:
+            continue
+        u, v = (int(a), int(b)) if a < b else (int(b), int(a))
+        if (u, v) in seen:
+            continue
+        seen.add((u, v))
+        out.append((u, v))
+
+    return np.array(out, dtype=np.int64)
+```
+
+- [ ] **Step 4: Confirm pass**
+
+```bash
+uv run pytest tests/unit/analysis/test_ontology_fidelity.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+make lint-fix && make format
+git add phentrieve/analysis/ontology_fidelity.py tests/unit/analysis/test_ontology_fidelity.py
+git commit -m "feat(analysis): add deterministic pair sampling"
+```
+
+---
+
+## Task 7: `global_distance_correlation` (TDD)
+
+**Files:**
+- Modify: `phentrieve/analysis/ontology_fidelity.py`
+- Modify: `tests/unit/analysis/test_ontology_fidelity.py`
+
+- [ ] **Step 1: Add failing tests**
+
+Append:
+
+```python
+def test_global_distance_correlation_returns_expected_keys(tiny_dag):
+    import numpy as np
+
+    from phentrieve.analysis.ontology_fidelity import (
+        build_descendants_index,
+        global_distance_correlation,
+        information_content,
+    )
+
+    ancestors, depths = tiny_dag
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants)
+
+    term_ids = list(depths.keys())
+    rng = np.random.default_rng(0)
+    embeddings = rng.standard_normal((len(term_ids), 16)).astype(np.float32)
+
+    result = global_distance_correlation(
+        term_ids, embeddings, ancestors, depths, ic, n_pairs=20, seed=0
+    )
+
+    assert set(result) >= {
+        "spearman_shortest_path",
+        "spearman_resnik",
+        "n_pairs",
+    }
+    assert isinstance(result["n_pairs"], int)
+    assert result["n_pairs"] <= 20
+
+
+def test_global_distance_correlation_seeded_is_deterministic(tiny_dag):
+    import numpy as np
+
+    from phentrieve.analysis.ontology_fidelity import (
+        build_descendants_index,
+        global_distance_correlation,
+        information_content,
+    )
+
+    ancestors, depths = tiny_dag
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants)
+
+    term_ids = list(depths.keys())
+    rng = np.random.default_rng(7)
+    embeddings = rng.standard_normal((len(term_ids), 16)).astype(np.float32)
+
+    a = global_distance_correlation(term_ids, embeddings, ancestors, depths, ic, n_pairs=15, seed=11)
+    b = global_distance_correlation(term_ids, embeddings, ancestors, depths, ic, n_pairs=15, seed=11)
+    assert a == b
+```
+
+- [ ] **Step 2: Confirm failure**
+
+```bash
+uv run pytest tests/unit/analysis/test_ontology_fidelity.py -v -k global_distance
+```
+
+Expected: 2 failures on `ImportError`.
+
+- [ ] **Step 3: Implement**
+
+Append:
+
+```python
+def _cosine_distance_rows(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    """Elementwise cosine distance between paired rows of a and b. Shape (n,)."""
+    num = np.sum(a * b, axis=1)
+    denom = np.linalg.norm(a, axis=1) * np.linalg.norm(b, axis=1)
+    # Avoid division-by-zero; zero-norm rows get 1.0 (max distance).
+    sim = np.where(denom > 0, num / np.maximum(denom, 1e-12), 0.0)
+    return 1.0 - sim
+
+
+def global_distance_correlation(
+    term_ids: list[str],
+    embeddings: np.ndarray,
+    ancestors: dict[str, set[str]],
+    depths: dict[str, int],
+    ic: dict[str, float],
+    n_pairs: int = 50_000,
+    seed: int = 42,
+) -> dict[str, float | int]:
+    """Spearman ρ between embedding cosine distance and (shortest-path, Resnik).
+
+    Returns a dict with keys 'spearman_shortest_path', 'spearman_resnik',
+    'n_pairs'. Uses sampled pairs; seed controls pair selection.
+    """
+    from scipy.stats import spearmanr
+
+    rng = np.random.default_rng(seed)
+    pairs = sample_pairs(len(term_ids), n_pairs, rng)
+    if pairs.size == 0:
+        return {
+            "spearman_shortest_path": float("nan"),
+            "spearman_resnik": float("nan"),
+            "n_pairs": 0,
+        }
+
+    u_ids = [term_ids[i] for i in pairs[:, 0]]
+    v_ids = [term_ids[i] for i in pairs[:, 1]]
+
+    cosine = _cosine_distance_rows(embeddings[pairs[:, 0]], embeddings[pairs[:, 1]])
+    shortest = np.array(
+        [graph_shortest_path(u, v, ancestors, depths) for u, v in zip(u_ids, v_ids)],
+        dtype=np.float64,
+    )
+    resnik = np.array(
+        [resnik_similarity(u, v, ancestors, ic) for u, v in zip(u_ids, v_ids)],
+        dtype=np.float64,
+    )
+
+    # Spearman expects distance-like arrays to correlate in the same direction.
+    # Cosine distance is larger for dissimilar pairs; shortest-path also larger;
+    # so a positive ρ means agreement. Resnik is a similarity — negate for agreement.
+    rho_sp, _ = spearmanr(cosine, shortest)
+    rho_rk, _ = spearmanr(cosine, -resnik)
+
+    return {
+        "spearman_shortest_path": float(rho_sp) if rho_sp == rho_sp else float("nan"),
+        "spearman_resnik": float(rho_rk) if rho_rk == rho_rk else float("nan"),
+        "n_pairs": int(len(pairs)),
+    }
+```
+
+- [ ] **Step 4: Confirm pass**
+
+```bash
+uv run pytest tests/unit/analysis/test_ontology_fidelity.py -v
+```
+
+Expected: all pass. (scipy is transitive via scikit-learn, already installed.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+make lint-fix && make format
+git add phentrieve/analysis/ontology_fidelity.py tests/unit/analysis/test_ontology_fidelity.py
+git commit -m "feat(analysis): add global distance correlation (Spearman ρ)"
+```
+
+---
+
+## Task 8: `per_term_fidelity` with self-exclusion + tie-break (TDD)
+
+**Files:**
+- Modify: `phentrieve/analysis/ontology_fidelity.py`
+- Modify: `tests/unit/analysis/test_ontology_fidelity.py`
+
+- [ ] **Step 1: Add failing tests**
+
+Append:
+
+```python
+def test_per_term_fidelity_bounds_0_to_1(tiny_dag):
+    import numpy as np
+
+    from phentrieve.analysis.ontology_fidelity import (
+        build_descendants_index,
+        information_content,
+        per_term_fidelity,
+    )
+
+    ancestors, depths = tiny_dag
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants)
+
+    term_ids = list(depths.keys())
+    rng = np.random.default_rng(0)
+    embeddings = rng.standard_normal((len(term_ids), 8)).astype(np.float32)
+
+    rows = per_term_fidelity(
+        term_ids, embeddings, ancestors, descendants, ic, k=3
+    )
+    assert len(rows) == len(term_ids)
+    for row in rows:
+        assert 0.0 <= row["fidelity"] <= 1.0
+        assert len(row["nn_embedding"]) == 3
+        assert len(row["nn_dag"]) == 3
+        # Self must be excluded from both neighborhoods.
+        assert row["id"] not in row["nn_embedding"]
+        assert row["id"] not in row["nn_dag"]
+
+
+def test_per_term_fidelity_tiebreak_is_lexicographic():
+    """Equal Resnik scores across candidates break by ascending HPO ID."""
+    import numpy as np
+
+    from phentrieve.analysis.ontology_fidelity import (
+        build_descendants_index,
+        information_content,
+        per_term_fidelity,
+    )
+
+    # Flat DAG: root + three depth-1 children. All sibling pairs have
+    # Resnik = IC(root) = 0, so ties. HP:0010 < HP:0020 < HP:0030.
+    ancestors = {
+        "HP:0000001": set(),
+        "HP:0010": {"HP:0000001"},
+        "HP:0020": {"HP:0000001"},
+        "HP:0030": {"HP:0000001"},
+    }
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants)
+    term_ids = ["HP:0000001", "HP:0010", "HP:0020", "HP:0030"]
+    embeddings = np.eye(4, dtype=np.float32)
+
+    rows = per_term_fidelity(term_ids, embeddings, ancestors, descendants, ic, k=2)
+    by_id = {r["id"]: r for r in rows}
+    # For HP:0030 the two lex-smallest non-self terms are HP:0000001 and HP:0010.
+    assert by_id["HP:0030"]["nn_dag"] == ["HP:0000001", "HP:0010"]
+
+
+def test_per_term_fidelity_identical_embeddings_yields_uniform_baseline():
+    """If all embeddings are identical, embedding k-NN is just the lex-smallest
+    non-self terms, which matches the Resnik-tiebreak fallback for a flat DAG —
+    so fidelity should be 1.0 on every term."""
+    import numpy as np
+
+    from phentrieve.analysis.ontology_fidelity import (
+        build_descendants_index,
+        information_content,
+        per_term_fidelity,
+    )
+
+    ancestors = {
+        "HP:0000001": set(),
+        "HP:0010": {"HP:0000001"},
+        "HP:0020": {"HP:0000001"},
+        "HP:0030": {"HP:0000001"},
+        "HP:0040": {"HP:0000001"},
+    }
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants)
+    term_ids = sorted(ancestors.keys())
+    embeddings = np.ones((len(term_ids), 4), dtype=np.float32)
+
+    rows = per_term_fidelity(term_ids, embeddings, ancestors, descendants, ic, k=2)
+    for row in rows:
+        assert row["fidelity"] == pytest.approx(1.0)
+```
+
+- [ ] **Step 2: Confirm failure**
+
+```bash
+uv run pytest tests/unit/analysis/test_ontology_fidelity.py -v -k per_term_fidelity
+```
+
+Expected: 3 failures on `ImportError`.
+
+- [ ] **Step 3: Implement**
+
+Append:
+
+```python
+def _embedding_knn(
+    embeddings: np.ndarray, k: int
+) -> np.ndarray:
+    """Return indices of the k nearest non-self neighbors per row, cosine metric.
+
+    Shape: (n, k) of int64. Self is always excluded.
+    """
+    from sklearn.neighbors import NearestNeighbors
+
+    # k+1 because the query point itself is always its own nearest neighbor.
+    nn = NearestNeighbors(n_neighbors=k + 1, metric="cosine", algorithm="brute")
+    nn.fit(embeddings)
+    _, idx = nn.kneighbors(embeddings, return_distance=True)
+    # idx[:, 0] is the self-hit in almost all cases. Drop it robustly:
+    n = idx.shape[0]
+    out = np.empty((n, k), dtype=np.int64)
+    for i in range(n):
+        row = [j for j in idx[i] if j != i][:k]
+        # Pad in case of degenerate metric behavior (duplicate self rows, etc.)
+        while len(row) < k:
+            row.append(row[-1] if row else 0)
+        out[i] = row
+    return out
+
+
+def _resnik_top_k(
+    query: str,
+    candidates: list[str],
+    ancestors: dict[str, set[str]],
+    ic: dict[str, float],
+    k: int,
+) -> list[str]:
+    """Return the k candidates with highest Resnik similarity to `query`,
+    ties broken by ascending HPO ID. Query itself is excluded.
+    """
+    scored = []
+    for c in candidates:
+        if c == query:
+            continue
+        scored.append((-resnik_similarity(query, c, ancestors, ic), c))
+    # (-resnik, id): primary ascending on -resnik (i.e. descending resnik);
+    # secondary ascending on id — this is exactly the tie-break rule.
+    scored.sort()
+    return [c for _, c in scored[:k]]
+
+
+def per_term_fidelity(
+    term_ids: list[str],
+    embeddings: np.ndarray,
+    ancestors: dict[str, set[str]],
+    descendants: dict[str, set[str]],
+    ic: dict[str, float],
+    k: int = 10,
+) -> list[dict]:
+    """Per-term fidelity: |embedding-kNN ∩ Resnik-top-k| / k, in [0, 1].
+
+    Returns a list of {id, fidelity, nn_embedding, nn_dag} dicts, one per term,
+    in the same order as `term_ids`.
+    """
+    if k < 1:
+        raise ValueError("k must be >= 1")
+    nn_idx = _embedding_knn(embeddings, k)
+    rows: list[dict] = []
+    for i, query in enumerate(term_ids):
+        nn_embedding = [term_ids[j] for j in nn_idx[i]]
+        nn_dag = _resnik_top_k(query, term_ids, ancestors, ic, k)
+        overlap = len(set(nn_embedding) & set(nn_dag))
+        rows.append(
+            {
+                "id": query,
+                "fidelity": overlap / k,
+                "nn_embedding": nn_embedding,
+                "nn_dag": nn_dag,
+            }
+        )
+    return rows
+```
+
+- [ ] **Step 4: Confirm pass**
+
+```bash
+uv run pytest tests/unit/analysis/test_ontology_fidelity.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+make lint-fix && make format
+git add phentrieve/analysis/ontology_fidelity.py tests/unit/analysis/test_ontology_fidelity.py
+git commit -m "feat(analysis): add per-term fidelity with self-exclusion and lex tiebreak"
+```
+
+---
+
+## Task 9: `branch_knn_purity` (TDD)
+
+**Files:**
+- Modify: `phentrieve/analysis/ontology_fidelity.py`
+- Modify: `tests/unit/analysis/test_ontology_fidelity.py`
+
+- [ ] **Step 1: Add failing tests**
+
+Append:
+
+```python
+def test_branch_knn_purity_monocluster_equals_one():
+    import numpy as np
+
+    from phentrieve.analysis.ontology_fidelity import branch_knn_purity
+
+    term_ids = ["HP:0010", "HP:0011", "HP:0012"]
+    branch_map = {"HP:0010": "HP:0001", "HP:0011": "HP:0001", "HP:0012": "HP:0001"}
+    # All identical embeddings -> every neighbor in the same branch.
+    embeddings = np.ones((3, 4), dtype=np.float32)
+    result = branch_knn_purity(term_ids, embeddings, branch_map, k=2)
+    assert result["overall"] == pytest.approx(1.0)
+    assert result["per_branch"]["HP:0001"] == pytest.approx(1.0)
+
+
+def test_branch_knn_purity_excludes_root_from_denominator():
+    """Terms whose branch is None (the HPO root) must not appear in per_branch
+    totals and must not contribute to the overall mean."""
+    import numpy as np
+
+    from phentrieve.analysis.ontology_fidelity import branch_knn_purity
+
+    term_ids = ["HP:0000001", "HP:0010", "HP:0011"]
+    branch_map = {"HP:0000001": None, "HP:0010": "HP:0001", "HP:0011": "HP:0001"}
+    embeddings = np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 0.0]], dtype=np.float32)
+    result = branch_knn_purity(term_ids, embeddings, branch_map, k=1)
+    assert "HP:0001" in result["per_branch"]
+    assert None not in result["per_branch"]
+    # HP:0010's 1-NN is HP:0011 (same branch) -> purity 1.0.
+    # HP:0011's 1-NN is HP:0010 (same branch) -> purity 1.0.
+    # HP:0000001 excluded from denominator.
+    assert result["overall"] == pytest.approx(1.0)
+    assert result["n_evaluated"] == 2
+```
+
+- [ ] **Step 2: Confirm failure**
+
+```bash
+uv run pytest tests/unit/analysis/test_ontology_fidelity.py -v -k branch_knn_purity
+```
+
+Expected: 2 failures on `ImportError`.
+
+- [ ] **Step 3: Implement**
+
+Append:
+
+```python
+def branch_knn_purity(
+    term_ids: list[str],
+    embeddings: np.ndarray,
+    branch_map: dict[str, str | None],
+    k: int = 10,
+) -> dict:
+    """Mean per-term branch purity over the embedding k-NN.
+
+    Terms whose branch is None (i.e. the HPO root) are excluded from both the
+    per-branch breakdown and the overall mean.
+
+    Returns {'overall': float, 'per_branch': {branch_id: float}, 'n_evaluated': int}.
+    """
+    if k < 1:
+        raise ValueError("k must be >= 1")
+    nn_idx = _embedding_knn(embeddings, k)
+
+    per_branch_scores: dict[str, list[float]] = {}
+    all_scores: list[float] = []
+
+    for i, query in enumerate(term_ids):
+        query_branch = branch_map.get(query)
+        if query_branch is None:
+            continue
+        neighbor_branches = [branch_map.get(term_ids[j]) for j in nn_idx[i]]
+        matches = sum(1 for nb in neighbor_branches if nb == query_branch)
+        score = matches / k
+        all_scores.append(score)
+        per_branch_scores.setdefault(query_branch, []).append(score)
+
+    overall = float(np.mean(all_scores)) if all_scores else float("nan")
+    per_branch = {b: float(np.mean(s)) for b, s in per_branch_scores.items()}
+    return {
+        "overall": overall,
+        "per_branch": per_branch,
+        "n_evaluated": len(all_scores),
+    }
+```
+
+- [ ] **Step 4: Confirm pass**
+
+```bash
+uv run pytest tests/unit/analysis/test_ontology_fidelity.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+make lint-fix && make format
+git add phentrieve/analysis/ontology_fidelity.py tests/unit/analysis/test_ontology_fidelity.py
+git commit -m "feat(analysis): add branch k-NN purity"
+```
+
+---
+
+## Task 10: `depth_correlation` (TDD)
+
+**Files:**
+- Modify: `phentrieve/analysis/ontology_fidelity.py`
+- Modify: `tests/unit/analysis/test_ontology_fidelity.py`
+
+- [ ] **Step 1: Add failing test**
+
+Append:
+
+```python
+def test_depth_correlation_returns_scalar_in_expected_range():
+    import numpy as np
+
+    from phentrieve.analysis.ontology_fidelity import depth_correlation
+
+    term_ids = [f"HP:{i:07d}" for i in range(20)]
+    depths = {tid: i % 5 for i, tid in enumerate(term_ids)}
+    rng = np.random.default_rng(0)
+    embeddings = rng.standard_normal((20, 8)).astype(np.float32)
+
+    rho = depth_correlation(term_ids, embeddings, depths)
+    assert isinstance(rho, float)
+    assert -1.0 <= rho <= 1.0
+```
+
+- [ ] **Step 2: Confirm failure**
+
+```bash
+uv run pytest tests/unit/analysis/test_ontology_fidelity.py -v -k depth_correlation
+```
+
+- [ ] **Step 3: Implement**
+
+Append:
+
+```python
+def depth_correlation(
+    term_ids: list[str],
+    embeddings: np.ndarray,
+    depths: dict[str, int],
+) -> float:
+    """Spearman ρ between term depth and Euclidean distance from the aligned centroid.
+
+    The centroid is computed on the provided embeddings (the aligned set),
+    not on any larger matrix.
+    """
+    from scipy.stats import spearmanr
+
+    centroid = embeddings.mean(axis=0)
+    dists = np.linalg.norm(embeddings - centroid, axis=1)
+    depth_arr = np.array([depths[tid] for tid in term_ids], dtype=np.float64)
+    rho, _ = spearmanr(depth_arr, dists)
+    return float(rho) if rho == rho else float("nan")
+```
+
+- [ ] **Step 4: Confirm pass**
+
+```bash
+uv run pytest tests/unit/analysis/test_ontology_fidelity.py -v
+```
+
+Expected: all tests pass, including the earlier ones.
+
+- [ ] **Step 5: Run coverage check and commit**
+
+```bash
+uv run pytest tests/unit/analysis/test_ontology_fidelity.py --cov=phentrieve.analysis.ontology_fidelity --cov-report=term-missing
+```
+
+Expected: coverage on `ontology_fidelity.py` is ≥ 85% (spec target).
+
+```bash
+make lint-fix && make format
+git add phentrieve/analysis/ontology_fidelity.py tests/unit/analysis/test_ontology_fidelity.py
+git commit -m "feat(analysis): add depth correlation metric"
+```
+
+---
+
+## Task 11: Embedding cache module (TDD)
+
+**Files:**
+- Create: `phentrieve/analysis/embedding_cache.py`
+- Create: `tests/unit/analysis/test_embedding_cache.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Write `tests/unit/analysis/test_embedding_cache.py`:
+
+```python
+"""Unit tests for phentrieve.analysis.embedding_cache."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+
+def _make_mock_client_with_collection(ids, embeddings) -> MagicMock:
+    """Return a mock chromadb.PersistentClient that exposes a collection
+    whose .get(include=['embeddings']) returns the given ids/embeddings."""
+    client = MagicMock()
+    collection = MagicMock()
+    collection.get.return_value = {
+        "ids": list(ids),
+        "embeddings": [list(row) for row in embeddings],
+    }
+    client.get_collection.return_value = collection
+    return client
+
+
+def test_embedding_cache_first_call_reads_chroma_and_writes_files(tmp_path):
+    from phentrieve.analysis.embedding_cache import load_cached_embeddings
+
+    ids = ["HP:0000001", "HP:0000002", "HP:0000003"]
+    vecs = np.array([[1.0, 0.0], [0.0, 1.0], [0.5, 0.5]], dtype=np.float32)
+    client = _make_mock_client_with_collection(ids, vecs)
+
+    with patch(
+        "phentrieve.analysis.embedding_cache.chromadb.PersistentClient",
+        return_value=client,
+    ):
+        got_ids, got_vecs = load_cached_embeddings(
+            model_name="FremyCompany/BioLORD-2023-M",
+            index_dir_override=str(tmp_path),
+        )
+
+    assert got_ids == ids
+    np.testing.assert_allclose(got_vecs, vecs)
+
+    cache_root = tmp_path / "ontology_fidelity_cache"
+    subdirs = list(cache_root.iterdir())
+    assert len(subdirs) == 1
+    cache_dir = subdirs[0]
+    assert (cache_dir / "embeddings.npy").exists()
+    assert (cache_dir / "hpo_ids.json").exists()
+    assert (cache_dir / "meta.json").exists()
+    meta = json.loads((cache_dir / "meta.json").read_text())
+    assert meta["model_name"] == "FremyCompany/BioLORD-2023-M"
+    assert meta["n_terms"] == 3
+    assert meta["dim"] == 2
+
+
+def test_embedding_cache_second_call_skips_chroma(tmp_path):
+    from phentrieve.analysis.embedding_cache import load_cached_embeddings
+
+    ids = ["HP:0000001", "HP:0000002"]
+    vecs = np.array([[1.0, 0.0], [0.0, 1.0]], dtype=np.float32)
+    client = _make_mock_client_with_collection(ids, vecs)
+
+    # Warm the cache.
+    with patch(
+        "phentrieve.analysis.embedding_cache.chromadb.PersistentClient",
+        return_value=client,
+    ):
+        load_cached_embeddings("FremyCompany/BioLORD-2023-M", index_dir_override=str(tmp_path))
+
+    # Second call must not construct PersistentClient at all.
+    with patch(
+        "phentrieve.analysis.embedding_cache.chromadb.PersistentClient",
+        side_effect=AssertionError("should not be called"),
+    ):
+        got_ids, got_vecs = load_cached_embeddings(
+            "FremyCompany/BioLORD-2023-M", index_dir_override=str(tmp_path)
+        )
+
+    assert got_ids == ids
+    np.testing.assert_allclose(got_vecs, vecs)
+
+
+def test_embedding_cache_refresh_overwrites(tmp_path):
+    from phentrieve.analysis.embedding_cache import load_cached_embeddings
+
+    ids_v1 = ["HP:0000001", "HP:0000002"]
+    vecs_v1 = np.array([[1.0, 0.0], [0.0, 1.0]], dtype=np.float32)
+    ids_v2 = ["HP:0000001", "HP:0000002", "HP:0000003"]
+    vecs_v2 = np.array([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]], dtype=np.float32)
+
+    with patch(
+        "phentrieve.analysis.embedding_cache.chromadb.PersistentClient",
+        return_value=_make_mock_client_with_collection(ids_v1, vecs_v1),
+    ):
+        load_cached_embeddings("FremyCompany/BioLORD-2023-M", index_dir_override=str(tmp_path))
+
+    with patch(
+        "phentrieve.analysis.embedding_cache.chromadb.PersistentClient",
+        return_value=_make_mock_client_with_collection(ids_v2, vecs_v2),
+    ):
+        got_ids, got_vecs = load_cached_embeddings(
+            "FremyCompany/BioLORD-2023-M",
+            refresh=True,
+            index_dir_override=str(tmp_path),
+        )
+
+    assert got_ids == ids_v2
+    assert got_vecs.shape == (3, 2)
+
+
+def test_embedding_cache_missing_collection_raises(tmp_path):
+    from phentrieve.analysis.embedding_cache import load_cached_embeddings
+
+    client = MagicMock()
+    client.get_collection.side_effect = ValueError("not found")
+    with patch(
+        "phentrieve.analysis.embedding_cache.chromadb.PersistentClient",
+        return_value=client,
+    ):
+        with pytest.raises(FileNotFoundError):
+            load_cached_embeddings("FremyCompany/BioLORD-2023-M", index_dir_override=str(tmp_path))
+```
+
+- [ ] **Step 2: Run and confirm failure**
+
+```bash
+uv run pytest tests/unit/analysis/test_embedding_cache.py -v
+```
+
+Expected: 4 failures on `ImportError`.
+
+- [ ] **Step 3: Implement**
+
+Write `phentrieve/analysis/embedding_cache.py`:
+
+```python
+"""Read HPO embeddings once from ChromaDB, then serve from a local `.npy` cache.
+
+Cache layout:
+    <index_dir>/ontology_fidelity_cache/<collection_name>/
+        embeddings.npy    # (N, D) float32
+        hpo_ids.json      # ["HP:0000001", ...] aligned with embeddings rows
+        meta.json         # {"model_name", "collection_name", "written_at",
+                          #  "n_terms", "dim"}
+
+index_dir defaults to phentrieve.utils.get_default_index_dir(), override via
+`index_dir_override`. collection_name comes from
+phentrieve.utils.generate_collection_name(model_name).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+import chromadb
+import numpy as np
+
+from phentrieve.utils import generate_collection_name, get_default_index_dir
+
+logger = logging.getLogger(__name__)
+
+
+def _cache_dir_for(index_dir: Path, collection_name: str) -> Path:
+    return index_dir / "ontology_fidelity_cache" / collection_name
+
+
+def _read_cache(cache_dir: Path) -> tuple[list[str], np.ndarray] | None:
+    """Return (ids, embeddings) if the cache is valid, else None.
+
+    Any missing/malformed file yields None (caller will refresh from Chroma).
+    """
+    emb_path = cache_dir / "embeddings.npy"
+    ids_path = cache_dir / "hpo_ids.json"
+    meta_path = cache_dir / "meta.json"
+    if not (emb_path.exists() and ids_path.exists() and meta_path.exists()):
+        return None
+    try:
+        embeddings = np.load(emb_path)
+        ids = json.loads(ids_path.read_text())
+        meta = json.loads(meta_path.read_text())
+    except (ValueError, OSError, json.JSONDecodeError) as e:
+        logger.error("Ontology-fidelity cache unreadable at %s: %s", cache_dir, e)
+        return None
+    if not isinstance(ids, list) or len(ids) != embeddings.shape[0]:
+        logger.error(
+            "Ontology-fidelity cache mismatch: %d ids vs %d embedding rows",
+            len(ids) if isinstance(ids, list) else -1,
+            embeddings.shape[0],
+        )
+        return None
+    if meta.get("n_terms") != embeddings.shape[0]:
+        logger.error("Ontology-fidelity cache meta.n_terms mismatch")
+        return None
+    return list(ids), embeddings
+
+
+def _write_cache(
+    cache_dir: Path,
+    ids: list[str],
+    embeddings: np.ndarray,
+    model_name: str,
+    collection_name: str,
+) -> None:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    np.save(cache_dir / "embeddings.npy", embeddings.astype(np.float32))
+    (cache_dir / "hpo_ids.json").write_text(json.dumps(list(ids)))
+    (cache_dir / "meta.json").write_text(
+        json.dumps(
+            {
+                "model_name": model_name,
+                "collection_name": collection_name,
+                "written_at": datetime.now(timezone.utc).isoformat(),
+                "n_terms": int(embeddings.shape[0]),
+                "dim": int(embeddings.shape[1]),
+            }
+        )
+    )
+
+
+def _clear_cache(cache_dir: Path) -> None:
+    for fname in ("embeddings.npy", "hpo_ids.json", "meta.json"):
+        p = cache_dir / fname
+        if p.exists():
+            p.unlink()
+
+
+def _read_from_chroma(
+    index_dir: Path, collection_name: str
+) -> tuple[list[str], np.ndarray]:
+    try:
+        client = chromadb.PersistentClient(path=str(index_dir))
+        collection = client.get_collection(collection_name)
+    except Exception as e:  # chromadb raises a variety of types
+        raise FileNotFoundError(
+            f"ChromaDB collection {collection_name!r} not found in {index_dir}. "
+            "Run 'phentrieve index build --model-name ...' first."
+        ) from e
+
+    got = collection.get(include=["embeddings"])
+    ids = list(got["ids"])
+    embeddings = np.asarray(got["embeddings"], dtype=np.float32)
+    if embeddings.ndim != 2 or embeddings.shape[0] != len(ids):
+        raise ValueError(
+            f"Malformed Chroma payload: {len(ids)} ids vs embeddings shape "
+            f"{embeddings.shape}"
+        )
+    return ids, embeddings
+
+
+def load_cached_embeddings(
+    model_name: str,
+    refresh: bool = False,
+    index_dir_override: str | None = None,
+) -> tuple[list[str], np.ndarray]:
+    """Return (hpo_ids, embeddings) for the given model.
+
+    First call: queries ChromaDB, writes cache, returns arrays.
+    Later calls: reads cache only. `refresh=True` forces a re-read.
+
+    Raises FileNotFoundError if the ChromaDB collection for `model_name`
+    does not exist.
+    """
+    index_dir = Path(index_dir_override) if index_dir_override else get_default_index_dir()
+    collection_name = generate_collection_name(model_name)
+    cache_dir = _cache_dir_for(index_dir, collection_name)
+
+    if not refresh:
+        cached = _read_cache(cache_dir)
+        if cached is not None:
+            logger.info("Loaded ontology-fidelity cache from %s", cache_dir)
+            return cached
+        if any(
+            (cache_dir / f).exists() for f in ("embeddings.npy", "hpo_ids.json", "meta.json")
+        ):
+            logger.warning(
+                "Ontology-fidelity cache at %s is partial/malformed; refreshing from Chroma",
+                cache_dir,
+            )
+
+    _clear_cache(cache_dir)
+    ids, embeddings = _read_from_chroma(index_dir, collection_name)
+    _write_cache(cache_dir, ids, embeddings, model_name, collection_name)
+    logger.info(
+        "Wrote ontology-fidelity cache: %d terms × %d dims → %s",
+        len(ids),
+        embeddings.shape[1],
+        cache_dir,
+    )
+    return ids, embeddings
+```
+
+- [ ] **Step 4: Confirm pass**
+
+```bash
+uv run pytest tests/unit/analysis/test_embedding_cache.py -v
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+make lint-fix && make format
+git add phentrieve/analysis/embedding_cache.py tests/unit/analysis/test_embedding_cache.py
+git commit -m "feat(analysis): add ChromaDB->npy embedding cache with refresh semantics"
+```
+
+---
+
+## Task 12: Add `analysis` optional dependency group
+
+**Files:**
+- Modify: `pyproject.toml`
+
+- [ ] **Step 1: Confirm there is no existing `[project.optional-dependencies]` section**
+
+```bash
+grep -n "optional-dependencies" pyproject.toml || echo "NONE FOUND"
+```
+
+If a section already exists: add the new `analysis` group inside it. If not: add the section (use the snippet below as-is).
+
+- [ ] **Step 2: Add the new extra**
+
+Append to `pyproject.toml` (after the `dependencies = [ ... ]` list, before the `[project.scripts]` section):
+
+```toml
+[project.optional-dependencies]
+analysis = [
+    "umap-learn>=0.5.6",
+    "plotly>=5.22.0",
+]
+```
+
+If the section exists, add the `analysis = [...]` entry inside it instead.
+
+- [ ] **Step 3: Install the extra in the dev environment**
+
+```bash
+uv sync --extra analysis
+```
+
+Expected: `umap-learn` and `plotly` (and `numba`/`llvmlite` pulled by umap-learn) are installed. No errors.
+
+- [ ] **Step 4: Verify imports**
+
+```bash
+uv run python -c "import umap, plotly.express; print(umap.__version__, plotly.__version__)"
+```
+
+Expected: version strings, no error.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "build(deps): add optional analysis extra (umap-learn, plotly)"
+```
+
+---
+
+## Task 13: Orchestrator — argument parsing + logging + HPO DB loading
+
+**Files:**
+- Create: `scripts/analyze_embedding_ontology.py`
+
+- [ ] **Step 1: Write the script skeleton**
+
+Write `scripts/analyze_embedding_ontology.py`:
+
+```python
+#!/usr/bin/env python3
+"""Ontology–embedding fidelity analysis.
+
+Loads HPO graph data + cached BioLORD embeddings, computes four correlation
+metrics and produces five plots in a timestamped output directory.
+
+Run `python scripts/analyze_embedding_ontology.py --help` for usage.
+
+This is a standalone research script — intentionally not exposed via the
+`phentrieve` CLI. See .planning/specs/2026-04-17-ontology-embedding-fidelity-design.md
+for the full contract.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger("analyze_embedding_ontology")
+
+
+@dataclass
+class Args:
+    model_name: str
+    output_dir: Path
+    k: int
+    n_pairs: int
+    umap_neighbors: int
+    umap_min_dist: float
+    metric: str
+    sample: int | None
+    seed: int
+    skip_interactive: bool
+    refresh_cache: bool
+    log_level: str
+
+
+def parse_args(argv: list[str] | None = None) -> Args:
+    p = argparse.ArgumentParser(
+        description="Ontology–embedding fidelity analysis.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument("--model-name", default="FremyCompany/BioLORD-2023-M")
+    p.add_argument(
+        "--output-dir",
+        default="data/results/ontology_fidelity",
+        type=Path,
+    )
+    p.add_argument("--k", type=int, default=10)
+    p.add_argument("--n-pairs", type=int, default=50_000)
+    p.add_argument("--umap-neighbors", type=int, default=15)
+    p.add_argument("--umap-min-dist", type=float, default=0.1)
+    p.add_argument("--metric", default="cosine")
+    p.add_argument("--sample", type=int, default=None)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--skip-interactive", action="store_true")
+    p.add_argument("--refresh-cache", action="store_true")
+    p.add_argument("--log-level", default="INFO")
+    ns = p.parse_args(argv)
+    return Args(
+        model_name=ns.model_name,
+        output_dir=ns.output_dir,
+        k=ns.k,
+        n_pairs=ns.n_pairs,
+        umap_neighbors=ns.umap_neighbors,
+        umap_min_dist=ns.umap_min_dist,
+        metric=ns.metric,
+        sample=ns.sample,
+        seed=ns.seed,
+        skip_interactive=ns.skip_interactive,
+        refresh_cache=ns.refresh_cache,
+        log_level=ns.log_level,
+    )
+
+
+def setup_logging(level: str) -> None:
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+
+def load_hpo_bundle(
+    data_dir_override: str | None = None,
+) -> tuple[list[dict], dict[str, set[str]], dict[str, int], str | None, Path]:
+    """Open HPODatabase directly, load terms + graph + version, close. Hard-fail
+    on missing DB (unlike document_creator.load_hpo_terms which soft-fails)."""
+    from phentrieve.config import DEFAULT_HPO_DB_FILENAME
+    from phentrieve.data_processing.hpo_database import HPODatabase
+    from phentrieve.utils import get_default_data_dir, resolve_data_path
+
+    data_dir = resolve_data_path(data_dir_override, "data_dir", get_default_data_dir)
+    db_path = data_dir / DEFAULT_HPO_DB_FILENAME
+    if not db_path.exists():
+        raise FileNotFoundError(
+            f"HPO database not found: {db_path}. "
+            "Run 'phentrieve data prepare' first."
+        )
+    db = HPODatabase(db_path)
+    try:
+        terms = db.load_all_terms()
+        ancestors, depths = db.load_graph_data()
+        hpo_version = db.get_metadata("hpo_version")
+    finally:
+        db.close()
+    logger.info(
+        "HPO DB loaded: %d terms, version=%s, path=%s",
+        len(terms),
+        hpo_version,
+        db_path,
+    )
+    return terms, ancestors, depths, hpo_version, db_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    setup_logging(args.log_level)
+    try:
+        terms, ancestors, depths, hpo_version, db_path = load_hpo_bundle()
+    except FileNotFoundError as e:
+        logger.error("%s", e)
+        return 1
+    logger.info("Loaded %d HPO terms (DB: %s)", len(terms), db_path)
+    # Further stages added in subsequent tasks.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 2: Dry-run with `--help`**
+
+```bash
+uv run python scripts/analyze_embedding_ontology.py --help
+```
+
+Expected: argparse help text listing all flags with defaults.
+
+- [ ] **Step 3: Dry-run against the real HPO DB**
+
+```bash
+uv run python scripts/analyze_embedding_ontology.py --log-level DEBUG
+```
+
+Expected: logs show the DB path and term count, exit code 0. If the HPO DB is missing on this machine: `phentrieve data prepare` first.
+
+- [ ] **Step 4: Commit**
+
+```bash
+make lint-fix && make format
+git add scripts/analyze_embedding_ontology.py
+git commit -m "feat(scripts): scaffold ontology fidelity orchestrator (HPO DB + argparse)"
+```
+
+---
+
+## Task 14: Orchestrator — embedding cache load + alignment
+
+**Files:**
+- Modify: `scripts/analyze_embedding_ontology.py`
+
+- [ ] **Step 1: Extend the script with alignment logic**
+
+Replace the `main` function in `scripts/analyze_embedding_ontology.py` with:
+
+```python
+def align_terms_and_embeddings(
+    terms: list[dict],
+    hpo_ids: list[str],
+    embeddings: "np.ndarray",
+    symmetric_diff_tolerance: float = 0.05,
+) -> tuple[list[dict], "np.ndarray"]:
+    """Filter both sides to the intersection of (HPO DB IDs) and (cache IDs).
+
+    - If |symmetric difference| / min(|A|, |B|) > tolerance, raise ValueError —
+      the cache is likely stale.
+    - Otherwise, log a warning with counts and proceed on the intersection.
+    - Preserves cache row order for returned embeddings.
+    """
+    import numpy as np
+
+    db_ids = {t["id"] for t in terms}
+    cache_ids = set(hpo_ids)
+    inter = db_ids & cache_ids
+    only_db = db_ids - cache_ids
+    only_cache = cache_ids - db_ids
+
+    sym_diff = len(only_db) + len(only_cache)
+    denom = max(min(len(db_ids), len(cache_ids)), 1)
+    if sym_diff / denom > symmetric_diff_tolerance:
+        raise ValueError(
+            f"HPO DB / embedding cache divergence too large: "
+            f"{sym_diff} mismatched IDs out of min({len(db_ids)}, {len(cache_ids)}) "
+            f"({sym_diff / denom:.1%} > {symmetric_diff_tolerance:.0%}). "
+            "Rebuild the index or refresh the cache (--refresh-cache)."
+        )
+    if sym_diff:
+        logger.warning(
+            "HPO DB / embedding cache mismatch: %d only in DB, %d only in cache",
+            len(only_db),
+            len(only_cache),
+        )
+    if not inter:
+        raise ValueError("Zero overlap between HPO DB and embedding cache.")
+
+    keep_cache_rows = [i for i, hid in enumerate(hpo_ids) if hid in inter]
+    aligned_embeddings = embeddings[keep_cache_rows]
+    aligned_ids_set = {hpo_ids[i] for i in keep_cache_rows}
+    aligned_terms = [t for t in terms if t["id"] in aligned_ids_set]
+
+    # Sort aligned_terms into the same order as aligned_embeddings rows.
+    ordered_ids = [hpo_ids[i] for i in keep_cache_rows]
+    by_id = {t["id"]: t for t in aligned_terms}
+    aligned_terms = [by_id[i] for i in ordered_ids]
+
+    return aligned_terms, aligned_embeddings
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    setup_logging(args.log_level)
+
+    try:
+        terms, ancestors, depths, hpo_version, db_path = load_hpo_bundle()
+    except FileNotFoundError as e:
+        logger.error("%s", e)
+        return 1
+
+    from phentrieve.analysis.embedding_cache import load_cached_embeddings
+
+    try:
+        hpo_ids, embeddings = load_cached_embeddings(
+            model_name=args.model_name,
+            refresh=args.refresh_cache,
+        )
+    except FileNotFoundError as e:
+        logger.error("%s", e)
+        return 1
+
+    try:
+        aligned_terms, aligned_embeddings = align_terms_and_embeddings(
+            terms, hpo_ids, embeddings
+        )
+    except ValueError as e:
+        logger.error("%s", e)
+        return 1
+
+    if args.sample is not None and args.sample < len(aligned_terms):
+        import numpy as np
+
+        rng = np.random.default_rng(args.seed)
+        sample_idx = rng.choice(len(aligned_terms), size=args.sample, replace=False)
+        sample_idx.sort()
+        aligned_terms = [aligned_terms[i] for i in sample_idx]
+        aligned_embeddings = aligned_embeddings[sample_idx]
+        logger.info("Sampled %d terms (seed=%d)", len(aligned_terms), args.seed)
+    elif args.sample is not None:
+        logger.info(
+            "Requested --sample %d >= %d aligned terms; using all.",
+            args.sample,
+            len(aligned_terms),
+        )
+
+    logger.info(
+        "Aligned: %d terms × %d dims", len(aligned_terms), aligned_embeddings.shape[1]
+    )
+
+    # Metrics, UMAP, and writers are added in subsequent tasks.
+    return 0
+```
+
+- [ ] **Step 2: Smoke-run**
+
+```bash
+uv run python scripts/analyze_embedding_ontology.py --log-level DEBUG
+```
+
+Expected: the script loads HPO, loads/caches embeddings (first run will read Chroma and write to `data/indexes/ontology_fidelity_cache/phentrieve_FremyCompany_BioLORD-2023-M/`), prints aligned count, exits 0.
+
+If ChromaDB does not contain the BioLORD collection on this machine: `phentrieve index build --model-name FremyCompany/BioLORD-2023-M` first.
+
+- [ ] **Step 3: Commit**
+
+```bash
+make lint-fix && make format
+git add scripts/analyze_embedding_ontology.py
+git commit -m "feat(scripts): add embedding cache load and alignment to orchestrator"
+```
+
+---
+
+## Task 15: Orchestrator — metrics assembly + summary.json + per-term CSV
+
+**Files:**
+- Modify: `scripts/analyze_embedding_ontology.py`
+
+- [ ] **Step 1: Add metrics computation and CSV/JSON writers**
+
+Add the following functions to `scripts/analyze_embedding_ontology.py` (above `main`):
+
+```python
+def compute_metrics(
+    aligned_terms: list[dict],
+    aligned_embeddings: "np.ndarray",
+    ancestors: dict[str, set[str]],
+    depths: dict[str, int],
+    args: Args,
+) -> tuple[dict, list[dict], dict[str, tuple[str | None, frozenset[str]]]]:
+    """Run all four metrics. Return (summary_dict, per_term_rows, branch_info)."""
+    from phentrieve.analysis.ontology_fidelity import (
+        branch_knn_purity,
+        build_descendants_index,
+        depth_correlation,
+        global_distance_correlation,
+        information_content,
+        per_term_fidelity,
+        top_level_branch,
+    )
+
+    term_ids = [t["id"] for t in aligned_terms]
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants)
+
+    branch_info = {
+        tid: top_level_branch(tid, ancestors, depths) for tid in term_ids
+    }
+    branch_map: dict[str, str | None] = {tid: branch_info[tid][0] for tid in term_ids}
+    multi_parent_count = sum(1 for tid in term_ids if len(branch_info[tid][1]) > 1)
+
+    corr = global_distance_correlation(
+        term_ids, aligned_embeddings, ancestors, depths, ic,
+        n_pairs=args.n_pairs, seed=args.seed,
+    )
+    fidelity_rows = per_term_fidelity(
+        term_ids, aligned_embeddings, ancestors, descendants, ic, k=args.k
+    )
+    purity = branch_knn_purity(term_ids, aligned_embeddings, branch_map, k=args.k)
+    depth_rho = depth_correlation(term_ids, aligned_embeddings, depths)
+
+    summary: dict = {
+        "metrics": {
+            "global_distance_correlation": corr,
+            "per_term_fidelity_mean": float(
+                sum(r["fidelity"] for r in fidelity_rows) / max(len(fidelity_rows), 1)
+            ),
+            "branch_knn_purity": purity,
+            "depth_correlation_spearman": depth_rho,
+        },
+        "meta": {
+            "multi_parent_term_count": multi_parent_count,
+            "n_terms_analyzed": len(term_ids),
+            "embedding_dim": int(aligned_embeddings.shape[1]),
+        },
+    }
+    return summary, fidelity_rows, branch_info
+
+
+def write_per_term_csv(
+    out_path: Path,
+    fidelity_rows: list[dict],
+    aligned_terms: list[dict],
+    branch_info: dict[str, tuple[str | None, frozenset[str]]],
+    depths: dict[str, int],
+) -> None:
+    import csv
+
+    labels = {t["id"]: t.get("label", "") for t in aligned_terms}
+    rows_sorted = sorted(fidelity_rows, key=lambda r: r["fidelity"])
+    with open(out_path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["hpo_id", "label", "branch", "all_branches", "depth", "fidelity", "rank"])
+        for rank, row in enumerate(rows_sorted, start=1):
+            tid = row["id"]
+            branch, all_branches = branch_info[tid]
+            w.writerow(
+                [
+                    tid,
+                    labels.get(tid, ""),
+                    branch if branch is not None else "",
+                    ";".join(sorted(all_branches)),
+                    depths.get(tid, -1),
+                    f"{row['fidelity']:.6f}",
+                    rank,
+                ]
+            )
+
+
+def write_summary_json(
+    out_path: Path,
+    summary: dict,
+    args: Args,
+    hpo_version: str | None,
+    db_path: Path,
+    aligned_n: int,
+) -> None:
+    import json
+
+    payload = {
+        **summary,
+        "config": {
+            "model_name": args.model_name,
+            "hpo_db_path": str(db_path),
+            "hpo_version": hpo_version,
+            "k": args.k,
+            "n_pairs": args.n_pairs,
+            "umap_neighbors": args.umap_neighbors,
+            "umap_min_dist": args.umap_min_dist,
+            "metric": args.metric,
+            "sample": args.sample,
+            "seed": args.seed,
+        },
+        "aligned_n_terms": aligned_n,
+    }
+    out_path.write_text(json.dumps(payload, indent=2, default=str))
+```
+
+- [ ] **Step 2: Wire them into `main`**
+
+Replace the `return 0` tail of `main` with:
+
+```python
+    from datetime import datetime
+
+    from phentrieve.utils import get_model_slug
+
+    slug = get_model_slug(args.model_name)
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    out_root = args.output_dir / f"{slug}_{ts}"
+    out_root.mkdir(parents=True, exist_ok=True)
+    logger.info("Output directory: %s", out_root)
+
+    summary, fidelity_rows, branch_info = compute_metrics(
+        aligned_terms, aligned_embeddings, ancestors, depths, args
+    )
+    write_per_term_csv(
+        out_root / "per_term_fidelity.csv",
+        fidelity_rows,
+        aligned_terms,
+        branch_info,
+        depths,
+    )
+    write_summary_json(
+        out_root / "summary.json",
+        summary,
+        args,
+        hpo_version,
+        db_path,
+        len(aligned_terms),
+    )
+    logger.info("Metrics written. Next: UMAP and plots.")
+    return 0
+```
+
+- [ ] **Step 3: Verify `get_model_slug` is importable**
+
+```bash
+uv run python -c "from phentrieve.utils import get_model_slug; print(get_model_slug('FremyCompany/BioLORD-2023-M'))"
+```
+
+Expected: a slug string like `FremyCompany_BioLORD-2023-M`. If the import fails, adjust the import above to use `generate_collection_name` instead (which strips the `phentrieve_` prefix) and update accordingly.
+
+- [ ] **Step 4: Smoke-run with `--sample` to keep it fast**
+
+```bash
+uv run python scripts/analyze_embedding_ontology.py --sample 300 --n-pairs 1000 --log-level DEBUG
+```
+
+Expected: `per_term_fidelity.csv` and `summary.json` appear under `data/results/ontology_fidelity/<slug>_<ts>/`; exit code 0. Verify files:
+
+```bash
+ls data/results/ontology_fidelity/
+head data/results/ontology_fidelity/*/per_term_fidelity.csv
+cat data/results/ontology_fidelity/*/summary.json | head -40
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+make lint-fix && make format
+git add scripts/analyze_embedding_ontology.py
+git commit -m "feat(scripts): compute metrics and write summary.json + per-term CSV"
+```
+
+---
+
+## Task 16: Orchestrator — UMAP + static PNG plots + coords CSV
+
+**Files:**
+- Modify: `scripts/analyze_embedding_ontology.py`
+
+- [ ] **Step 1: Add UMAP + plotting functions**
+
+Add above `main`:
+
+```python
+def run_umap(
+    embeddings: "np.ndarray",
+    args: Args,
+) -> "np.ndarray":
+    """Return 2-D UMAP coordinates with shape (n, 2)."""
+    import umap
+
+    reducer = umap.UMAP(
+        n_neighbors=args.umap_neighbors,
+        min_dist=args.umap_min_dist,
+        metric=args.metric,
+        n_components=2,
+        random_state=args.seed,
+    )
+    return reducer.fit_transform(embeddings)
+
+
+def write_umap_coords_csv(
+    out_path: Path,
+    aligned_terms: list[dict],
+    coords: "np.ndarray",
+    branch_info: dict[str, tuple[str | None, frozenset[str]]],
+    fidelity_by_id: dict[str, float],
+    depths: dict[str, int],
+) -> None:
+    import csv
+
+    labels = {t["id"]: t.get("label", "") for t in aligned_terms}
+    with open(out_path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["hpo_id", "label", "umap_x", "umap_y", "branch", "fidelity", "depth"])
+        for (term, (x, y)) in zip(aligned_terms, coords):
+            tid = term["id"]
+            branch, _ = branch_info[tid]
+            w.writerow(
+                [
+                    tid,
+                    labels.get(tid, ""),
+                    f"{x:.6f}",
+                    f"{y:.6f}",
+                    branch if branch is not None else "",
+                    f"{fidelity_by_id.get(tid, float('nan')):.6f}",
+                    depths.get(tid, -1),
+                ]
+            )
+
+
+def plot_umap_by_branch(
+    out_path: Path,
+    coords: "np.ndarray",
+    aligned_terms: list[dict],
+    branch_info: dict[str, tuple[str | None, frozenset[str]]],
+) -> None:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    branches = [branch_info[t["id"]][0] or "ROOT" for t in aligned_terms]
+    unique = sorted(set(branches))
+    cmap = plt.get_cmap("tab20", len(unique))
+    color_of = {b: cmap(i) for i, b in enumerate(unique)}
+    colors = [color_of[b] for b in branches]
+
+    fig, ax = plt.subplots(figsize=(12, 9), dpi=120)
+    ax.scatter(coords[:, 0], coords[:, 1], s=3, c=colors, alpha=0.7, linewidths=0)
+    ax.set_title("HPO embedding UMAP — colored by top-level branch")
+    ax.set_xlabel("UMAP 1")
+    ax.set_ylabel("UMAP 2")
+    handles = [
+        plt.Line2D([0], [0], marker="o", linestyle="", color=color_of[b], label=b, markersize=6)
+        for b in unique
+    ]
+    ax.legend(handles=handles, loc="best", fontsize=7, ncol=1, frameon=False)
+    fig.tight_layout()
+    fig.savefig(out_path)
+    plt.close(fig)
+
+
+def plot_umap_by_fidelity(
+    out_path: Path,
+    coords: "np.ndarray",
+    aligned_terms: list[dict],
+    fidelity_by_id: dict[str, float],
+) -> None:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    fid = [fidelity_by_id.get(t["id"], 0.0) for t in aligned_terms]
+    fig, ax = plt.subplots(figsize=(12, 9), dpi=120)
+    sc = ax.scatter(
+        coords[:, 0], coords[:, 1], s=4, c=fid, cmap="RdBu", vmin=0.0, vmax=1.0,
+        alpha=0.8, linewidths=0,
+    )
+    ax.set_title("HPO embedding UMAP — colored by per-term fidelity")
+    ax.set_xlabel("UMAP 1")
+    ax.set_ylabel("UMAP 2")
+    cb = fig.colorbar(sc, ax=ax)
+    cb.set_label("fidelity (0=disagree, 1=agree)")
+    fig.tight_layout()
+    fig.savefig(out_path)
+    plt.close(fig)
+
+
+def plot_distance_correlation(
+    out_path: Path,
+    aligned_terms: list[dict],
+    aligned_embeddings: "np.ndarray",
+    ancestors: dict[str, set[str]],
+    depths: dict[str, int],
+    args: Args,
+) -> dict[str, float]:
+    """Hexbin: cosine distance vs (shortest-path, Resnik), two subplots."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    from phentrieve.analysis.ontology_fidelity import (
+        _cosine_distance_rows,  # type: ignore[attr-defined]
+        build_descendants_index,
+        graph_shortest_path,
+        information_content,
+        resnik_similarity,
+        sample_pairs,
+    )
+    from scipy.stats import spearmanr
+
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants)
+    term_ids = [t["id"] for t in aligned_terms]
+    rng = np.random.default_rng(args.seed)
+    pairs = sample_pairs(len(term_ids), args.n_pairs, rng)
+    if pairs.size == 0:
+        return {"spearman_shortest_path": float("nan"), "spearman_resnik": float("nan")}
+
+    cos = _cosine_distance_rows(
+        aligned_embeddings[pairs[:, 0]], aligned_embeddings[pairs[:, 1]]
+    )
+    u_ids = [term_ids[i] for i in pairs[:, 0]]
+    v_ids = [term_ids[i] for i in pairs[:, 1]]
+    shortest = np.array(
+        [graph_shortest_path(u, v, ancestors, depths) for u, v in zip(u_ids, v_ids)],
+        dtype=np.float64,
+    )
+    resnik = np.array(
+        [resnik_similarity(u, v, ancestors, ic) for u, v in zip(u_ids, v_ids)],
+        dtype=np.float64,
+    )
+    rho_sp, _ = spearmanr(cos, shortest)
+    rho_rk, _ = spearmanr(cos, -resnik)
+
+    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 6), dpi=120)
+    ax1.hexbin(shortest, cos, gridsize=40, cmap="viridis", mincnt=1)
+    ax1.set_xlabel("HPO shortest-path distance")
+    ax1.set_ylabel("embedding cosine distance")
+    ax1.set_title(f"shortest-path  ρ={rho_sp:.3f}  (n={len(pairs)})")
+    ax2.hexbin(-resnik, cos, gridsize=40, cmap="viridis", mincnt=1)
+    ax2.set_xlabel("−Resnik similarity  (larger = more distant)")
+    ax2.set_ylabel("embedding cosine distance")
+    ax2.set_title(f"Resnik  ρ={rho_rk:.3f}")
+    fig.tight_layout()
+    fig.savefig(out_path)
+    plt.close(fig)
+
+    return {"spearman_shortest_path": float(rho_sp), "spearman_resnik": float(rho_rk)}
+
+
+def plot_branch_fidelity(
+    out_path: Path,
+    purity: dict,
+    fidelity_rows: list[dict],
+    branch_info: dict[str, tuple[str | None, frozenset[str]]],
+) -> None:
+    """Horizontal bar chart of per-branch MEAN FIDELITY (not purity).
+    Purity is a separate metric surfaced in summary.json.
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    by_branch: dict[str, list[float]] = {}
+    for row in fidelity_rows:
+        branch, _ = branch_info[row["id"]]
+        if branch is None:
+            continue
+        by_branch.setdefault(branch, []).append(row["fidelity"])
+    ordered = sorted(by_branch.items(), key=lambda kv: np.mean(kv[1]))
+    branches = [b for b, _ in ordered]
+    means = [float(np.mean(v)) for _, v in ordered]
+
+    fig, ax = plt.subplots(figsize=(10, max(4, 0.35 * len(branches))), dpi=120)
+    ax.barh(branches, means, color="#3b82f6")
+    ax.set_xlim(0.0, 1.0)
+    ax.set_xlabel("mean per-term fidelity")
+    ax.set_title("Fidelity by top-level HPO branch")
+    fig.tight_layout()
+    fig.savefig(out_path)
+    plt.close(fig)
+```
+
+- [ ] **Step 2: Extend `main`**
+
+Before the `return 0` at the end of `main`, insert:
+
+```python
+    logger.info("Running UMAP (n_neighbors=%d, min_dist=%s) ...", args.umap_neighbors, args.umap_min_dist)
+    coords = run_umap(aligned_embeddings, args)
+    fidelity_by_id = {r["id"]: r["fidelity"] for r in fidelity_rows}
+
+    write_umap_coords_csv(
+        out_root / "umap_coords.csv",
+        aligned_terms,
+        coords,
+        branch_info,
+        fidelity_by_id,
+        depths,
+    )
+    plot_umap_by_branch(
+        out_root / "umap_by_branch.png", coords, aligned_terms, branch_info
+    )
+    plot_umap_by_fidelity(
+        out_root / "umap_by_fidelity.png", coords, aligned_terms, fidelity_by_id
+    )
+    plot_distance_correlation(
+        out_root / "distance_correlation.png",
+        aligned_terms,
+        aligned_embeddings,
+        ancestors,
+        depths,
+        args,
+    )
+    plot_branch_fidelity(
+        out_root / "branch_fidelity.png",
+        summary["metrics"]["branch_knn_purity"],
+        fidelity_rows,
+        branch_info,
+    )
+    logger.info("Static plots written.")
+```
+
+- [ ] **Step 3: Smoke-run**
+
+```bash
+uv run python scripts/analyze_embedding_ontology.py --sample 500 --n-pairs 2000 --log-level INFO
+ls data/results/ontology_fidelity/*/
+```
+
+Expected: all of `summary.json`, `per_term_fidelity.csv`, `umap_coords.csv`, `umap_by_branch.png`, `umap_by_fidelity.png`, `distance_correlation.png`, `branch_fidelity.png` are written. Open one PNG to verify it renders.
+
+- [ ] **Step 4: Commit**
+
+```bash
+make lint-fix && make format
+git add scripts/analyze_embedding_ontology.py
+git commit -m "feat(scripts): add UMAP and four static plots + coords CSV"
+```
+
+---
+
+## Task 17: Orchestrator — interactive Plotly HTML
+
+**Files:**
+- Modify: `scripts/analyze_embedding_ontology.py`
+
+- [ ] **Step 1: Add the Plotly plot function**
+
+Add above `main`:
+
+```python
+def plot_umap_interactive(
+    out_path: Path,
+    coords: "np.ndarray",
+    aligned_terms: list[dict],
+    branch_info: dict[str, tuple[str | None, frozenset[str]]],
+    fidelity_by_id: dict[str, float],
+) -> None:
+    """Single HTML with two traces (branch + fidelity) toggled by legend groups."""
+    import plotly.graph_objects as go
+
+    ids = [t["id"] for t in aligned_terms]
+    labels = [t.get("label", "") for t in aligned_terms]
+    defs = [t.get("definition", "") or "" for t in aligned_terms]
+    branches = [branch_info[t["id"]][0] or "ROOT" for t in aligned_terms]
+    fid = [fidelity_by_id.get(t["id"], float("nan")) for t in aligned_terms]
+
+    hover = [
+        f"<b>{hid}</b><br>{lab}<br>branch: {br}<br>fidelity: {f:.3f}<br>{d[:160]}"
+        for hid, lab, br, f, d in zip(ids, labels, branches, fid, defs)
+    ]
+
+    unique_branches = sorted(set(branches))
+    branch_to_color = {b: i for i, b in enumerate(unique_branches)}
+    branch_colors = [branch_to_color[b] for b in branches]
+
+    fig = go.Figure()
+    fig.add_trace(
+        go.Scattergl(
+            x=coords[:, 0],
+            y=coords[:, 1],
+            mode="markers",
+            marker=dict(
+                size=5,
+                color=branch_colors,
+                colorscale="Viridis",
+                showscale=False,
+                opacity=0.8,
+            ),
+            text=hover,
+            hoverinfo="text",
+            name="by branch",
+            visible=True,
+        )
+    )
+    fig.add_trace(
+        go.Scattergl(
+            x=coords[:, 0],
+            y=coords[:, 1],
+            mode="markers",
+            marker=dict(
+                size=5,
+                color=fid,
+                colorscale="RdBu",
+                cmin=0.0,
+                cmax=1.0,
+                showscale=True,
+                colorbar=dict(title="fidelity"),
+                opacity=0.85,
+            ),
+            text=hover,
+            hoverinfo="text",
+            name="by fidelity",
+            visible=False,
+        )
+    )
+    fig.update_layout(
+        title="HPO embedding UMAP — interactive",
+        xaxis_title="UMAP 1",
+        yaxis_title="UMAP 2",
+        updatemenus=[
+            dict(
+                type="buttons",
+                direction="right",
+                x=0.0,
+                y=1.08,
+                buttons=[
+                    dict(
+                        label="by branch",
+                        method="update",
+                        args=[{"visible": [True, False]}],
+                    ),
+                    dict(
+                        label="by fidelity",
+                        method="update",
+                        args=[{"visible": [False, True]}],
+                    ),
+                ],
+            )
+        ],
+    )
+    fig.write_html(out_path, include_plotlyjs="cdn", full_html=True)
+```
+
+- [ ] **Step 2: Wire it into `main`**
+
+After the static plots block in `main`, add:
+
+```python
+    if not args.skip_interactive:
+        try:
+            plot_umap_interactive(
+                out_root / "umap_interactive.html",
+                coords,
+                aligned_terms,
+                branch_info,
+                fidelity_by_id,
+            )
+            logger.info("Interactive HTML written.")
+        except ImportError:
+            logger.error(
+                "plotly not installed. Install with: uv sync --extra analysis  "
+                "(or pass --skip-interactive to skip this output)."
+            )
+            return 1
+    else:
+        logger.info("Skipping interactive HTML (--skip-interactive).")
+```
+
+- [ ] **Step 3: Smoke-run**
+
+```bash
+uv run python scripts/analyze_embedding_ontology.py --sample 500 --n-pairs 2000
+ls data/results/ontology_fidelity/*/umap_interactive.html
+```
+
+Expected: an HTML file is present. Open it in a browser to verify both traces toggle.
+
+- [ ] **Step 4: Test the --skip-interactive path**
+
+```bash
+uv run python scripts/analyze_embedding_ontology.py --sample 300 --skip-interactive
+```
+
+Expected: no `umap_interactive.html` in the new output dir.
+
+- [ ] **Step 5: Commit**
+
+```bash
+make lint-fix && make format
+git add scripts/analyze_embedding_ontology.py
+git commit -m "feat(scripts): add interactive Plotly HTML with branch/fidelity toggle"
+```
+
+---
+
+## Task 18: Integration smoke test
+
+**Files:**
+- Create: `tests/integration/analysis/test_analyze_script_smoke.py`
+
+- [ ] **Step 1: Write the integration test**
+
+Write `tests/integration/analysis/test_analyze_script_smoke.py`:
+
+```python
+"""End-to-end smoke test for scripts/analyze_embedding_ontology.py.
+
+Runs the orchestrator against the real HPO SQLite DB but mocks the embedding
+cache (so ChromaDB is never touched and UMAP operates on tiny synthetic vectors).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "scripts" / "analyze_embedding_ontology.py"
+
+
+pytestmark = [pytest.mark.slow, pytest.mark.integration]
+
+
+def _write_stub_cache(tmp_path: Path, term_ids: list[str]) -> Path:
+    """Write a fake ontology-fidelity cache with deterministic synthetic vectors."""
+    rng = np.random.default_rng(0)
+    vecs = rng.standard_normal((len(term_ids), 16)).astype(np.float32)
+
+    # Mirrors the real cache layout.
+    from phentrieve.utils import generate_collection_name
+
+    collection = generate_collection_name("FremyCompany/BioLORD-2023-M")
+    cache_dir = tmp_path / "indexes" / "ontology_fidelity_cache" / collection
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    np.save(cache_dir / "embeddings.npy", vecs)
+    (cache_dir / "hpo_ids.json").write_text(json.dumps(term_ids))
+    (cache_dir / "meta.json").write_text(
+        json.dumps(
+            {
+                "model_name": "FremyCompany/BioLORD-2023-M",
+                "collection_name": collection,
+                "written_at": "2026-04-17T00:00:00+00:00",
+                "n_terms": len(term_ids),
+                "dim": 16,
+            }
+        )
+    )
+    return cache_dir
+
+
+def test_analyze_script_smoke(tmp_path, monkeypatch):
+    """Run the script against a real HPO DB with a stubbed embedding cache."""
+    from phentrieve.data_processing.hpo_database import HPODatabase
+    from phentrieve.utils import get_default_data_dir
+
+    db_path = get_default_data_dir() / "hpo_data.db"
+    if not db_path.exists():
+        pytest.skip("HPO SQLite DB not present on this machine")
+
+    db = HPODatabase(db_path)
+    try:
+        all_terms = db.load_all_terms()
+    finally:
+        db.close()
+    # Take the first 200 for speed.
+    term_ids = [t["id"] for t in all_terms[:200]]
+
+    # Point PHENTRIEVE_INDEX_DIR at a temp tree and write a stubbed cache there.
+    tmp_index_root = tmp_path
+    _write_stub_cache(tmp_index_root, term_ids)
+    monkeypatch.setenv("PHENTRIEVE_INDEX_DIR", str(tmp_index_root / "indexes"))
+
+    out_dir = tmp_path / "out"
+    cmd = [
+        sys.executable,
+        str(SCRIPT),
+        "--sample",
+        "150",
+        "--n-pairs",
+        "300",
+        "--k",
+        "5",
+        "--umap-neighbors",
+        "10",
+        "--output-dir",
+        str(out_dir),
+        "--log-level",
+        "INFO",
+        "--skip-interactive",
+    ]
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    assert r.returncode == 0, f"stdout:\n{r.stdout}\nstderr:\n{r.stderr}"
+
+    # Exactly one run subdir.
+    run_dirs = list(out_dir.iterdir())
+    assert len(run_dirs) == 1
+    run = run_dirs[0]
+
+    expected = [
+        "summary.json",
+        "per_term_fidelity.csv",
+        "umap_coords.csv",
+        "umap_by_branch.png",
+        "umap_by_fidelity.png",
+        "distance_correlation.png",
+        "branch_fidelity.png",
+    ]
+    for name in expected:
+        assert (run / name).exists(), f"missing {name}; dir has {list(run.iterdir())}"
+
+    summary = json.loads((run / "summary.json").read_text())
+    assert "metrics" in summary
+    assert "config" in summary
+    assert summary["config"]["model_name"] == "FremyCompany/BioLORD-2023-M"
+```
+
+- [ ] **Step 2: Confirm `PHENTRIEVE_INDEX_DIR` overrides `get_default_index_dir`**
+
+```bash
+grep -n "PHENTRIEVE_INDEX_DIR\|index_dir" phentrieve/utils.py | head -20
+```
+
+If `PHENTRIEVE_INDEX_DIR` is **not** the correct env var name for overriding the index dir in this repo, replace the `monkeypatch.setenv(...)` line in the test with the correct mechanism (for example, construct the script command with a `--index-dir` flag if one exists, or use `phentrieve/phentrieve.yaml`-based override). If no env var/flag exists, add a `--index-dir` flag to the script by plumbing `index_dir_override` through `load_cached_embeddings` and re-run. Leave a note in the commit message.
+
+- [ ] **Step 3: Run the smoke test**
+
+```bash
+uv run pytest tests/integration/analysis/test_analyze_script_smoke.py -v -m slow
+```
+
+Expected: `1 passed`. Skipped if the HPO DB isn't present locally.
+
+- [ ] **Step 4: Commit**
+
+```bash
+make lint-fix && make format
+git add tests/integration/analysis/test_analyze_script_smoke.py
+git commit -m "test(analysis): add integration smoke test for analyze script"
+```
+
+---
+
+## Task 19: Documentation — scripts/README.md
+
+**Files:**
+- Modify: `scripts/README.md`
+
+- [ ] **Step 1: Read the current README**
+
+```bash
+uv run cat scripts/README.md | head -60
+```
+
+Use `Read` to inspect the file and pick an insertion point (typically a new section after the existing scripts).
+
+- [ ] **Step 2: Append a new section**
+
+Append to `scripts/README.md`:
+
+```markdown
+### `analyze_embedding_ontology.py`
+
+Ontology–embedding fidelity analysis. Loads BioLORD HPO embeddings from the
+existing ChromaDB collection (cached to `.npy` on first run), computes four
+correlation metrics between the embedding space and the curated HPO DAG, and
+produces a timestamped results directory with a summary JSON, a per-term
+fidelity CSV, and five plots.
+
+**Prerequisites:**
+
+1. Phentrieve installed with the `analysis` extra:
+   ```bash
+   uv sync --extra analysis
+   ```
+2. HPO SQLite DB prepared:
+   ```bash
+   phentrieve data prepare
+   ```
+3. BioLORD index built:
+   ```bash
+   phentrieve index build --model-name FremyCompany/BioLORD-2023-M
+   ```
+
+**Usage:**
+
+```bash
+python scripts/analyze_embedding_ontology.py \
+    --model-name FremyCompany/BioLORD-2023-M \
+    --k 10 \
+    --n-pairs 50000
+```
+
+Full flag set: see `--help`.
+
+**Outputs** — under `data/results/ontology_fidelity/<model-slug>_<YYYYMMDD-HHMMSS>/`:
+
+| File | Description |
+|---|---|
+| `summary.json` | Spearman ρ (shortest-path & Resnik), mean per-term fidelity, branch k-NN purity, depth correlation, config echo. |
+| `per_term_fidelity.csv` | Per-term fidelity, sorted ascending (worst first). |
+| `umap_coords.csv` | UMAP coordinates for each HPO term. |
+| `umap_by_branch.png` | UMAP colored by top-level HPO branch. |
+| `umap_by_fidelity.png` | UMAP colored by per-term fidelity (RdBu). |
+| `umap_interactive.html` | Interactive Plotly; toggle between branch and fidelity colorings. |
+| `distance_correlation.png` | Hexbin of embedding cosine vs graph distance (two panels). |
+| `branch_fidelity.png` | Per-branch mean fidelity bar chart. |
+
+See [`.planning/specs/2026-04-17-ontology-embedding-fidelity-design.md`](../.planning/specs/2026-04-17-ontology-embedding-fidelity-design.md)
+for the full contract and metric definitions.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/README.md
+git commit -m "docs(scripts): document analyze_embedding_ontology.py"
+```
+
+---
+
+## Task 20: Final quality gate
+
+**Files:**
+- None (verification only).
+
+- [ ] **Step 1: Run the full required check trio**
+
+```bash
+make check && make typecheck-fast && make test
+```
+
+Expected: all pass. If any fail — stop, investigate, fix. Do not claim completion until green.
+
+- [ ] **Step 2: Run the analysis unit tests with coverage**
+
+```bash
+uv run pytest tests/unit/analysis/ --cov=phentrieve.analysis --cov-report=term-missing
+```
+
+Expected: ≥ 85% line coverage on `phentrieve/analysis/*`. If below, add tests for uncovered branches (most likely: malformed cache paths, `refresh=True` overwrite path).
+
+- [ ] **Step 3: Run the integration smoke test**
+
+```bash
+uv run pytest tests/integration/analysis/ -v -m slow
+```
+
+Expected: smoke test passes (or skips with a clear "HPO DB not present" reason on a fresh checkout).
+
+- [ ] **Step 4: Tag the branch ready for PR**
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expected: ~14 atomic commits, one per task (Tasks 1–3 combined into the scaffold commit, others one-per-task). Confirm the list is clean.
+
+- [ ] **Step 5: Push and open a PR**
+
+```bash
+git push -u origin feat/ontology-embedding-fidelity
+gh pr create --title "feat: ontology–embedding fidelity analysis script" --body "$(cat <<'EOF'
+## Summary
+Implements the spec at `.planning/specs/2026-04-17-ontology-embedding-fidelity-design.md` (commit 1bb3326).
+
+Ships a standalone research script `scripts/analyze_embedding_ontology.py` that:
+- Loads BioLORD-2023-M embeddings once from ChromaDB (cached to `.npy`).
+- Computes four ontology-fidelity metrics against the curated HPO DAG: global distance correlation (Spearman ρ for shortest-path and Resnik), per-term fidelity, branch k-NN purity, depth correlation.
+- Produces a timestamped output directory with summary JSON, per-term fidelity CSV, UMAP coords CSV, four static PNG plots, and an interactive Plotly HTML.
+
+No CLI change — the script is invoked directly per the user's request.
+
+Addresses #34 (proposes closing with a pointer to the script).
+
+## Test plan
+- [ ] `make check && make typecheck-fast && make test` green
+- [ ] `uv run pytest tests/unit/analysis/` green, ≥ 85% coverage
+- [ ] `uv run pytest tests/integration/analysis/ -m slow` green on a machine with the HPO DB
+- [ ] Manual run on full dataset produces all 8 expected artifacts
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review against the spec
+
+Spec sections → task that implements each:
+
+- **Inputs & outputs table (spec §"User-facing artifact")** → Tasks 13–17 (orchestrator + writers); integration asserts all 8 files (Task 18).
+- **Metric 1: global distance correlation** → Task 7 (library) + Task 15 (orchestrator call).
+- **Metric 2: per-term fidelity** → Task 8 (library) + Task 15 (orchestrator call + CSV writer).
+- **Metric 3: branch k-NN purity** → Task 9 (library) + Task 15 (orchestrator call).
+- **Metric 4: depth correlation** → Task 10 (library) + Task 15 (orchestrator call).
+- **Determinism — k-NN self-exclusion** → Task 8, `_embedding_knn` + test `test_per_term_fidelity_bounds_0_to_1`.
+- **Determinism — Resnik tie-break** → Task 8, `_resnik_top_k` + test `test_per_term_fidelity_tiebreak_is_lexicographic`.
+- **Determinism — multi-parent top-level branch** → Task 5, `top_level_branch` + test `test_top_level_branch_multi_parent_picks_lex_smallest`.
+- **Determinism — zero-descendant leaves / IC(root)=0** → Task 2 tests.
+- **Determinism — depth-0 handling** → Task 5, `test_top_level_branch_for_depth_0_term_is_none`; Task 9, `test_branch_knn_purity_excludes_root_from_denominator`.
+- **Determinism — seed sole entropy** → Task 6 (`test_sample_pairs_deterministic_given_seed`), Task 7 (`test_global_distance_correlation_seeded_is_deterministic`), Task 16 (`umap.UMAP(random_state=args.seed)`).
+- **Determinism — centroid on aligned set** → Task 10 (`depth_correlation` works on whatever embedding matrix is passed; orchestrator passes aligned only).
+- **Determinism — 5% alignment threshold** → Task 14, `align_terms_and_embeddings`.
+- **Cache path layout** → Task 11, `_cache_dir_for` + writers; verified by `test_embedding_cache_first_call_reads_chroma_and_writes_files`.
+- **`load_hpo_bundle` uses `HPODatabase` directly** → Task 13.
+- **Dependencies: `analysis` optional extra** → Task 12.
+- **Error handling — missing HPO DB hard-fails** → Task 13.
+- **Error handling — missing Chroma collection hard-fails** → Task 11, `_read_from_chroma`.
+- **Error handling — malformed cache → delete + retry** → Task 11, `_read_cache` returns None + logger.warning in `load_cached_embeddings`.
+- **Error handling — zero intersection aborts** → Task 14.
+- **Plots 1–4 PNG + 5 Plotly HTML** → Task 16 + Task 17.
+- **UMAP coords CSV** → Task 16.
+- **summary.json config echo** → Task 15 (`write_summary_json`).
+- **Testing — unit names listed in spec** → Tasks 2–10 (by name; re-check in Task 20 coverage output).
+- **Testing — integration smoke** → Task 18.
+- **Testing — coverage ≥ 85%** → Task 20 gate.
+- **Docs — scripts/README.md** → Task 19.
+- **Worktree-based feature work** → Task 0.
+
+No gaps identified. Placeholders scan: each step contains concrete code or a concrete command. Type consistency: `per_term_fidelity` returns `list[dict]` with keys `{id, fidelity, nn_embedding, nn_dag}` in Task 8, and Tasks 15–16 access those keys by the same names. `top_level_branch` returns `tuple[str | None, frozenset[str]]` in Task 5, and Tasks 15–16 unpack it as `(branch, all_branches)`. `branch_knn_purity` returns `{'overall', 'per_branch', 'n_evaluated'}` in Task 9, consumed only by `summary.json` in Task 15.
+
+Two open questions from the spec were resolved during the plan and noted here so readers don't need to cross-reference:
+- **Distance-correlation hexbin: two subplots in one PNG.** Implemented in Task 16, `plot_distance_correlation`.
+- **Plotly HTML: single file with toggle.** Implemented in Task 17, `plot_umap_interactive`.

--- a/.planning/specs/2026-04-17-llm-multi-provider-python-cli-design.md
+++ b/.planning/specs/2026-04-17-llm-multi-provider-python-cli-design.md
@@ -1,0 +1,371 @@
+# LLM Multi-Provider Python CLI Design
+
+- Date: 2026-04-17
+- Status: Draft for review
+- Scope: Python-only LLM provider support for the CLI, shared service/pipeline, and benchmark path
+- Out of scope: API request/response contract changes, frontend changes, embedding provider swaps, agent loops, and non-structured-output tool orchestration
+
+## 1. Goal
+
+Extend the current Gemini-only Python LLM path so Phentrieve can run the
+existing structured extraction workflow against multiple providers:
+
+- Ollama local models with explicit model choice and optional base URL
+- OpenAI via API
+- Anthropic via API
+- Gemini via API
+
+Phase one implementation and testing will start with Ollama, using
+`qwen3.5:35b` as the primary local validation model and `qwen3.5:27b` as the
+fallback local validation model.
+
+## 2. Current State
+
+The current provider surface is narrower than the CLI suggests:
+
+- The CLI and benchmark paths accept `--llm-model`, but not a first-class
+  provider field.
+- The provider factory in `phentrieve/llm/provider.py` reads
+  `PHENTRIEVE_LLM_PROVIDER` but explicitly rejects anything other than
+  `gemini`.
+- `LLMPipelineConfig` carries model, mode, language, and seed, but not
+  provider identity or base URL.
+- The shared pipeline depends mainly on the `LLMProvider` contract and is
+  otherwise close to provider-agnostic.
+
+This makes the provider factory, config layer, and CLI normalization path the
+correct refactor boundary.
+
+## 3. Design Principles
+
+- Provider is first-class internally, even when inferred from user input.
+- Model and provider are normalized once at the boundary, then propagated in
+  typed form.
+- Provider adapters preserve the existing pipeline contract instead of forcing
+  a pipeline rewrite.
+- Native structured output is preferred per provider, followed by local
+  Pydantic validation of the returned payload.
+- Ollama uses its native `/api/chat` structured-output path, not the OpenAI
+  compatibility path, for stricter schema behavior.
+- Logs, benchmark results, and internal metadata must distinguish provider from
+  model.
+- Validation should be strict about incompatible provider/model combinations,
+  but not brittle about local Ollama model names.
+
+## 4. Scope Boundaries
+
+Included in this design:
+
+- CLI provider/model/base URL configuration
+- Shared normalization and validation logic
+- Multi-provider factory dispatch
+- Provider adapters for Gemini, OpenAI, Anthropic, and Ollama
+- Benchmark path propagation of provider metadata
+- Unit and targeted integration coverage for the Python path
+
+Excluded from this design:
+
+- FastAPI schema or router changes
+- Frontend controls or settings
+- Server-owned model allowlists for API clients
+- Embedding backend changes
+- Multi-turn agent abstractions
+
+## 5. User-Facing Behavior
+
+### 5.1 CLI inputs
+
+Add these Python CLI inputs where `--llm-model` is already supported:
+
+- `--llm-provider`
+- `--llm-model`
+- `--llm-base-url`
+
+Retain provider-relevant existing options like `--llm-seed`, but only apply
+them when supported by the selected provider.
+
+### 5.2 Normalization rules
+
+User input is normalized into a typed provider request with:
+
+- `provider`
+- `model`
+- `base_url`
+
+Normalization rules:
+
+1. If `--llm-model` uses a known prefix such as `gemini/...`, `openai/...`,
+   `anthropic/...`, or `ollama/...`, infer the provider from that prefix.
+2. If `--llm-provider` is also supplied, it must match the inferred provider.
+3. If the model has no prefix, use `--llm-provider` when present.
+4. If neither field is explicit, fall back to environment/config defaults.
+5. After parsing, the stored runtime state becomes provider-native:
+   `provider="ollama"`, `model="qwen3.5:35b"`, rather than a combined string.
+
+### 5.3 Error behavior
+
+The CLI should fail fast with clear errors for:
+
+- unknown provider prefixes
+- unsupported providers
+- explicit provider/model mismatches
+- missing required API keys for cloud providers
+- malformed base URLs
+
+For Ollama, model names should remain flexible. The CLI should not attempt to
+hardcode a strict allowlist of local model identifiers.
+
+## 6. Configuration
+
+Add or formalize these environment variables:
+
+- `PHENTRIEVE_LLM_PROVIDER`
+- `PHENTRIEVE_LLM_MODEL`
+- `PHENTRIEVE_LLM_BASE_URL`
+- `PHENTRIEVE_OPENAI_API_KEY` with `OPENAI_API_KEY` fallback
+- `PHENTRIEVE_ANTHROPIC_API_KEY` with `ANTHROPIC_API_KEY` fallback
+- existing Gemini key fallbacks remain supported
+
+Recommended defaults:
+
+- default Ollama base URL: `http://localhost:11434`
+- default provider remains repo-configurable in `phentrieve/llm/config.py`
+- default model remains repo-configurable in `phentrieve/llm/config.py`
+
+Provider-specific defaults should be represented separately from global
+defaults so the code can evolve without encoding Gemini assumptions as the
+general case.
+
+## 7. Internal Architecture
+
+### 7.1 Provider resolution layer
+
+Introduce a small typed normalization object, conceptually:
+
+- `provider`
+- `model`
+- `base_url`
+- `api_key`
+- `seed`
+
+This object is constructed once in the CLI/service boundary and passed into the
+provider factory.
+
+### 7.2 Factory dispatch
+
+Replace Gemini-only branching in `phentrieve/llm/provider.py` with a dispatch
+factory that selects a provider adapter based on normalized provider identity.
+
+Planned adapters:
+
+- `GeminiStructuredOutputProvider`
+- `OpenAIStructuredOutputProvider`
+- `AnthropicStructuredOutputProvider`
+- `OllamaStructuredOutputProvider`
+
+The factory must stop inferring provider behavior from raw model strings after
+normalization has completed.
+
+### 7.3 Stable pipeline contract
+
+The current `LLMProvider` abstraction should remain the pipeline contract:
+
+- `complete(messages)`
+- `run_structured_prompt(...)`
+- `count_tokens(...)`
+
+The pipeline should continue to expect:
+
+- a validated Pydantic object from `run_structured_prompt()`
+- provider-populated `last_usage`
+- provider-populated `last_finish_reason`
+- provider-populated `last_request_count`
+
+This keeps `phentrieve/llm/pipeline.py` mostly unchanged and confines most work
+to provider, config, CLI, and service plumbing.
+
+## 8. Provider-Specific Behavior
+
+### 8.1 Ollama
+
+Ollama is the phase one implementation and testing target.
+
+Requirements:
+
+- use native `POST /api/chat`
+- use `format=<json schema>` for structured outputs
+- set low temperature, defaulting to `0` for extraction tasks
+- validate returned JSON locally with Pydantic
+- support explicit `base_url`, defaulting to `http://localhost:11434`
+
+The implementation should not rely on Ollama's OpenAI compatibility endpoint
+for strict schema handling in the first phase.
+
+### 8.2 OpenAI
+
+Use native structured output support on the current official API path selected
+at implementation time. The adapter must handle structured-output refusal or
+non-schema terminal states explicitly and keep local validation in place.
+
+### 8.3 Anthropic
+
+Use current Claude API structured outputs on the GA path, using
+`output_config.format` semantics. Preserve local validation and provider-level
+error mapping.
+
+### 8.4 Gemini
+
+Retain Gemini support, but move it behind the same provider registry so Gemini
+is no longer the hardcoded default behavior for the entire provider layer.
+
+## 9. Metadata And Observability
+
+Record provider-specific metadata in the Python path:
+
+- provider
+- model
+- base URL when relevant
+- token count source: `exact` or `estimated`
+
+Benchmark metadata and CLI-visible metadata should stop treating `llm_model`
+alone as sufficient identity for cross-provider comparisons.
+
+## 10. Token Counting
+
+Token counting behavior should be explicit:
+
+- use exact provider-native token counting when available
+- if unavailable, use a heuristic estimate
+- record whether the count is exact or estimated
+
+Token-counting uncertainty must not silently mix with exact values in
+benchmarking or observability.
+
+## 11. Testing Strategy
+
+### 11.1 Unit coverage
+
+Add or update tests for:
+
+- model-prefix parsing
+- provider/model mismatch errors
+- env and CLI fallback order
+- Ollama base URL normalization
+- provider dispatch behavior
+- provider-specific structured-output request shaping
+- metadata propagation including provider identity
+- exact vs estimated token count metadata
+
+### 11.2 Pipeline coverage
+
+Keep the current provider-agnostic pipeline tests, but add at least one
+non-Gemini fake provider smoke test to prove the pipeline still depends only on
+the abstract contract.
+
+### 11.3 Ollama-focused integration coverage
+
+Add targeted Ollama tests around:
+
+- native schema request payload shape
+- successful Pydantic validation
+- invalid or truncated JSON handling
+- default local base URL behavior
+
+Phase one validation should concentrate on Ollama before broadening to the
+other providers.
+
+## 12. Rollout Plan
+
+### Phase 1
+
+- Implement provider normalization
+- Implement Ollama adapter
+- Thread provider/model/base URL through CLI, service, and benchmark path
+- Add Ollama-focused tests
+- Validate locally with `qwen3.5:35b`
+
+### Phase 2
+
+- Add OpenAI adapter
+- Add Anthropic adapter
+- Re-home Gemini behind the shared dispatch layer
+- Expand tests for cloud providers
+
+This staged rollout reduces surface area while enabling immediate local
+development and validation.
+
+## 13. Local Model Recommendation
+
+Primary local validation model:
+
+- `qwen3.5:35b`
+
+Fallback local validation model:
+
+- `qwen3.5:27b`
+
+Comparison model after adapter stability:
+
+- `gpt-oss:20b`
+
+Reasoning:
+
+- the development machine has an NVIDIA RTX 5090 with 32 GB VRAM
+- `qwen3.5` is a current official Ollama family with a practical middle tier
+  suitable for local validation
+- `qwen3.5:35b` is the best first attempt for capability-per-local-run
+- `qwen3.5:27b` gives a lower-risk fallback if memory pressure, latency, or
+  schema reliability is better there
+- `gpt-oss:20b` is a useful later comparison because it is also positioned for
+  structured-output local use
+
+## 14. Risks
+
+- token preflight logic may drift if providers differ in token accounting
+- provider retries may need provider-specific tuning rather than one global
+  policy
+- structured-output schema support differs by provider and may require
+  provider-specific shaping
+- benchmark result identity may become ambiguous if metadata is not updated
+  consistently
+- Ollama can still return schema-shaped but semantically bad data, so local
+  validation and extraction-focused tests remain necessary
+
+## 15. Implementation Entry Points
+
+Expected primary files:
+
+- `phentrieve/llm/provider.py`
+- `phentrieve/llm/config.py`
+- `phentrieve/llm/types.py`
+- `phentrieve/text_processing/full_text_service.py`
+- `phentrieve/cli/text_commands.py`
+- `phentrieve/benchmark/llm_cli.py`
+- `phentrieve/benchmark/llm_benchmark.py`
+- `tests/unit/llm/test_provider.py`
+- `tests/unit/llm/test_pipeline.py`
+- `tests/unit/text_processing/test_full_text_service.py`
+- `tests/unit/cli/test_text_commands.py`
+- `tests/unit/cli/test_benchmark_commands.py`
+
+## 16. Sources
+
+- Ollama structured outputs:
+  https://docs.ollama.com/capabilities/structured-outputs
+- Ollama Qwen 3.5 library:
+  https://ollama.com/library/qwen3.5
+- Ollama Qwen 2.5 library:
+  https://ollama.com/library/qwen2.5
+- Ollama gpt-oss library:
+  https://ollama.com/library/gpt-oss
+- NVIDIA RTX 5090 official specs:
+  https://www.nvidia.com/en-us/geforce/graphics-cards/50-series/rtx-5090/
+- Anthropic release notes for GA structured outputs:
+  https://platform.claude.com/docs/en/release-notes/overview
+- Anthropic structured outputs docs:
+  https://platform.claude.com/docs/en/build-with-claude/structured-outputs
+- OpenAI model docs showing structured-output support:
+  https://developers.openai.com/api/docs/models
+  https://developers.openai.com/api/docs/models/gpt-4o
+  https://developers.openai.com/api/docs/models/gpt-4o-mini
+  https://developers.openai.com/api/docs/models/gpt-oss-20b

--- a/.planning/specs/2026-04-17-llm-multi-provider-python-cli-design.md
+++ b/.planning/specs/2026-04-17-llm-multi-provider-python-cli-design.md
@@ -17,7 +17,10 @@ existing structured extraction workflow against multiple providers:
 
 Phase one implementation and testing will start with Ollama, using
 `qwen3.5:35b` as the primary local validation model and `qwen3.5:27b` as the
-fallback local validation model.
+fallback local validation model, assuming current Ollama library availability
+at implementation time. If those tags move before implementation, the plan
+should switch to the nearest official Qwen 3.5 Ollama tags rather than
+hardcoding stale model names.
 
 ## 2. Current State
 
@@ -26,8 +29,8 @@ The current provider surface is narrower than the CLI suggests:
 - The CLI and benchmark paths accept `--llm-model`, but not a first-class
   provider field.
 - The provider factory in `phentrieve/llm/provider.py` reads
-  `PHENTRIEVE_LLM_PROVIDER` but explicitly rejects anything other than
-  `gemini`.
+  `PHENTRIEVE_LLM_PROVIDER` from the environment, but explicitly rejects
+  anything other than `gemini`. There is no CLI-level provider flag today.
 - `LLMPipelineConfig` carries model, mode, language, and seed, but not
   provider identity or base URL.
 - The shared pipeline depends mainly on the `LLMProvider` contract and is
@@ -132,9 +135,31 @@ Recommended defaults:
 - default provider remains repo-configurable in `phentrieve/llm/config.py`
 - default model remains repo-configurable in `phentrieve/llm/config.py`
 
+Base URL semantics:
+
+- Ollama gets a concrete default base URL.
+- Cloud providers may also accept an explicit base URL for enterprise proxies,
+  gateways, or compatible deployments, but they should not have a hardcoded
+  non-standard default.
+
+Per-provider timeout defaults should be represented explicitly instead of
+reusing Gemini-tuned values across every provider. In particular, Ollama
+should get a longer default timeout to tolerate cold starts and large local
+model runs, with a starting design target of 300 seconds unless local testing
+supports a tighter value.
+
 Provider-specific defaults should be represented separately from global
 defaults so the code can evolve without encoding Gemini assumptions as the
 general case.
+
+Dependency strategy:
+
+- Ollama should use plain HTTP against its native API rather than adding a
+  hard dependency on an Ollama SDK.
+- The Python `llm` extra should be expanded to include whatever official SDKs
+  or minimal client dependencies are required for OpenAI and Anthropic support.
+- Dependency layout should remain simple unless optional extras become large
+  enough to justify provider-specific splits later.
 
 ## 7. Internal Architecture
 
@@ -150,6 +175,12 @@ Introduce a small typed normalization object, conceptually:
 
 This object is constructed once in the CLI/service boundary and passed into the
 provider factory.
+
+`LLMPipelineConfig` should be extended explicitly to carry at least
+`provider`, and optionally `base_url` if downstream tracing or behavior needs
+that field. `LLMMeta` should also gain `llm_provider` so benchmark and service
+metadata preserve provider identity beyond the lifetime of the live provider
+instance.
 
 ### 7.2 Factory dispatch
 
@@ -197,6 +228,8 @@ Requirements:
 - set low temperature, defaulting to `0` for extraction tasks
 - validate returned JSON locally with Pydantic
 - support explicit `base_url`, defaulting to `http://localhost:11434`
+- use an Ollama-specific retry and timeout policy rather than inheriting
+  Gemini's structured retry behavior mechanically
 
 The implementation should not rely on Ollama's OpenAI compatibility endpoint
 for strict schema handling in the first phase.
@@ -206,17 +239,22 @@ for strict schema handling in the first phase.
 Use native structured output support on the current official API path selected
 at implementation time. The adapter must handle structured-output refusal or
 non-schema terminal states explicitly and keep local validation in place.
+OpenAI-specific retry and timeout behavior should live in the OpenAI adapter.
 
 ### 8.3 Anthropic
 
 Use current Claude API structured outputs on the GA path, using
-`output_config.format` semantics. Preserve local validation and provider-level
-error mapping.
+`output_config.format` semantics where supported by the selected model family.
+Preserve local validation and provider-level error mapping. If a chosen Claude
+model lacks GA structured outputs, the adapter must fail clearly or use a
+documented fallback path rather than silently pretending native support exists.
 
 ### 8.4 Gemini
 
 Retain Gemini support, but move it behind the same provider registry so Gemini
 is no longer the hardcoded default behavior for the entire provider layer.
+Gemini-specific retry and timeout behavior should remain adapter-owned rather
+than treated as the global policy template.
 
 ## 9. Metadata And Observability
 
@@ -229,6 +267,8 @@ Record provider-specific metadata in the Python path:
 
 Benchmark metadata and CLI-visible metadata should stop treating `llm_model`
 alone as sufficient identity for cross-provider comparisons.
+`LLMResponse.provider` is not sufficient on its own; durable pipeline and
+benchmark metadata should include provider identity through `LLMMeta`.
 
 ## 10. Token Counting
 
@@ -240,6 +280,13 @@ Token counting behavior should be explicit:
 
 Token-counting uncertainty must not silently mix with exact values in
 benchmarking or observability.
+
+Existing bare model-name behavior must remain backward compatible:
+
+- a bare model name such as `gemini-3.1-flash-lite-preview` should continue to
+  resolve through the configured default provider
+- prefixed model names become the new cross-provider path, not a breaking
+  replacement for existing Gemini workflows
 
 ## 11. Testing Strategy
 
@@ -253,8 +300,10 @@ Add or update tests for:
 - Ollama base URL normalization
 - provider dispatch behavior
 - provider-specific structured-output request shaping
+- provider-specific retry behavior
 - metadata propagation including provider identity
 - exact vs estimated token count metadata
+- redaction of API keys and other secrets in logged errors
 
 ### 11.2 Pipeline coverage
 
@@ -313,7 +362,8 @@ Reasoning:
 - the development machine has an NVIDIA RTX 5090 with 32 GB VRAM
 - `qwen3.5` is a current official Ollama family with a practical middle tier
   suitable for local validation
-- `qwen3.5:35b` is the best first attempt for capability-per-local-run
+- `qwen3.5:35b` is the best first attempt for capability-per-local-run on a
+  quantized local deployment
 - `qwen3.5:27b` gives a lower-risk fallback if memory pressure, latency, or
   schema reliability is better there
 - `gpt-oss:20b` is a useful later comparison because it is also positioned for
@@ -322,14 +372,16 @@ Reasoning:
 ## 14. Risks
 
 - token preflight logic may drift if providers differ in token accounting
-- provider retries may need provider-specific tuning rather than one global
-  policy
+- provider retries and timeouts need provider-specific tuning rather than one
+  global policy
 - structured-output schema support differs by provider and may require
   provider-specific shaping
 - benchmark result identity may become ambiguous if metadata is not updated
   consistently
 - Ollama can still return schema-shaped but semantically bad data, so local
   validation and extraction-focused tests remain necessary
+- normalization objects that carry secrets increase the chance of accidental
+  key leakage in logs unless errors are redacted consistently
 
 ## 15. Implementation Entry Points
 

--- a/.planning/specs/2026-04-17-ontology-embedding-fidelity-design.md
+++ b/.planning/specs/2026-04-17-ontology-embedding-fidelity-design.md
@@ -1,0 +1,251 @@
+# Ontology–Embedding Fidelity Analysis Script
+
+**Date:** 2026-04-17
+**Issue:** [#34 — HPO term embedding visualization with UMAP](https://github.com/berntpopp/phentrieve/issues/34)
+**Status:** Design, awaiting implementation plan
+**Branch:** `feat/ontology-embedding-fidelity`
+
+## Problem
+
+Phentrieve relies on BioLORD-2023-M embeddings to retrieve HPO terms from clinical text. We have no quantitative evidence that the embedding geometry reflects the curated HPO DAG, and no way to see *where* language agrees or disagrees with the ontology. Issue #34 proposes a visualization CLI; this spec extends the intent into a correlation analysis that produces both numbers and plots, so we can answer "does the language model recapitulate the curated ontology, and if not, where does it fail?"
+
+## Goal
+
+Ship a one-shot research script that, for a given indexed model (default BioLORD-2023-M), emits a timestamped output directory containing four correlation metrics, a per-term fidelity table, and five plots. The script is standalone (not a CLI subcommand) and reuses the existing HPO database and ChromaDB collections without forcing a re-index.
+
+## Non-goals
+
+- Not exposed via `phentrieve` CLI — script only (`scripts/analyze_embedding_ontology.py`).
+- No model-vs-model comparison.
+- No Vue frontend integration.
+- No Nomic Atlas upload.
+- No multi-vector index support (single-vector only for this pass).
+- No re-indexing. Embeddings are read from the existing ChromaDB collection once and cached next to it.
+- No hosting or deployment of generated HTML plots — they are static artifacts.
+
+## Out-of-spec (future work)
+
+- Exposing this as a `phentrieve visualize` CLI command family.
+- Multi-model comparison dashboards.
+- Per-term fidelity surfaced in the Vue frontend (e.g., retrieval-panel side indicator).
+
+## User-facing artifact
+
+A single Python script invoked from the repo root:
+
+```bash
+python scripts/analyze_embedding_ontology.py \
+    --model-name FremyCompany/BioLORD-2023-M \
+    --k 10 \
+    --n-pairs 50000
+```
+
+Produces `data/results/ontology_fidelity/<model-slug>_<YYYYMMDD-HHMMSS>/` containing:
+
+| File | Description |
+|---|---|
+| `summary.json` | Headline numbers, per-branch breakdown, config echo (model, HPO DB path, HPO version if available, k, n-pairs, seed, UMAP params, timestamp). |
+| `per_term_fidelity.csv` | Columns: `hpo_id`, `label`, `branch`, `depth`, `fidelity`, `rank`. Sorted ascending by fidelity (worst first). |
+| `umap_coords.csv` | Columns: `hpo_id`, `label`, `umap_x`, `umap_y`, `branch`, `fidelity`, `depth`. |
+| `umap_by_branch.png` | Plot 1. Static scatter colored by top-level HPO branch. |
+| `umap_by_fidelity.png` | Plot 2. Same UMAP layout, colored by per-term fidelity (diverging colormap). |
+| `umap_interactive.html` | Plots 1+2 as Plotly (hover shows id/label/definition/branch/fidelity). |
+| `distance_correlation.png` | Plot 3. Hexbin of graph distance (shortest-path & Resnik panels) vs embedding cosine distance. Spearman ρ annotated. |
+| `branch_fidelity.png` | Plot 4. Horizontal bar chart of mean fidelity per top-level HPO branch. |
+
+## Metrics
+
+Four metrics, all computed once per run:
+
+1. **Global distance correlation.** Spearman ρ between pairwise cosine distance (embedding) and (a) shortest-path distance on the HPO is_a DAG, (b) Resnik similarity. Computed on `--n-pairs` sampled term pairs (default 50 000). Reports both correlations plus sample size.
+2. **Per-term fidelity.** For each term *t*, compute the *k* nearest terms by embedding cosine and the *k* most Resnik-similar terms from the DAG. Fidelity(*t*) = |embedding-kNN ∩ DAG-kNN| / k, in [0, 1]. Exported as `per_term_fidelity.csv`; mean reported in summary.
+3. **k-NN branch purity.** For each term, what fraction of its *k* embedding nearest neighbors share its top-level HPO branch. Mean overall + per-branch breakdown.
+4. **Depth correlation.** Spearman ρ between term depth in the DAG and Euclidean distance from the centroid of the embedding cloud. Single scalar; surfaces whether deeper (more specific) terms tend toward the periphery of the embedding space.
+
+All four live in `summary.json` under a `metrics` key with clearly-named subfields.
+
+## Architecture
+
+Two new Python modules, following the established `scripts/` + `phentrieve/` split.
+
+### `phentrieve/analysis/ontology_fidelity.py` (new module)
+
+Pure functions, no I/O, no matplotlib. Public surface:
+
+```python
+def build_descendants_index(ancestors: dict[str, set[str]]) -> dict[str, set[str]]: ...
+def graph_shortest_path(u: str, v: str, ancestors, depths) -> int: ...
+def information_content(descendants, root: str = "HP:0000001") -> dict[str, float]: ...
+def resnik_similarity(u: str, v: str, ancestors, ic) -> float: ...
+def top_level_branch(term_id: str, ancestors, depths) -> str | None: ...
+def sample_pairs(n_terms: int, n_pairs: int, rng) -> np.ndarray: ...
+def global_distance_correlation(
+    term_ids, embeddings, ancestors, depths, ic, n_pairs=50_000, seed=42
+) -> dict[str, float]: ...
+def per_term_fidelity(
+    term_ids, embeddings, ancestors, descendants, ic, k=10
+) -> list[dict]: ...
+def branch_knn_purity(
+    term_ids, embeddings, branch_map, k=10
+) -> dict[str, float]: ...
+def depth_correlation(term_ids, embeddings, depths) -> float: ...
+```
+
+Inputs are plain dicts and numpy arrays; no database or ChromaDB dependencies. This is the unit-testable core.
+
+### `phentrieve/analysis/embedding_cache.py` (new module)
+
+```python
+def load_cached_embeddings(
+    model_name: str, refresh: bool = False
+) -> tuple[list[str], np.ndarray]: ...
+```
+
+On first call: queries the existing ChromaDB collection via the current Phentrieve helpers, writes `embeddings.npy` + `hpo_ids.json` next to the collection directory, returns the arrays. On subsequent calls: reads from disk. `refresh=True` forces a re-read.
+
+The cache location is derived from the same path logic used by `phentrieve/indexing/chromadb_orchestrator.py`, so no new configuration is introduced. Collection resolution uses the existing single-vector helpers.
+
+### `scripts/analyze_embedding_ontology.py` (new script)
+
+Orchestrator. Responsibilities in order:
+
+1. Parse CLI flags (see "Flags" below).
+2. `setup_logging` at the requested level.
+3. Load HPO graph via `HPODatabase.load_graph_data()` → `ancestors`, `depths`.
+4. Load HPO term metadata (id, label, definition) via `load_hpo_terms`.
+5. Call `load_cached_embeddings(model_name, refresh=...)`.
+6. Align `hpo_ids` ↔ loaded terms (filter to intersection; warn on mismatches).
+7. Build `descendants`, `ic`, `branch_map` via analysis module.
+8. Compute metrics 1–4.
+9. Fit UMAP (`umap.UMAP(n_neighbors=..., min_dist=..., metric=..., random_state=seed)`).
+10. Write CSVs, PNGs, optional HTML, and `summary.json`.
+11. Return exit code.
+
+Script is ~200–300 lines, mostly glue; plotting functions live in-file since they are output-shaped and not reused.
+
+### Flags
+
+```
+--model-name STR        default: FremyCompany/BioLORD-2023-M
+--output-dir PATH       default: data/results/ontology_fidelity/
+--k INT                 default: 10
+--n-pairs INT           default: 50000
+--umap-neighbors INT    default: 15
+--umap-min-dist FLOAT   default: 0.1
+--metric STR            default: cosine
+--sample INT            default: None  (sample N HPO terms; None = all)
+--seed INT              default: 42
+--skip-interactive      flag — skip Plotly HTML
+--refresh-cache         flag — re-read embeddings from ChromaDB
+--log-level STR         default: INFO
+```
+
+## Data flow
+
+```
+HPO DB (sqlite)          ChromaDB collection
+    |                            |
+    v                            v
+ancestors, depths       embeddings.npy cache (first run)
+    |                            |
+    +------- align ids ----------+
+                |
+                v
+        analysis module (pure)
+          |        |        |
+          v        v        v
+       metrics  fidelity  UMAP coords
+          |        |        |
+          +--------+--------+
+                   |
+                   v
+          plotting + writers
+                   |
+                   v
+    data/results/ontology_fidelity/<slug>_<ts>/
+```
+
+## Performance
+
+- Cold runtime target: ≤ 5 min (includes ChromaDB read).
+- Warm runtime target: ≤ 3 min.
+- Peak memory target: ≤ 4 GB (during UMAP).
+- `--n-pairs 50000` keeps graph-distance computation in-memory and yields a stable Spearman ρ; tunable.
+- k-NN uses `sklearn.neighbors.NearestNeighbors(metric='cosine')` — avoids materializing the full 18k × 18k cosine matrix.
+- `--skip-interactive` skips the ~30s Plotly HTML serialization.
+- `--sample` is for smoke testing only, not real runs.
+
+## Error handling
+
+- Missing HPO DB → error message pointing to `phentrieve data prepare`, exit code 1.
+- Missing ChromaDB collection for model → error message pointing to `phentrieve index build --model-name ...`, exit code 1.
+- ID mismatch between graph and embeddings → log warning with counts, proceed on intersection.
+- Zero intersection → error, exit code 1.
+- UMAP failure → propagate exception with context; no silent swallowing.
+- Any `--sample` value ≥ total terms is clamped silently (with a log info line).
+
+## Dependencies
+
+Added to `pyproject.toml` under a new optional extra `analysis`:
+
+- `umap-learn`
+- `matplotlib`
+- `plotly`
+- `scipy` (verify if already transitive; pin if not)
+
+Install: `uv sync --extra analysis`. Core runtime install stays lean. scikit-learn is already an indirect dependency via sentence-transformers; the spec explicitly depends on it and pins if necessary.
+
+## Testing
+
+All tests under `tests/unit/analysis/` and `tests/integration/analysis/`, mirroring the existing layout.
+
+### Unit tests (`tests/unit/analysis/test_ontology_fidelity.py`)
+
+- `test_graph_shortest_path_known_pairs` — hand-built 5-term DAG.
+- `test_graph_shortest_path_identical_terms_is_zero`.
+- `test_resnik_similarity_identical_terms_equals_own_ic`.
+- `test_information_content_root_is_zero`.
+- `test_build_descendants_index_matches_manual_inverse`.
+- `test_top_level_branch_for_depth_1_term_is_self`.
+- `test_top_level_branch_for_depth_0_term_is_none`.
+- `test_per_term_fidelity_bounds_0_to_1`.
+- `test_per_term_fidelity_identical_embeddings_yields_uniform_baseline`.
+- `test_global_distance_correlation_returns_expected_keys`.
+- `test_branch_knn_purity_monocluster_equals_one`.
+- `test_depth_correlation_returns_scalar_in_expected_range`.
+
+### Unit test for cache
+
+- `test_embedding_cache_writes_and_reloads` (uses temp dir, mocks ChromaDB collection).
+- `test_embedding_cache_refresh_overwrites`.
+
+### Integration smoke test (`tests/integration/analysis/test_analyze_script_smoke.py`, marked `slow`)
+
+- Runs `scripts/analyze_embedding_ontology.py --sample 200` against the real HPO DB with patched `load_cached_embeddings` returning synthetic vectors.
+- Asserts output directory contains all 8 expected files.
+- Asserts `summary.json` parses and contains required keys.
+- Asserts `per_term_fidelity.csv` has expected columns and row count.
+- Does not hit ChromaDB; does not fit full UMAP on real BioLORD embeddings.
+
+### Coverage expectation
+
+All new code under `phentrieve/analysis/` must reach ≥ 85% line coverage. Script orchestration may be below that since some branches are exercised only in integration.
+
+## Documentation
+
+- `scripts/README.md` — add section documenting `analyze_embedding_ontology.py` with example invocation and description of outputs.
+- Project docs — no new mkdocs page; a short entry in the analysis/tools section if one exists, otherwise the script README is the canonical reference.
+
+## Git / PR process
+
+- Work happens on branch `feat/ontology-embedding-fidelity` in a worktree (`~/worktrees/phentrieve-ontology-fidelity/`).
+- Atomic commits: one per module (`analysis/embedding_cache.py`, `analysis/ontology_fidelity.py`, `scripts/analyze_embedding_ontology.py`, tests, pyproject extra, docs).
+- PR references #34 and proposes closing it with a pointer to the script.
+
+## Open questions deferred to implementation plan
+
+- Exact HPO version echoing: whether we embed the version string from the SQLite schema or compute a hash of the `hp.json` bundle.
+- Whether the distance-correlation hexbin renders both shortest-path and Resnik in a single figure (two subplots) or separate files; leaning toward two subplots.
+- Plotly figure: single HTML with two tabs/buttons toggling color scheme, or two separate HTMLs. Leaning toward single HTML with toggle.
+
+These are decided during the implementation plan (next step), not this spec.

--- a/.planning/specs/2026-04-17-ontology-embedding-fidelity-design.md
+++ b/.planning/specs/2026-04-17-ontology-embedding-fidelity-design.md
@@ -20,7 +20,7 @@ Ship a one-shot research script that, for a given indexed model (default BioLORD
 - No Vue frontend integration.
 - No Nomic Atlas upload.
 - No multi-vector index support (single-vector only for this pass).
-- No re-indexing. Embeddings are read from the existing ChromaDB collection once and cached next to it.
+- No re-indexing. Embeddings are read from the existing ChromaDB collection once and cached in a dedicated per-model cache directory (see "Embedding cache" for the exact path).
 - No hosting or deployment of generated HTML plots — they are static artifacts.
 
 ## Out-of-spec (future work)
@@ -55,7 +55,7 @@ Produces `data/results/ontology_fidelity/<model-slug>_<YYYYMMDD-HHMMSS>/` contai
 
 ## Metrics
 
-Four metrics, all computed once per run:
+Four metrics, all computed once per run.
 
 1. **Global distance correlation.** Spearman ρ between pairwise cosine distance (embedding) and (a) shortest-path distance on the HPO is_a DAG, (b) Resnik similarity. Computed on `--n-pairs` sampled term pairs (default 50 000). Reports both correlations plus sample size.
 2. **Per-term fidelity.** For each term *t*, compute the *k* nearest terms by embedding cosine and the *k* most Resnik-similar terms from the DAG. Fidelity(*t*) = |embedding-kNN ∩ DAG-kNN| / k, in [0, 1]. Exported as `per_term_fidelity.csv`; mean reported in summary.
@@ -63,6 +63,20 @@ Four metrics, all computed once per run:
 4. **Depth correlation.** Spearman ρ between term depth in the DAG and Euclidean distance from the centroid of the embedding cloud. Single scalar; surfaces whether deeper (more specific) terms tend toward the periphery of the embedding space.
 
 All four live in `summary.json` under a `metrics` key with clearly-named subfields.
+
+### Determinism rules
+
+The above definitions are ambiguous for several edge cases in the HPO DAG. The rules below are binding — they define the computation and the tests lock them in.
+
+- **k-NN self-exclusion.** Both the embedding k-NN and the DAG k-NN exclude the query term itself. `k` refers to the count *after* exclusion. Implemented by fitting a `NearestNeighbors` with `n_neighbors=k+1` and dropping the self-hit.
+- **Resnik top-k tie-breaking.** Candidates are sorted by Resnik similarity descending; ties are broken by ascending HPO ID (lexicographic). If fewer than *k* non-self candidates have Resnik > 0, the remaining slots are filled with the lexicographically smallest non-self HPO IDs that have not been chosen yet. (A term deep in a sparse branch may otherwise have < *k* meaningful DAG neighbors.) This fallback is rare — we log a count of terms that hit it.
+- **Multi-parent top-level branch.** HPO is a DAG; a term can have multiple depth-1 ancestors. For deterministic branch assignment we take the set of depth-1 ancestors reachable from *t* (plus *t* itself if `depth(t) == 1`), sort ascending by HPO ID, and pick the first. The full set is recorded in the per-term CSV as `all_branches` (semicolon-separated) for audit. `summary.json` notes the count of multi-parent terms that hit this tiebreaker.
+- **Branch purity** uses the single deterministic assignment from the previous rule. A neighbor "shares" the branch iff its own deterministic branch equals the query term's. Purity = share-count / *k*.
+- **Zero-descendant terms (leaves).** `descendants(t)` is defined to always include *t* itself, so `|descendants| ≥ 1` for every term and IC is always well-defined. IC(root) = 0 by construction. IC of a leaf = `log(N)` where N = `|descendants(root)|`.
+- **Depth-0 terms.** Only the HPO root (`HP:0000001`) has depth 0. It has no top-level branch (`branch = None`), is excluded from branch purity, and its per-term fidelity and depth correlation contributions are still computed normally (it is still a valid k-NN query).
+- **Randomness.** `--seed` is the sole entropy source. It seeds (a) the pair sampler for metric 1, (b) `umap.UMAP(random_state=seed)`, (c) any other stochastic step. Reruns with the same seed, same embeddings, and same HPO DB must produce byte-identical `summary.json` metrics and `per_term_fidelity.csv`.
+- **Centroid for depth correlation.** Computed on the aligned term set (post HPO↔embedding intersection), not on the full embedding matrix.
+- **Alignment warnings are non-fatal below threshold.** If the symmetric difference between HPO DB term IDs and cached embedding IDs is > 5% of either side, abort with an error — the index is likely stale. Otherwise log a warning with counts and proceed on the intersection.
 
 ## Architecture
 
@@ -97,13 +111,31 @@ Inputs are plain dicts and numpy arrays; no database or ChromaDB dependencies. T
 
 ```python
 def load_cached_embeddings(
-    model_name: str, refresh: bool = False
+    model_name: str,
+    refresh: bool = False,
+    index_dir_override: str | None = None,
 ) -> tuple[list[str], np.ndarray]: ...
 ```
 
-On first call: queries the existing ChromaDB collection via the current Phentrieve helpers, writes `embeddings.npy` + `hpo_ids.json` next to the collection directory, returns the arrays. On subsequent calls: reads from disk. `refresh=True` forces a re-read.
+**Cache path.** ChromaDB stores all single-vector collections in one shared directory (`data/indexes/chroma.sqlite3` plus Chroma-managed subdirs) — it is *not* a per-collection layout. To avoid collisions across models, the fidelity cache lives in a dedicated sibling directory:
 
-The cache location is derived from the same path logic used by `phentrieve/indexing/chromadb_orchestrator.py`, so no new configuration is introduced. Collection resolution uses the existing single-vector helpers.
+```
+<index_dir>/ontology_fidelity_cache/<collection_name>/
+    embeddings.npy      # shape (N, D), float32
+    hpo_ids.json        # ["HP:0000001", ...] — same order as rows in embeddings.npy
+    meta.json           # {"model_name": ..., "collection_name": ..., "written_at": ISO8601, "n_terms": N, "dim": D}
+```
+
+- `index_dir` comes from `phentrieve.utils.get_default_index_dir()` (overridable via `index_dir_override`, matching the orchestrator's interface).
+- `collection_name` is the single-vector name returned by the existing `generate_collection_name(model_name)` helper (no `_multi` suffix — this pass explicitly excludes multi-vector).
+- The cache directory is created on first write; `.gitignore` already covers `data/indexes/`.
+
+**Behavior.**
+- First call (or `refresh=True`): resolve the ChromaDB collection via existing single-vector helpers, call `collection.get(include=["embeddings"])` in one shot (≈18k × 768 floats → ~55 MB, acceptable), write `embeddings.npy`, `hpo_ids.json`, and `meta.json`, return the arrays.
+- Subsequent calls: read `hpo_ids.json` and `embeddings.npy` directly — no Chroma dependency loaded at runtime.
+- `refresh=True` deletes the three files before rewriting.
+- If the cache exists but is malformed (missing file, mismatched row count between ids and array, unparsable meta), log an error and fall back to a full refresh rather than crashing.
+- If the source ChromaDB collection does not exist, raise `FileNotFoundError` with a message pointing to `phentrieve index build --model-name ...`.
 
 ### `scripts/analyze_embedding_ontology.py` (new script)
 
@@ -111,14 +143,18 @@ Orchestrator. Responsibilities in order:
 
 1. Parse CLI flags (see "Flags" below).
 2. `setup_logging` at the requested level.
-3. Load HPO graph via `HPODatabase.load_graph_data()` → `ancestors`, `depths`.
-4. Load HPO term metadata (id, label, definition) via `load_hpo_terms`.
+3. Open the HPO database directly: resolve its path via `phentrieve.utils` (`resolve_data_path` + `DEFAULT_HPO_DB_FILENAME`), and if the file does not exist, raise `FileNotFoundError` pointing to `phentrieve data prepare` and exit 1. *Do not* use `phentrieve.data_processing.document_creator.load_hpo_terms()` — its soft-fail (log + return `[]`) swallows this error and violates the hard-fail contract in "Error handling".
+4. Construct `HPODatabase(db_path)` and, in a single open/close cycle, call:
+   - `load_all_terms()` → list of `{id, label, definition, synonyms, comments}` records.
+   - `load_graph_data()` → `(ancestors, depths)`.
+   - `get_metadata("hpo_version")` → `hpo_version` string (may be `None`; record `null` in summary.json).
+   - Close the connection immediately after.
 5. Call `load_cached_embeddings(model_name, refresh=...)`.
-6. Align `hpo_ids` ↔ loaded terms (filter to intersection; warn on mismatches).
+6. Align `hpo_ids` ↔ loaded terms (build the intersection; apply the alignment rule from "Determinism rules" — abort if the symmetric difference is > 5%, otherwise warn and proceed).
 7. Build `descendants`, `ic`, `branch_map` via analysis module.
 8. Compute metrics 1–4.
 9. Fit UMAP (`umap.UMAP(n_neighbors=..., min_dist=..., metric=..., random_state=seed)`).
-10. Write CSVs, PNGs, optional HTML, and `summary.json`.
+10. Write CSVs, PNGs, optional HTML, and `summary.json` (which echoes `hpo_db_path`, `hpo_version`, `collection_name`, `embedding_dim`, `n_terms`, and the flag values).
 11. Return exit code.
 
 Script is ~200–300 lines, mostly glue; plotting functions live in-file since they are output-shaped and not reused.
@@ -177,23 +213,38 @@ ancestors, depths       embeddings.npy cache (first run)
 
 ## Error handling
 
-- Missing HPO DB → error message pointing to `phentrieve data prepare`, exit code 1.
-- Missing ChromaDB collection for model → error message pointing to `phentrieve index build --model-name ...`, exit code 1.
-- ID mismatch between graph and embeddings → log warning with counts, proceed on intersection.
+- Missing HPO DB → raise `FileNotFoundError`, message points to `phentrieve data prepare`, exit code 1. Explicitly not the log-and-return-empty behavior of `load_hpo_terms()`.
+- Missing ChromaDB collection for model → raise `FileNotFoundError` from `load_cached_embeddings`, message points to `phentrieve index build --model-name ...`, exit code 1.
+- ID mismatch between HPO DB and cached embeddings → if the symmetric difference exceeds 5% of either set, abort with exit code 1 (likely stale index); otherwise log a warning with counts and proceed on the intersection (see "Determinism rules").
 - Zero intersection → error, exit code 1.
+- Malformed cache (missing file, row-count mismatch, unparsable `meta.json`) → log error, delete the cache, re-read from ChromaDB once, retry. If still malformed → exit code 1.
 - UMAP failure → propagate exception with context; no silent swallowing.
-- Any `--sample` value ≥ total terms is clamped silently (with a log info line).
+- Any `--sample` value ≥ total terms is clamped to the total (with a log info line).
 
 ## Dependencies
 
-Added to `pyproject.toml` under a new optional extra `analysis`:
+Audit of the current `pyproject.toml` core deps:
 
-- `umap-learn`
-- `matplotlib`
-- `plotly`
-- `scipy` (verify if already transitive; pin if not)
+- `matplotlib>=3.10.8` — **already core.** Used as-is.
+- `scikit-learn>=1.4.0` — **already core.** Used as-is (pulls `scipy` transitively, so `scipy` is available without a direct pin).
+- `pandas>=2.0.0`, `numpy>=2.0.0`, `networkx>=3.0` — **already core.** Used as-is.
 
-Install: `uv sync --extra analysis`. Core runtime install stays lean. scikit-learn is already an indirect dependency via sentence-transformers; the spec explicitly depends on it and pins if necessary.
+Genuinely new dependencies — added under a new optional extra `analysis` in `pyproject.toml`:
+
+```
+[project.optional-dependencies]
+analysis = [
+    "umap-learn>=0.5.6",
+    "plotly>=5.22.0",
+]
+```
+
+Rationale for optional (not core):
+- `umap-learn` pulls `numba` + `llvmlite`, a heavy install not needed by the CLI, API, MCP server, or test suite.
+- `plotly` is only used by the interactive HTML output; static PNGs cover the common case.
+- The script gracefully reports a friendly install hint (`pip install 'phentrieve[analysis]'` or `uv sync --extra analysis`) if the imports fail at top-level, rather than a bare `ModuleNotFoundError`.
+
+Install: `uv sync --extra analysis`. `scipy` is *not* pinned directly; if CI surfaces a version issue we add an explicit pin in a follow-up commit. No changes to the core install set.
 
 ## Testing
 
@@ -208,10 +259,15 @@ All tests under `tests/unit/analysis/` and `tests/integration/analysis/`, mirror
 - `test_build_descendants_index_matches_manual_inverse`.
 - `test_top_level_branch_for_depth_1_term_is_self`.
 - `test_top_level_branch_for_depth_0_term_is_none`.
+- `test_top_level_branch_multi_parent_picks_lex_smallest` — locks in the multi-parent determinism rule.
 - `test_per_term_fidelity_bounds_0_to_1`.
+- `test_per_term_fidelity_excludes_self_from_knn` — both embedding-kNN and DAG-kNN.
+- `test_per_term_fidelity_tiebreak_is_lexicographic` — construct a DAG with tied Resnik scores.
 - `test_per_term_fidelity_identical_embeddings_yields_uniform_baseline`.
 - `test_global_distance_correlation_returns_expected_keys`.
+- `test_global_distance_correlation_seeded_is_deterministic` — two runs with the same seed produce identical ρ.
 - `test_branch_knn_purity_monocluster_equals_one`.
+- `test_branch_knn_purity_excludes_root_from_denominator`.
 - `test_depth_correlation_returns_scalar_in_expected_range`.
 
 ### Unit test for cache
@@ -244,7 +300,6 @@ All new code under `phentrieve/analysis/` must reach ≥ 85% line coverage. Scri
 
 ## Open questions deferred to implementation plan
 
-- Exact HPO version echoing: whether we embed the version string from the SQLite schema or compute a hash of the `hp.json` bundle.
 - Whether the distance-correlation hexbin renders both shortest-path and Resnik in a single figure (two subplots) or separate files; leaning toward two subplots.
 - Plotly figure: single HTML with two tabs/buttons toggling color scheme, or two separate HTMLs. Leaning toward single HTML with toggle.
 

--- a/phentrieve/analysis/__init__.py
+++ b/phentrieve/analysis/__init__.py
@@ -1,0 +1,1 @@
+"""Analysis helpers for ontology/embedding correlation."""

--- a/phentrieve/analysis/embedding_cache.py
+++ b/phentrieve/analysis/embedding_cache.py
@@ -1,0 +1,159 @@
+"""Read HPO embeddings once from ChromaDB, then serve from a local `.npy` cache.
+
+Cache layout:
+    <index_dir>/ontology_fidelity_cache/<collection_name>/
+        embeddings.npy    # (N, D) float32
+        hpo_ids.json      # ["HP:0000001", ...] aligned with embeddings rows
+        meta.json         # {"model_name", "collection_name", "written_at",
+                          #  "n_terms", "dim"}
+
+index_dir defaults to phentrieve.utils.get_default_index_dir(), override via
+`index_dir_override`. collection_name comes from
+phentrieve.utils.generate_collection_name(model_name).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+import chromadb
+import numpy as np
+
+from phentrieve.utils import generate_collection_name, get_default_index_dir
+
+logger = logging.getLogger(__name__)
+
+
+def _cache_dir_for(index_dir: Path, collection_name: str) -> Path:
+    return index_dir / "ontology_fidelity_cache" / collection_name
+
+
+def _read_cache(cache_dir: Path) -> tuple[list[str], np.ndarray] | None:
+    """Return (ids, embeddings) if the cache is valid, else None.
+
+    Any missing/malformed file yields None (caller will refresh from Chroma).
+    """
+    emb_path = cache_dir / "embeddings.npy"
+    ids_path = cache_dir / "hpo_ids.json"
+    meta_path = cache_dir / "meta.json"
+    if not (emb_path.exists() and ids_path.exists() and meta_path.exists()):
+        return None
+    try:
+        embeddings = np.load(emb_path)
+        ids = json.loads(ids_path.read_text())
+        meta = json.loads(meta_path.read_text())
+    except (ValueError, OSError, json.JSONDecodeError) as e:
+        logger.error("Ontology-fidelity cache unreadable at %s: %s", cache_dir, e)
+        return None
+    if not isinstance(ids, list) or len(ids) != embeddings.shape[0]:
+        logger.error(
+            "Ontology-fidelity cache mismatch: %d ids vs %d embedding rows",
+            len(ids) if isinstance(ids, list) else -1,
+            embeddings.shape[0],
+        )
+        return None
+    if meta.get("n_terms") != embeddings.shape[0]:
+        logger.error("Ontology-fidelity cache meta.n_terms mismatch")
+        return None
+    return list(ids), embeddings
+
+
+def _write_cache(
+    cache_dir: Path,
+    ids: list[str],
+    embeddings: np.ndarray,
+    model_name: str,
+    collection_name: str,
+) -> None:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    np.save(cache_dir / "embeddings.npy", embeddings.astype(np.float32))
+    (cache_dir / "hpo_ids.json").write_text(json.dumps(list(ids)))
+    (cache_dir / "meta.json").write_text(
+        json.dumps(
+            {
+                "model_name": model_name,
+                "collection_name": collection_name,
+                "written_at": datetime.now(UTC).isoformat(),
+                "n_terms": int(embeddings.shape[0]),
+                "dim": int(embeddings.shape[1]),
+            }
+        )
+    )
+
+
+def _clear_cache(cache_dir: Path) -> None:
+    for fname in ("embeddings.npy", "hpo_ids.json", "meta.json"):
+        p = cache_dir / fname
+        if p.exists():
+            p.unlink()
+
+
+def _read_from_chroma(
+    index_dir: Path, collection_name: str
+) -> tuple[list[str], np.ndarray]:
+    try:
+        client = chromadb.PersistentClient(path=str(index_dir))
+        collection = client.get_collection(collection_name)
+    except Exception as e:  # chromadb raises a variety of types
+        raise FileNotFoundError(
+            f"ChromaDB collection {collection_name!r} not found in {index_dir}. "
+            "Run 'phentrieve index build --model-name ...' first."
+        ) from e
+
+    got = collection.get(include=["embeddings"])
+    ids = list(got["ids"])
+    embeddings = np.asarray(got["embeddings"], dtype=np.float32)
+    if embeddings.ndim != 2 or embeddings.shape[0] != len(ids):
+        raise ValueError(
+            f"Malformed Chroma payload: {len(ids)} ids vs embeddings shape "
+            f"{embeddings.shape}"
+        )
+    return ids, embeddings
+
+
+def load_cached_embeddings(
+    model_name: str,
+    refresh: bool = False,
+    index_dir_override: str | None = None,
+) -> tuple[list[str], np.ndarray]:
+    """Return (hpo_ids, embeddings) for the given model.
+
+    First call: queries ChromaDB, writes cache, returns arrays.
+    Later calls: reads cache only. `refresh=True` forces a re-read.
+
+    Raises FileNotFoundError if the ChromaDB collection for `model_name`
+    does not exist.
+    """
+    index_dir = (
+        Path(index_dir_override) if index_dir_override else get_default_index_dir()
+    )
+    collection_name = generate_collection_name(model_name)
+    cache_dir = _cache_dir_for(index_dir, collection_name)
+
+    if not refresh:
+        cached = _read_cache(cache_dir)
+        if cached is not None:
+            logger.info("Loaded ontology-fidelity cache from %s", cache_dir)
+            return cached
+        if any(
+            (cache_dir / f).exists()
+            for f in ("embeddings.npy", "hpo_ids.json", "meta.json")
+        ):
+            logger.warning(
+                "Ontology-fidelity cache at %s is partial/malformed; refreshing from Chroma",
+                cache_dir,
+            )
+
+    _clear_cache(cache_dir)
+    ids, embeddings = _read_from_chroma(index_dir, collection_name)
+    _write_cache(cache_dir, ids, embeddings, model_name, collection_name)
+    logger.info(
+        "Wrote ontology-fidelity cache: %d terms x %d dims -> %s",
+        len(ids),
+        embeddings.shape[1],
+        cache_dir,
+    )
+    return ids, embeddings

--- a/phentrieve/analysis/ontology_fidelity.py
+++ b/phentrieve/analysis/ontology_fidelity.py
@@ -241,3 +241,79 @@ def global_distance_correlation(
         "spearman_resnik": float(rho_rk) if rho_rk == rho_rk else float("nan"),
         "n_pairs": int(len(pairs)),
     }
+
+
+def _embedding_knn(embeddings: np.ndarray, k: int) -> np.ndarray:
+    """Return indices of the k nearest non-self neighbors per row, cosine metric.
+
+    Shape: (n, k) of int64. Self is always excluded.
+    """
+    from sklearn.neighbors import NearestNeighbors
+
+    # k+1 because the query point itself is always its own nearest neighbor.
+    nn = NearestNeighbors(n_neighbors=k + 1, metric="cosine", algorithm="brute")
+    nn.fit(embeddings)
+    _, idx = nn.kneighbors(embeddings, return_distance=True)
+    # idx[:, 0] is the self-hit in almost all cases. Drop it robustly:
+    n = idx.shape[0]
+    out = np.empty((n, k), dtype=np.int64)
+    for i in range(n):
+        row = [j for j in idx[i] if j != i][:k]
+        # Pad in case of degenerate metric behavior (duplicate self rows, etc.)
+        while len(row) < k:
+            row.append(row[-1] if row else 0)
+        out[i] = row
+    return out
+
+
+def _resnik_top_k(
+    query: str,
+    candidates: list[str],
+    ancestors: dict[str, set[str]],
+    ic: dict[str, float],
+    k: int,
+) -> list[str]:
+    """Return the k candidates with highest Resnik similarity to `query`,
+    ties broken by ascending HPO ID. Query itself is excluded.
+    """
+    scored = []
+    for c in candidates:
+        if c == query:
+            continue
+        scored.append((-resnik_similarity(query, c, ancestors, ic), c))
+    # (-resnik, id): primary ascending on -resnik (i.e. descending resnik);
+    # secondary ascending on id -- this is exactly the tie-break rule.
+    scored.sort()
+    return [c for _, c in scored[:k]]
+
+
+def per_term_fidelity(
+    term_ids: list[str],
+    embeddings: np.ndarray,
+    ancestors: dict[str, set[str]],
+    descendants: dict[str, set[str]],
+    ic: dict[str, float],
+    k: int = 10,
+) -> list[dict]:
+    """Per-term fidelity: |embedding-kNN intersection Resnik-top-k| / k, in [0, 1].
+
+    Returns a list of {id, fidelity, nn_embedding, nn_dag} dicts, one per term,
+    in the same order as `term_ids`.
+    """
+    if k < 1:
+        raise ValueError("k must be >= 1")
+    nn_idx = _embedding_knn(embeddings, k)
+    rows: list[dict] = []
+    for i, query in enumerate(term_ids):
+        nn_embedding = [term_ids[j] for j in nn_idx[i]]
+        nn_dag = _resnik_top_k(query, term_ids, ancestors, ic, k)
+        overlap = len(set(nn_embedding) & set(nn_dag))
+        rows.append(
+            {
+                "id": query,
+                "fidelity": overlap / k,
+                "nn_embedding": nn_embedding,
+                "nn_dag": nn_dag,
+            }
+        )
+    return rows

--- a/phentrieve/analysis/ontology_fidelity.py
+++ b/phentrieve/analysis/ontology_fidelity.py
@@ -48,3 +48,34 @@ def information_content(
     return {
         term: -math.log(len(desc) / root_count) for term, desc in descendants.items()
     }
+
+
+def _include_self(ancestors_of_t: set[str], t: str) -> set[str]:
+    """Return ancestors(t) ∪ {t}. Useful for LCA computation."""
+    return ancestors_of_t | {t}
+
+
+def graph_shortest_path(
+    u: str,
+    v: str,
+    ancestors: dict[str, set[str]],
+    depths: dict[str, int],
+) -> int:
+    """Shortest-path distance on the HPO is_a DAG.
+
+    dist(u, v) = depth(u) + depth(v) - 2 * depth(LCA(u, v))
+
+    LCA is chosen as the common (ancestor-or-self) term with maximum depth.
+    Ties between equal-depth common ancestors are irrelevant for the distance
+    formula, so we do not break them deterministically.
+    """
+    if u == v:
+        return 0
+    common = _include_self(ancestors[u], u) & _include_self(ancestors[v], v)
+    if not common:
+        raise ValueError(
+            f"No common ancestor between {u!r} and {v!r}; "
+            "graph is disconnected or root not reachable."
+        )
+    lca_depth = max(depths[c] for c in common)
+    return depths[u] + depths[v] - 2 * lca_depth

--- a/phentrieve/analysis/ontology_fidelity.py
+++ b/phentrieve/analysis/ontology_fidelity.py
@@ -175,3 +175,69 @@ def sample_pairs(
         out.append((u, v))
 
     return np.array(out, dtype=np.int64)
+
+
+def _cosine_distance_rows(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    """Elementwise cosine distance between paired rows of a and b. Shape (n,)."""
+    num = np.sum(a * b, axis=1)
+    denom = np.linalg.norm(a, axis=1) * np.linalg.norm(b, axis=1)
+    # Avoid division-by-zero; zero-norm rows get 1.0 (max distance).
+    sim = np.where(denom > 0, num / np.maximum(denom, 1e-12), 0.0)
+    return 1.0 - sim
+
+
+def global_distance_correlation(
+    term_ids: list[str],
+    embeddings: np.ndarray,
+    ancestors: dict[str, set[str]],
+    depths: dict[str, int],
+    ic: dict[str, float],
+    n_pairs: int = 50_000,
+    seed: int = 42,
+) -> dict[str, float | int]:
+    """Spearman rho between embedding cosine distance and (shortest-path, Resnik).
+
+    Returns a dict with keys 'spearman_shortest_path', 'spearman_resnik',
+    'n_pairs'. Uses sampled pairs; seed controls pair selection.
+    """
+    from scipy.stats import spearmanr
+
+    rng = np.random.default_rng(seed)
+    pairs = sample_pairs(len(term_ids), n_pairs, rng)
+    if pairs.size == 0:
+        return {
+            "spearman_shortest_path": float("nan"),
+            "spearman_resnik": float("nan"),
+            "n_pairs": 0,
+        }
+
+    u_ids = [term_ids[i] for i in pairs[:, 0]]
+    v_ids = [term_ids[i] for i in pairs[:, 1]]
+
+    cosine = _cosine_distance_rows(embeddings[pairs[:, 0]], embeddings[pairs[:, 1]])
+    shortest = np.array(
+        [
+            graph_shortest_path(u, v, ancestors, depths)
+            for u, v in zip(u_ids, v_ids, strict=True)
+        ],
+        dtype=np.float64,
+    )
+    resnik = np.array(
+        [
+            resnik_similarity(u, v, ancestors, ic)
+            for u, v in zip(u_ids, v_ids, strict=True)
+        ],
+        dtype=np.float64,
+    )
+
+    # Spearman expects distance-like arrays to correlate in the same direction.
+    # Cosine distance is larger for dissimilar pairs; shortest-path also larger;
+    # so a positive rho means agreement. Resnik is a similarity -- negate for agreement.
+    rho_sp, _ = spearmanr(cosine, shortest)
+    rho_rk, _ = spearmanr(cosine, -resnik)
+
+    return {
+        "spearman_shortest_path": float(rho_sp) if rho_sp == rho_sp else float("nan"),
+        "spearman_resnik": float(rho_rk) if rho_rk == rho_rk else float("nan"),
+        "n_pairs": int(len(pairs)),
+    }

--- a/phentrieve/analysis/ontology_fidelity.py
+++ b/phentrieve/analysis/ontology_fidelity.py
@@ -79,3 +79,24 @@ def graph_shortest_path(
         )
     lca_depth = max(depths[c] for c in common)
     return depths[u] + depths[v] - 2 * lca_depth
+
+
+def resnik_similarity(
+    u: str,
+    v: str,
+    ancestors: dict[str, set[str]],
+    ic: dict[str, float],
+) -> float:
+    """Resnik similarity: IC of the most-informative common ancestor.
+
+    Returns 0.0 when the only common ancestor is the root (IC(root) == 0).
+    """
+    if u == v:
+        return ic[u]
+    common = _include_self(ancestors[u], u) & _include_self(ancestors[v], v)
+    if not common:
+        raise ValueError(
+            f"No common ancestor between {u!r} and {v!r}; "
+            "graph is disconnected or root not reachable."
+        )
+    return max(ic[c] for c in common)

--- a/phentrieve/analysis/ontology_fidelity.py
+++ b/phentrieve/analysis/ontology_fidelity.py
@@ -287,6 +287,45 @@ def _resnik_top_k(
     return [c for _, c in scored[:k]]
 
 
+def branch_knn_purity(
+    term_ids: list[str],
+    embeddings: np.ndarray,
+    branch_map: dict[str, str | None],
+    k: int = 10,
+) -> dict:
+    """Mean per-term branch purity over the embedding k-NN.
+
+    Terms whose branch is None (i.e. the HPO root) are excluded from both the
+    per-branch breakdown and the overall mean.
+
+    Returns {'overall': float, 'per_branch': {branch_id: float}, 'n_evaluated': int}.
+    """
+    if k < 1:
+        raise ValueError("k must be >= 1")
+    nn_idx = _embedding_knn(embeddings, k)
+
+    per_branch_scores: dict[str, list[float]] = {}
+    all_scores: list[float] = []
+
+    for i, query in enumerate(term_ids):
+        query_branch = branch_map.get(query)
+        if query_branch is None:
+            continue
+        neighbor_branches = [branch_map.get(term_ids[j]) for j in nn_idx[i]]
+        matches = sum(1 for nb in neighbor_branches if nb == query_branch)
+        score = matches / k
+        all_scores.append(score)
+        per_branch_scores.setdefault(query_branch, []).append(score)
+
+    overall = float(np.mean(all_scores)) if all_scores else float("nan")
+    per_branch = {b: float(np.mean(s)) for b, s in per_branch_scores.items()}
+    return {
+        "overall": overall,
+        "per_branch": per_branch,
+        "n_evaluated": len(all_scores),
+    }
+
+
 def per_term_fidelity(
     term_ids: list[str],
     embeddings: np.ndarray,

--- a/phentrieve/analysis/ontology_fidelity.py
+++ b/phentrieve/analysis/ontology_fidelity.py
@@ -326,6 +326,25 @@ def branch_knn_purity(
     }
 
 
+def depth_correlation(
+    term_ids: list[str],
+    embeddings: np.ndarray,
+    depths: dict[str, int],
+) -> float:
+    """Spearman ρ between term depth and Euclidean distance from the aligned centroid.
+
+    The centroid is computed on the provided embeddings (the aligned set),
+    not on any larger matrix.
+    """
+    from scipy.stats import spearmanr
+
+    centroid = embeddings.mean(axis=0)
+    dists = np.linalg.norm(embeddings - centroid, axis=1)
+    depth_arr = np.array([depths[tid] for tid in term_ids], dtype=np.float64)
+    rho, _ = spearmanr(depth_arr, dists)
+    return float(rho) if rho == rho else float("nan")
+
+
 def per_term_fidelity(
     term_ids: list[str],
     embeddings: np.ndarray,

--- a/phentrieve/analysis/ontology_fidelity.py
+++ b/phentrieve/analysis/ontology_fidelity.py
@@ -1,0 +1,50 @@
+"""Pure functions for ontology/embedding fidelity analysis.
+
+No I/O, no matplotlib, no ChromaDB. Inputs are plain dicts and numpy arrays.
+
+Conventions
+-----------
+- ancestors[t] does NOT include t itself (matches HPODatabase.load_graph_data).
+- descendants[t] DOES include t itself (so |descendants| >= 1 always, IC
+  is always well-defined).
+"""
+
+from __future__ import annotations
+
+import math
+
+
+def build_descendants_index(
+    ancestors: dict[str, set[str]],
+) -> dict[str, set[str]]:
+    """Invert an ancestors map into a descendants map.
+
+    Each term is defined as its own descendant, so |descendants(t)| >= 1
+    for every term.
+    """
+    descendants: dict[str, set[str]] = {t: {t} for t in ancestors}
+    for term, anc_set in ancestors.items():
+        for anc in anc_set:
+            # anc may be outside the ancestors map only if the DAG is malformed;
+            # ignore silently rather than crash — correlates with DB integrity.
+            if anc in descendants:
+                descendants[anc].add(term)
+    return descendants
+
+
+def information_content(
+    descendants: dict[str, set[str]],
+    root: str = "HP:0000001",
+) -> dict[str, float]:
+    """Resnik information content: IC(t) = -log(|descendants(t)| / |descendants(root)|).
+
+    IC(root) == 0 exactly. Leaves have max IC.
+    """
+    if root not in descendants:
+        raise KeyError(f"Root {root!r} not in descendants map")
+    root_count = len(descendants[root])
+    if root_count <= 0:
+        raise ValueError("Root has zero descendants; descendants map is empty.")
+    return {
+        term: -math.log(len(desc) / root_count) for term, desc in descendants.items()
+    }

--- a/phentrieve/analysis/ontology_fidelity.py
+++ b/phentrieve/analysis/ontology_fidelity.py
@@ -100,3 +100,31 @@ def resnik_similarity(
             "graph is disconnected or root not reachable."
         )
     return max(ic[c] for c in common)
+
+
+def top_level_branch(
+    term_id: str,
+    ancestors: dict[str, set[str]],
+    depths: dict[str, int],
+) -> tuple[str | None, frozenset[str]]:
+    """Return (deterministic_branch, all_depth_1_ancestors_including_self_if_depth1).
+
+    Rules (from spec's determinism section):
+    - depth 0 (the root): returns (None, empty frozenset).
+    - depth 1: returns (term_id, {term_id}).
+    - depth > 1: collect all depth-1 ancestors of term_id; the deterministic
+      branch is the lexicographically smallest HPO ID in that set.
+    """
+    d = depths.get(term_id)
+    if d is None:
+        raise KeyError(f"Unknown term {term_id!r}")
+    if d == 0:
+        return None, frozenset()
+    if d == 1:
+        return term_id, frozenset({term_id})
+
+    depth_one_ancs = {a for a in ancestors[term_id] if depths.get(a) == 1}
+    if not depth_one_ancs:
+        # Should not happen in a well-formed HPO DAG, but guard anyway.
+        return None, frozenset()
+    return min(depth_one_ancs), frozenset(depth_one_ancs)

--- a/phentrieve/analysis/ontology_fidelity.py
+++ b/phentrieve/analysis/ontology_fidelity.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import math
 
+import numpy as np
+
 
 def build_descendants_index(
     ancestors: dict[str, set[str]],
@@ -128,3 +130,48 @@ def top_level_branch(
         # Should not happen in a well-formed HPO DAG, but guard anyway.
         return None, frozenset()
     return min(depth_one_ancs), frozenset(depth_one_ancs)
+
+
+def sample_pairs(
+    n_terms: int,
+    n_pairs: int,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    """Return `n_pairs` distinct unordered index pairs in [0, n_terms), as (n_pairs, 2) int64.
+
+    - No self-pairs ((i, i) excluded).
+    - If n_pairs exceeds the total number of distinct unordered pairs, the
+      result is clamped to the maximum available (len <= n_terms*(n_terms-1)/2).
+    - Deterministic given the same rng state.
+    """
+    if n_terms < 2:
+        return np.empty((0, 2), dtype=np.int64)
+
+    max_pairs = n_terms * (n_terms - 1) // 2
+    target = min(n_pairs, max_pairs)
+
+    # Sample with rejection — simpler and faster than enumerating pairs for
+    # realistic n_terms (~18k) and target (~50k). Fall back to exhaustive
+    # enumeration when target is close to max_pairs.
+    if target >= max_pairs * 0.5:
+        rows, cols = np.triu_indices(n_terms, k=1)
+        all_pairs = np.stack([rows, cols], axis=1)
+        idx = rng.choice(len(all_pairs), size=target, replace=False)
+        return all_pairs[idx].astype(np.int64)
+
+    seen: set[tuple[int, int]] = set()
+    out: list[tuple[int, int]] = []
+    attempts = 0
+    max_attempts = max(target * 10, 1000)
+    while len(out) < target and attempts < max_attempts:
+        attempts += 1
+        a, b = rng.integers(0, n_terms, size=2)
+        if a == b:
+            continue
+        u, v = (int(a), int(b)) if a < b else (int(b), int(a))
+        if (u, v) in seen:
+            continue
+        seen.add((u, v))
+        out.append((u, v))
+
+    return np.array(out, dtype=np.int64)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,10 @@ mcp = [
 llm = [
     "google-genai>=1.22.0,<2.0.0",
 ]
+analysis = [
+    "umap-learn>=0.5.6",
+    "plotly>=5.22.0",
+]
 # Install CLI + API with: pip install "phentrieve[api]"
 # Install CLI + MCP with: pip install "phentrieve[mcp]"
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -282,7 +282,13 @@ fidelity CSV, and five plots.
    phentrieve index build --model-name FremyCompany/BioLORD-2023-M
    ```
 
-> **Note:** The script uses the ChromaDB index at the location determined by `PHENTRIEVE_INDEX_DIR` (or defaults to `data/indexes`). In dev/local setups, if you have a non-standard index layout, either set `PHENTRIEVE_INDEX_DIR` before running, or pass a custom index directory via the script's `--index-dir-override` flag (if available). See `python scripts/analyze_embedding_ontology.py --help` for all options.
+> **Note:** The embedding cache reads the Chroma index location from the `PHENTRIEVE_INDEX_DIR` environment variable (falling back to `~/.phentrieve/hpo_chroma_index/`). When running from a dev checkout whose index lives under the repo's `data/indexes/`, export it first:
+>
+> ```bash
+> export PHENTRIEVE_INDEX_DIR=$PWD/data/indexes
+> ```
+>
+> Run `python scripts/analyze_embedding_ontology.py --help` for all flags.
 
 **Usage:**
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -256,3 +256,57 @@ To modify or extend the conversion:
    ```
 
 See `.planning/active/PHENOBERT-CORPUS-CONVERSION-PLAN.md` for architecture details.
+
+---
+
+### `analyze_embedding_ontology.py`
+
+Ontology–embedding fidelity analysis. Loads BioLORD HPO embeddings from the
+existing ChromaDB collection (cached to `.npy` on first run), computes four
+correlation metrics between the embedding space and the curated HPO DAG, and
+produces a timestamped results directory with a summary JSON, a per-term
+fidelity CSV, and five plots.
+
+**Prerequisites:**
+
+1. Phentrieve installed with the `analysis` extra:
+   ```bash
+   uv sync --extra analysis
+   ```
+2. HPO SQLite DB prepared:
+   ```bash
+   phentrieve data prepare
+   ```
+3. BioLORD index built:
+   ```bash
+   phentrieve index build --model-name FremyCompany/BioLORD-2023-M
+   ```
+
+> **Note:** The script uses the ChromaDB index at the location determined by `PHENTRIEVE_INDEX_DIR` (or defaults to `data/indexes`). In dev/local setups, if you have a non-standard index layout, either set `PHENTRIEVE_INDEX_DIR` before running, or pass a custom index directory via the script's `--index-dir-override` flag (if available). See `python scripts/analyze_embedding_ontology.py --help` for all options.
+
+**Usage:**
+
+```bash
+python scripts/analyze_embedding_ontology.py \
+    --model-name FremyCompany/BioLORD-2023-M \
+    --k 10 \
+    --n-pairs 50000
+```
+
+Full flag set: see `--help`.
+
+**Outputs** — under `data/results/ontology_fidelity/<model-slug>_<YYYYMMDD-HHMMSS>/`:
+
+| File | Description |
+|---|---|
+| `summary.json` | Spearman ρ (shortest-path & Resnik), mean per-term fidelity, branch k-NN purity, depth correlation, config echo. |
+| `per_term_fidelity.csv` | Per-term fidelity, sorted ascending (worst first). |
+| `umap_coords.csv` | UMAP coordinates for each HPO term. |
+| `umap_by_branch.png` | UMAP colored by top-level HPO branch. |
+| `umap_by_fidelity.png` | UMAP colored by per-term fidelity (RdBu). |
+| `umap_interactive.html` | Interactive Plotly; toggle between branch and fidelity colorings. |
+| `distance_correlation.png` | Hexbin of embedding cosine vs graph distance (two panels). |
+| `branch_fidelity.png` | Per-branch mean fidelity bar chart. |
+
+See [`.planning/specs/2026-04-17-ontology-embedding-fidelity-design.md`](../.planning/specs/2026-04-17-ontology-embedding-fidelity-design.md)
+for the full contract and metric definitions.

--- a/scripts/analyze_embedding_ontology.py
+++ b/scripts/analyze_embedding_ontology.py
@@ -286,6 +286,229 @@ def write_summary_json(
     out_path.write_text(json.dumps(payload, indent=2, default=str))
 
 
+def run_umap(
+    embeddings: np.ndarray,
+    args: Args,
+) -> np.ndarray:
+    """Return 2-D UMAP coordinates with shape (n, 2)."""
+    import umap
+
+    reducer = umap.UMAP(
+        n_neighbors=args.umap_neighbors,
+        min_dist=args.umap_min_dist,
+        metric=args.metric,
+        n_components=2,
+        random_state=args.seed,
+    )
+    return reducer.fit_transform(embeddings)
+
+
+def write_umap_coords_csv(
+    out_path: Path,
+    aligned_terms: list[dict],
+    coords: np.ndarray,
+    branch_info: dict[str, tuple[str | None, frozenset[str]]],
+    fidelity_by_id: dict[str, float],
+    depths: dict[str, int],
+) -> None:
+    import csv
+
+    labels = {t["id"]: t.get("label", "") for t in aligned_terms}
+    with open(out_path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(
+            ["hpo_id", "label", "umap_x", "umap_y", "branch", "fidelity", "depth"]
+        )
+        for term, (x, y) in zip(aligned_terms, coords, strict=False):
+            tid = term["id"]
+            branch, _ = branch_info[tid]
+            w.writerow(
+                [
+                    tid,
+                    labels.get(tid, ""),
+                    f"{x:.6f}",
+                    f"{y:.6f}",
+                    branch if branch is not None else "",
+                    f"{fidelity_by_id.get(tid, float('nan')):.6f}",
+                    depths.get(tid, -1),
+                ]
+            )
+
+
+def plot_umap_by_branch(
+    out_path: Path,
+    coords: np.ndarray,
+    aligned_terms: list[dict],
+    branch_info: dict[str, tuple[str | None, frozenset[str]]],
+) -> None:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    branches = [branch_info[t["id"]][0] or "ROOT" for t in aligned_terms]
+    unique = sorted(set(branches))
+    cmap = plt.get_cmap("tab20", len(unique))
+    color_of = {b: cmap(i) for i, b in enumerate(unique)}
+    colors = [color_of[b] for b in branches]
+
+    fig, ax = plt.subplots(figsize=(12, 9), dpi=120)
+    ax.scatter(coords[:, 0], coords[:, 1], s=3, c=colors, alpha=0.7, linewidths=0)
+    ax.set_title("HPO embedding UMAP — colored by top-level branch")
+    ax.set_xlabel("UMAP 1")
+    ax.set_ylabel("UMAP 2")
+    handles = [
+        plt.Line2D(
+            [0], [0], marker="o", linestyle="", color=color_of[b], label=b, markersize=6
+        )
+        for b in unique
+    ]
+    ax.legend(handles=handles, loc="best", fontsize=7, ncol=1, frameon=False)
+    fig.tight_layout()
+    fig.savefig(out_path)
+    plt.close(fig)
+
+
+def plot_umap_by_fidelity(
+    out_path: Path,
+    coords: np.ndarray,
+    aligned_terms: list[dict],
+    fidelity_by_id: dict[str, float],
+) -> None:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    fid = [fidelity_by_id.get(t["id"], 0.0) for t in aligned_terms]
+    fig, ax = plt.subplots(figsize=(12, 9), dpi=120)
+    sc = ax.scatter(
+        coords[:, 0],
+        coords[:, 1],
+        s=4,
+        c=fid,
+        cmap="RdBu",
+        vmin=0.0,
+        vmax=1.0,
+        alpha=0.8,
+        linewidths=0,
+    )
+    ax.set_title("HPO embedding UMAP — colored by per-term fidelity")
+    ax.set_xlabel("UMAP 1")
+    ax.set_ylabel("UMAP 2")
+    cb = fig.colorbar(sc, ax=ax)
+    cb.set_label("fidelity (0=disagree, 1=agree)")
+    fig.tight_layout()
+    fig.savefig(out_path)
+    plt.close(fig)
+
+
+def plot_distance_correlation(
+    out_path: Path,
+    aligned_terms: list[dict],
+    aligned_embeddings: np.ndarray,
+    ancestors: dict[str, set[str]],
+    depths: dict[str, int],
+    args: Args,
+) -> dict[str, float]:
+    """Hexbin: cosine distance vs (shortest-path, Resnik), two subplots."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    import numpy as np
+    from scipy.stats import spearmanr
+
+    from phentrieve.analysis.ontology_fidelity import (
+        _cosine_distance_rows,  # type: ignore[attr-defined]
+        build_descendants_index,
+        graph_shortest_path,
+        information_content,
+        resnik_similarity,
+        sample_pairs,
+    )
+
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants)
+    term_ids = [t["id"] for t in aligned_terms]
+    rng = np.random.default_rng(args.seed)
+    pairs = sample_pairs(len(term_ids), args.n_pairs, rng)
+    if pairs.size == 0:
+        return {"spearman_shortest_path": float("nan"), "spearman_resnik": float("nan")}
+
+    cos = _cosine_distance_rows(
+        aligned_embeddings[pairs[:, 0]], aligned_embeddings[pairs[:, 1]]
+    )
+    u_ids = [term_ids[i] for i in pairs[:, 0]]
+    v_ids = [term_ids[i] for i in pairs[:, 1]]
+    shortest = np.array(
+        [
+            graph_shortest_path(u, v, ancestors, depths)
+            for u, v in zip(u_ids, v_ids, strict=False)
+        ],
+        dtype=np.float64,
+    )
+    resnik = np.array(
+        [
+            resnik_similarity(u, v, ancestors, ic)
+            for u, v in zip(u_ids, v_ids, strict=False)
+        ],
+        dtype=np.float64,
+    )
+    rho_sp, _ = spearmanr(cos, shortest)
+    rho_rk, _ = spearmanr(cos, -resnik)
+
+    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 6), dpi=120)
+    ax1.hexbin(shortest, cos, gridsize=40, cmap="viridis", mincnt=1)
+    ax1.set_xlabel("HPO shortest-path distance")
+    ax1.set_ylabel("embedding cosine distance")
+    ax1.set_title(f"shortest-path  ρ={rho_sp:.3f}  (n={len(pairs)})")
+    ax2.hexbin(-resnik, cos, gridsize=40, cmap="viridis", mincnt=1)
+    ax2.set_xlabel("−Resnik similarity  (larger = more distant)")
+    ax2.set_ylabel("embedding cosine distance")
+    ax2.set_title(f"Resnik  ρ={rho_rk:.3f}")
+    fig.tight_layout()
+    fig.savefig(out_path)
+    plt.close(fig)
+
+    return {"spearman_shortest_path": float(rho_sp), "spearman_resnik": float(rho_rk)}
+
+
+def plot_branch_fidelity(
+    out_path: Path,
+    purity: dict,
+    fidelity_rows: list[dict],
+    branch_info: dict[str, tuple[str | None, frozenset[str]]],
+) -> None:
+    """Horizontal bar chart of per-branch MEAN FIDELITY (not purity).
+    Purity is a separate metric surfaced in summary.json.
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    by_branch: dict[str, list[float]] = {}
+    for row in fidelity_rows:
+        branch, _ = branch_info[row["id"]]
+        if branch is None:
+            continue
+        by_branch.setdefault(branch, []).append(row["fidelity"])
+    ordered = sorted(by_branch.items(), key=lambda kv: np.mean(kv[1]))
+    branches = [b for b, _ in ordered]
+    means = [float(np.mean(v)) for _, v in ordered]
+
+    fig, ax = plt.subplots(figsize=(10, max(4, 0.35 * len(branches))), dpi=120)
+    ax.barh(branches, means, color="#3b82f6")
+    ax.set_xlim(0.0, 1.0)
+    ax.set_xlabel("mean per-term fidelity")
+    ax.set_title("Fidelity by top-level HPO branch")
+    fig.tight_layout()
+    fig.savefig(out_path)
+    plt.close(fig)
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     setup_logging(args.log_level)
@@ -364,6 +587,44 @@ def main(argv: list[str] | None = None) -> int:
         len(aligned_terms),
     )
     logger.info("Metrics written. Next: UMAP and plots.")
+
+    logger.info(
+        "Running UMAP (n_neighbors=%d, min_dist=%s) ...",
+        args.umap_neighbors,
+        args.umap_min_dist,
+    )
+    coords = run_umap(aligned_embeddings, args)
+    fidelity_by_id = {r["id"]: r["fidelity"] for r in fidelity_rows}
+
+    write_umap_coords_csv(
+        out_root / "umap_coords.csv",
+        aligned_terms,
+        coords,
+        branch_info,
+        fidelity_by_id,
+        depths,
+    )
+    plot_umap_by_branch(
+        out_root / "umap_by_branch.png", coords, aligned_terms, branch_info
+    )
+    plot_umap_by_fidelity(
+        out_root / "umap_by_fidelity.png", coords, aligned_terms, fidelity_by_id
+    )
+    plot_distance_correlation(
+        out_root / "distance_correlation.png",
+        aligned_terms,
+        aligned_embeddings,
+        ancestors,
+        depths,
+        args,
+    )
+    plot_branch_fidelity(
+        out_root / "branch_fidelity.png",
+        summary["metrics"]["branch_knn_purity"],
+        fidelity_rows,
+        branch_info,
+    )
+    logger.info("Static plots written.")
     return 0
 
 

--- a/scripts/analyze_embedding_ontology.py
+++ b/scripts/analyze_embedding_ontology.py
@@ -19,6 +19,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+import numpy as np
+
 logger = logging.getLogger("analyze_embedding_ontology")
 
 
@@ -114,16 +116,106 @@ def load_hpo_bundle(
     return terms, ancestors, depths, hpo_version, db_path
 
 
+def align_terms_and_embeddings(
+    terms: list[dict],
+    hpo_ids: list[str],
+    embeddings: np.ndarray,
+    symmetric_diff_tolerance: float = 0.05,
+) -> tuple[list[dict], np.ndarray]:
+    """Filter both sides to the intersection of (HPO DB IDs) and (cache IDs).
+
+    - If |symmetric difference| / min(|A|, |B|) > tolerance, raise ValueError —
+      the cache is likely stale.
+    - Otherwise, log a warning with counts and proceed on the intersection.
+    - Preserves cache row order for returned embeddings.
+    """
+    db_ids = {t["id"] for t in terms}
+    cache_ids = set(hpo_ids)
+    inter = db_ids & cache_ids
+    only_db = db_ids - cache_ids
+    only_cache = cache_ids - db_ids
+
+    sym_diff = len(only_db) + len(only_cache)
+    denom = max(min(len(db_ids), len(cache_ids)), 1)
+    if sym_diff / denom > symmetric_diff_tolerance:
+        raise ValueError(
+            f"HPO DB / embedding cache divergence too large: "
+            f"{sym_diff} mismatched IDs out of min({len(db_ids)}, {len(cache_ids)}) "
+            f"({sym_diff / denom:.1%} > {symmetric_diff_tolerance:.0%}). "
+            "Rebuild the index or refresh the cache (--refresh-cache)."
+        )
+    if sym_diff:
+        logger.warning(
+            "HPO DB / embedding cache mismatch: %d only in DB, %d only in cache",
+            len(only_db),
+            len(only_cache),
+        )
+    if not inter:
+        raise ValueError("Zero overlap between HPO DB and embedding cache.")
+
+    keep_cache_rows = [i for i, hid in enumerate(hpo_ids) if hid in inter]
+    aligned_embeddings = embeddings[keep_cache_rows]
+    aligned_ids_set = {hpo_ids[i] for i in keep_cache_rows}
+    aligned_terms = [t for t in terms if t["id"] in aligned_ids_set]
+
+    # Sort aligned_terms into the same order as aligned_embeddings rows.
+    ordered_ids = [hpo_ids[i] for i in keep_cache_rows]
+    by_id = {t["id"]: t for t in aligned_terms}
+    aligned_terms = [by_id[i] for i in ordered_ids]
+
+    return aligned_terms, aligned_embeddings
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     setup_logging(args.log_level)
+
     try:
         terms, ancestors, depths, hpo_version, db_path = load_hpo_bundle()
     except FileNotFoundError as e:
         logger.error("%s", e)
         return 1
-    logger.info("Loaded %d HPO terms (DB: %s)", len(terms), db_path)
-    # Further stages added in subsequent tasks.
+
+    from phentrieve.analysis.embedding_cache import load_cached_embeddings
+
+    try:
+        hpo_ids, embeddings = load_cached_embeddings(
+            model_name=args.model_name,
+            refresh=args.refresh_cache,
+        )
+    except FileNotFoundError as e:
+        logger.error("%s", e)
+        return 1
+
+    try:
+        aligned_terms, aligned_embeddings = align_terms_and_embeddings(
+            terms, hpo_ids, embeddings
+        )
+    except ValueError as e:
+        logger.error("%s", e)
+        return 1
+
+    if args.sample is not None and args.sample < len(aligned_terms):
+        import numpy as np
+
+        rng = np.random.default_rng(args.seed)
+        sample_idx = rng.choice(len(aligned_terms), size=args.sample, replace=False)
+        sample_idx.sort()
+        aligned_terms = [aligned_terms[i] for i in sample_idx]
+        aligned_embeddings = aligned_embeddings[sample_idx]
+        logger.info("Sampled %d terms (seed=%d)", len(aligned_terms), args.seed)
+    elif args.sample is not None:
+        logger.info(
+            "Requested --sample %d >= %d aligned terms; using all.",
+            args.sample,
+            len(aligned_terms),
+        )
+
+    logger.info(
+        "Aligned: %d terms × %d dims", len(aligned_terms), aligned_embeddings.shape[1]
+    )
+
+    # Metrics, UMAP, and writers are added in subsequent tasks.
     return 0
 
 

--- a/scripts/analyze_embedding_ontology.py
+++ b/scripts/analyze_embedding_ontology.py
@@ -166,6 +166,126 @@ def align_terms_and_embeddings(
     return aligned_terms, aligned_embeddings
 
 
+def compute_metrics(
+    aligned_terms: list[dict],
+    aligned_embeddings: np.ndarray,
+    ancestors: dict[str, set[str]],
+    depths: dict[str, int],
+    args: Args,
+) -> tuple[dict, list[dict], dict[str, tuple[str | None, frozenset[str]]]]:
+    """Run all four metrics. Return (summary_dict, per_term_rows, branch_info)."""
+    from phentrieve.analysis.ontology_fidelity import (
+        branch_knn_purity,
+        build_descendants_index,
+        depth_correlation,
+        global_distance_correlation,
+        information_content,
+        per_term_fidelity,
+        top_level_branch,
+    )
+
+    term_ids = [t["id"] for t in aligned_terms]
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants)
+
+    branch_info = {tid: top_level_branch(tid, ancestors, depths) for tid in term_ids}
+    branch_map: dict[str, str | None] = {tid: branch_info[tid][0] for tid in term_ids}
+    multi_parent_count = sum(1 for tid in term_ids if len(branch_info[tid][1]) > 1)
+
+    corr = global_distance_correlation(
+        term_ids,
+        aligned_embeddings,
+        ancestors,
+        depths,
+        ic,
+        n_pairs=args.n_pairs,
+        seed=args.seed,
+    )
+    fidelity_rows = per_term_fidelity(
+        term_ids, aligned_embeddings, ancestors, descendants, ic, k=args.k
+    )
+    purity = branch_knn_purity(term_ids, aligned_embeddings, branch_map, k=args.k)
+    depth_rho = depth_correlation(term_ids, aligned_embeddings, depths)
+
+    summary: dict = {
+        "metrics": {
+            "global_distance_correlation": corr,
+            "per_term_fidelity_mean": float(
+                sum(r["fidelity"] for r in fidelity_rows) / max(len(fidelity_rows), 1)
+            ),
+            "branch_knn_purity": purity,
+            "depth_correlation_spearman": depth_rho,
+        },
+        "meta": {
+            "multi_parent_term_count": multi_parent_count,
+            "n_terms_analyzed": len(term_ids),
+            "embedding_dim": int(aligned_embeddings.shape[1]),
+        },
+    }
+    return summary, fidelity_rows, branch_info
+
+
+def write_per_term_csv(
+    out_path: Path,
+    fidelity_rows: list[dict],
+    aligned_terms: list[dict],
+    branch_info: dict[str, tuple[str | None, frozenset[str]]],
+    depths: dict[str, int],
+) -> None:
+    import csv
+
+    labels = {t["id"]: t.get("label", "") for t in aligned_terms}
+    rows_sorted = sorted(fidelity_rows, key=lambda r: r["fidelity"])
+    with open(out_path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(
+            ["hpo_id", "label", "branch", "all_branches", "depth", "fidelity", "rank"]
+        )
+        for rank, row in enumerate(rows_sorted, start=1):
+            tid = row["id"]
+            branch, all_branches = branch_info[tid]
+            w.writerow(
+                [
+                    tid,
+                    labels.get(tid, ""),
+                    branch if branch is not None else "",
+                    ";".join(sorted(all_branches)),
+                    depths.get(tid, -1),
+                    f"{row['fidelity']:.6f}",
+                    rank,
+                ]
+            )
+
+
+def write_summary_json(
+    out_path: Path,
+    summary: dict,
+    args: Args,
+    hpo_version: str | None,
+    db_path: Path,
+    aligned_n: int,
+) -> None:
+    import json
+
+    payload = {
+        **summary,
+        "config": {
+            "model_name": args.model_name,
+            "hpo_db_path": str(db_path),
+            "hpo_version": hpo_version,
+            "k": args.k,
+            "n_pairs": args.n_pairs,
+            "umap_neighbors": args.umap_neighbors,
+            "umap_min_dist": args.umap_min_dist,
+            "metric": args.metric,
+            "sample": args.sample,
+            "seed": args.seed,
+        },
+        "aligned_n_terms": aligned_n,
+    }
+    out_path.write_text(json.dumps(payload, indent=2, default=str))
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     setup_logging(args.log_level)
@@ -215,7 +335,35 @@ def main(argv: list[str] | None = None) -> int:
         "Aligned: %d terms × %d dims", len(aligned_terms), aligned_embeddings.shape[1]
     )
 
-    # Metrics, UMAP, and writers are added in subsequent tasks.
+    from datetime import datetime
+
+    from phentrieve.utils import get_model_slug
+
+    slug = get_model_slug(args.model_name)
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    out_root = args.output_dir / f"{slug}_{ts}"
+    out_root.mkdir(parents=True, exist_ok=True)
+    logger.info("Output directory: %s", out_root)
+
+    summary, fidelity_rows, branch_info = compute_metrics(
+        aligned_terms, aligned_embeddings, ancestors, depths, args
+    )
+    write_per_term_csv(
+        out_root / "per_term_fidelity.csv",
+        fidelity_rows,
+        aligned_terms,
+        branch_info,
+        depths,
+    )
+    write_summary_json(
+        out_root / "summary.json",
+        summary,
+        args,
+        hpo_version,
+        db_path,
+        len(aligned_terms),
+    )
+    logger.info("Metrics written. Next: UMAP and plots.")
     return 0
 
 

--- a/scripts/analyze_embedding_ontology.py
+++ b/scripts/analyze_embedding_ontology.py
@@ -509,6 +509,99 @@ def plot_branch_fidelity(
     plt.close(fig)
 
 
+def plot_umap_interactive(
+    out_path: Path,
+    coords: np.ndarray,
+    aligned_terms: list[dict],
+    branch_info: dict[str, tuple[str | None, frozenset[str]]],
+    fidelity_by_id: dict[str, float],
+) -> None:
+    """Single HTML with two traces (branch + fidelity) toggled by legend groups."""
+    import plotly.graph_objects as go
+
+    ids = [t["id"] for t in aligned_terms]
+    labels = [t.get("label", "") for t in aligned_terms]
+    defs = [t.get("definition", "") or "" for t in aligned_terms]
+    branches = [branch_info[t["id"]][0] or "ROOT" for t in aligned_terms]
+    fid = [fidelity_by_id.get(t["id"], float("nan")) for t in aligned_terms]
+
+    hover = [
+        f"<b>{hid}</b><br>{lab}<br>branch: {br}<br>fidelity: {f:.3f}<br>{d[:160]}"
+        for hid, lab, br, f, d in zip(ids, labels, branches, fid, defs, strict=False)
+    ]
+
+    unique_branches = sorted(set(branches))
+    branch_to_color = {b: i for i, b in enumerate(unique_branches)}
+    branch_colors = [branch_to_color[b] for b in branches]
+
+    fig = go.Figure()
+    fig.add_trace(
+        go.Scattergl(
+            x=coords[:, 0],
+            y=coords[:, 1],
+            mode="markers",
+            marker={
+                "size": 5,
+                "color": branch_colors,
+                "colorscale": "Viridis",
+                "showscale": False,
+                "opacity": 0.8,
+            },
+            text=hover,
+            hoverinfo="text",
+            name="by branch",
+            visible=True,
+        )
+    )
+    fig.add_trace(
+        go.Scattergl(
+            x=coords[:, 0],
+            y=coords[:, 1],
+            mode="markers",
+            marker={
+                "size": 5,
+                "color": fid,
+                "colorscale": "RdBu",
+                "cmin": 0.0,
+                "cmax": 1.0,
+                "showscale": True,
+                "colorbar": {"title": "fidelity"},
+                "opacity": 0.85,
+            },
+            text=hover,
+            hoverinfo="text",
+            name="by fidelity",
+            visible=False,
+        )
+    )
+    fig.update_layout(
+        title="HPO embedding UMAP — interactive",
+        xaxis_title="UMAP 1",
+        yaxis_title="UMAP 2",
+        updatemenus=[
+            {
+                "type": "buttons",
+                "direction": "right",
+                "x": 0.0,
+                "y": 1.08,
+                "buttons": [
+                    {
+                        "label": "by branch",
+                        "method": "update",
+                        "args": [{"visible": [True, False]}],
+                    },
+                    {
+                        "label": "by fidelity",
+                        "method": "update",
+                        "args": [{"visible": [False, True]}],
+                    },
+                ],
+            }
+        ],
+    )
+    fig.write_html(out_path, include_plotlyjs="cdn", full_html=True)
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     setup_logging(args.log_level)
@@ -625,6 +718,25 @@ def main(argv: list[str] | None = None) -> int:
         branch_info,
     )
     logger.info("Static plots written.")
+
+    if not args.skip_interactive:
+        try:
+            plot_umap_interactive(
+                out_root / "umap_interactive.html",
+                coords,
+                aligned_terms,
+                branch_info,
+                fidelity_by_id,
+            )
+            logger.info("Interactive HTML written.")
+        except ImportError:
+            logger.error(
+                "plotly not installed. Install with: uv sync --extra analysis  "
+                "(or pass --skip-interactive to skip this output)."
+            )
+            return 1
+    else:
+        logger.info("Skipping interactive HTML (--skip-interactive).")
     return 0
 
 

--- a/scripts/analyze_embedding_ontology.py
+++ b/scripts/analyze_embedding_ontology.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Ontology-embedding fidelity analysis.
+
+Loads HPO graph data + cached BioLORD embeddings, computes four correlation
+metrics and produces five plots in a timestamped output directory.
+
+Run `python scripts/analyze_embedding_ontology.py --help` for usage.
+
+This is a standalone research script - intentionally not exposed via the
+`phentrieve` CLI. See .planning/specs/2026-04-17-ontology-embedding-fidelity-design.md
+for the full contract.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger("analyze_embedding_ontology")
+
+
+@dataclass
+class Args:
+    model_name: str
+    output_dir: Path
+    k: int
+    n_pairs: int
+    umap_neighbors: int
+    umap_min_dist: float
+    metric: str
+    sample: int | None
+    seed: int
+    skip_interactive: bool
+    refresh_cache: bool
+    log_level: str
+
+
+def parse_args(argv: list[str] | None = None) -> Args:
+    p = argparse.ArgumentParser(
+        description="Ontology-embedding fidelity analysis.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument("--model-name", default="FremyCompany/BioLORD-2023-M")
+    p.add_argument(
+        "--output-dir",
+        default="data/results/ontology_fidelity",
+        type=Path,
+    )
+    p.add_argument("--k", type=int, default=10)
+    p.add_argument("--n-pairs", type=int, default=50_000)
+    p.add_argument("--umap-neighbors", type=int, default=15)
+    p.add_argument("--umap-min-dist", type=float, default=0.1)
+    p.add_argument("--metric", default="cosine")
+    p.add_argument("--sample", type=int, default=None)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--skip-interactive", action="store_true")
+    p.add_argument("--refresh-cache", action="store_true")
+    p.add_argument("--log-level", default="INFO")
+    ns = p.parse_args(argv)
+    return Args(
+        model_name=ns.model_name,
+        output_dir=ns.output_dir,
+        k=ns.k,
+        n_pairs=ns.n_pairs,
+        umap_neighbors=ns.umap_neighbors,
+        umap_min_dist=ns.umap_min_dist,
+        metric=ns.metric,
+        sample=ns.sample,
+        seed=ns.seed,
+        skip_interactive=ns.skip_interactive,
+        refresh_cache=ns.refresh_cache,
+        log_level=ns.log_level,
+    )
+
+
+def setup_logging(level: str) -> None:
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+
+def load_hpo_bundle(
+    data_dir_override: str | None = None,
+) -> tuple[list[dict], dict[str, set[str]], dict[str, int], str | None, Path]:
+    """Open HPODatabase directly, load terms + graph + version, close. Hard-fail
+    on missing DB (unlike document_creator.load_hpo_terms which soft-fails)."""
+    from phentrieve.config import DEFAULT_HPO_DB_FILENAME
+    from phentrieve.data_processing.hpo_database import HPODatabase
+    from phentrieve.utils import get_default_data_dir, resolve_data_path
+
+    data_dir = resolve_data_path(data_dir_override, "data_dir", get_default_data_dir)
+    db_path = data_dir / DEFAULT_HPO_DB_FILENAME
+    if not db_path.exists():
+        raise FileNotFoundError(
+            f"HPO database not found: {db_path}. Run 'phentrieve data prepare' first."
+        )
+    db = HPODatabase(db_path)
+    try:
+        terms = db.load_all_terms()
+        ancestors, depths = db.load_graph_data()
+        hpo_version = db.get_metadata("hpo_version")
+    finally:
+        db.close()
+    logger.info(
+        "HPO DB loaded: %d terms, version=%s, path=%s",
+        len(terms),
+        hpo_version,
+        db_path,
+    )
+    return terms, ancestors, depths, hpo_version, db_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    setup_logging(args.log_level)
+    try:
+        terms, ancestors, depths, hpo_version, db_path = load_hpo_bundle()
+    except FileNotFoundError as e:
+        logger.error("%s", e)
+        return 1
+    logger.info("Loaded %d HPO terms (DB: %s)", len(terms), db_path)
+    # Further stages added in subsequent tasks.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/analysis/test_analyze_script_smoke.py
+++ b/tests/integration/analysis/test_analyze_script_smoke.py
@@ -51,11 +51,12 @@ def _write_stub_cache(tmp_path: Path, term_ids: list[str]) -> Path:
 def test_analyze_script_smoke(tmp_path, monkeypatch):
     """Run the script against a real HPO DB with a stubbed embedding cache."""
     from phentrieve.data_processing.hpo_database import HPODatabase
-    from phentrieve.utils import get_default_data_dir
+    from phentrieve.utils import get_default_data_dir, resolve_data_path
 
-    db_path = get_default_data_dir() / "hpo_data.db"
+    data_dir = resolve_data_path(None, "data_dir", get_default_data_dir)
+    db_path = data_dir / "hpo_data.db"
     if not db_path.exists():
-        pytest.skip("HPO SQLite DB not present on this machine")
+        pytest.skip(f"HPO SQLite DB not present at {db_path}")
 
     db = HPODatabase(db_path)
     try:

--- a/tests/integration/analysis/test_analyze_script_smoke.py
+++ b/tests/integration/analysis/test_analyze_script_smoke.py
@@ -1,0 +1,114 @@
+"""End-to-end smoke test for scripts/analyze_embedding_ontology.py.
+
+Runs the orchestrator against the real HPO SQLite DB but mocks the embedding
+cache (so ChromaDB is never touched and UMAP operates on tiny synthetic vectors).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "scripts" / "analyze_embedding_ontology.py"
+
+
+pytestmark = [pytest.mark.slow, pytest.mark.integration]
+
+
+def _write_stub_cache(tmp_path: Path, term_ids: list[str]) -> Path:
+    """Write a fake ontology-fidelity cache with deterministic synthetic vectors."""
+    rng = np.random.default_rng(0)
+    vecs = rng.standard_normal((len(term_ids), 16)).astype(np.float32)
+
+    # Mirrors the real cache layout.
+    from phentrieve.utils import generate_collection_name
+
+    collection = generate_collection_name("FremyCompany/BioLORD-2023-M")
+    cache_dir = tmp_path / "indexes" / "ontology_fidelity_cache" / collection
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    np.save(cache_dir / "embeddings.npy", vecs)
+    (cache_dir / "hpo_ids.json").write_text(json.dumps(term_ids))
+    (cache_dir / "meta.json").write_text(
+        json.dumps(
+            {
+                "model_name": "FremyCompany/BioLORD-2023-M",
+                "collection_name": collection,
+                "written_at": "2026-04-17T00:00:00+00:00",
+                "n_terms": len(term_ids),
+                "dim": 16,
+            }
+        )
+    )
+    return cache_dir
+
+
+def test_analyze_script_smoke(tmp_path, monkeypatch):
+    """Run the script against a real HPO DB with a stubbed embedding cache."""
+    from phentrieve.data_processing.hpo_database import HPODatabase
+    from phentrieve.utils import get_default_data_dir
+
+    db_path = get_default_data_dir() / "hpo_data.db"
+    if not db_path.exists():
+        pytest.skip("HPO SQLite DB not present on this machine")
+
+    db = HPODatabase(db_path)
+    try:
+        all_terms = db.load_all_terms()
+    finally:
+        db.close()
+    # Use all terms so the divergence check passes; --sample 150 limits computation.
+    term_ids = [t["id"] for t in all_terms]
+
+    # Point PHENTRIEVE_INDEX_DIR at a temp tree and write a stubbed cache there.
+    tmp_index_root = tmp_path
+    _write_stub_cache(tmp_index_root, term_ids)
+    monkeypatch.setenv("PHENTRIEVE_INDEX_DIR", str(tmp_index_root / "indexes"))
+
+    out_dir = tmp_path / "out"
+    cmd = [
+        sys.executable,
+        str(SCRIPT),
+        "--sample",
+        "150",
+        "--n-pairs",
+        "300",
+        "--k",
+        "5",
+        "--umap-neighbors",
+        "10",
+        "--output-dir",
+        str(out_dir),
+        "--log-level",
+        "INFO",
+        "--skip-interactive",
+    ]
+    r = subprocess.run(cmd, capture_output=True, text=True)  # noqa: S603
+    assert r.returncode == 0, f"stdout:\n{r.stdout}\nstderr:\n{r.stderr}"
+
+    # Exactly one run subdir.
+    run_dirs = list(out_dir.iterdir())
+    assert len(run_dirs) == 1
+    run = run_dirs[0]
+
+    expected = [
+        "summary.json",
+        "per_term_fidelity.csv",
+        "umap_coords.csv",
+        "umap_by_branch.png",
+        "umap_by_fidelity.png",
+        "distance_correlation.png",
+        "branch_fidelity.png",
+    ]
+    for name in expected:
+        assert (run / name).exists(), f"missing {name}; dir has {list(run.iterdir())}"
+
+    summary = json.loads((run / "summary.json").read_text())
+    assert "metrics" in summary
+    assert "config" in summary
+    assert summary["config"]["model_name"] == "FremyCompany/BioLORD-2023-M"

--- a/tests/unit/analysis/test_embedding_cache.py
+++ b/tests/unit/analysis/test_embedding_cache.py
@@ -1,0 +1,128 @@
+"""Unit tests for phentrieve.analysis.embedding_cache."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+
+def _make_mock_client_with_collection(ids, embeddings) -> MagicMock:
+    """Return a mock chromadb.PersistentClient that exposes a collection
+    whose .get(include=['embeddings']) returns the given ids/embeddings."""
+    client = MagicMock()
+    collection = MagicMock()
+    collection.get.return_value = {
+        "ids": list(ids),
+        "embeddings": [list(row) for row in embeddings],
+    }
+    client.get_collection.return_value = collection
+    return client
+
+
+def test_embedding_cache_first_call_reads_chroma_and_writes_files(tmp_path):
+    from phentrieve.analysis.embedding_cache import load_cached_embeddings
+
+    ids = ["HP:0000001", "HP:0000002", "HP:0000003"]
+    vecs = np.array([[1.0, 0.0], [0.0, 1.0], [0.5, 0.5]], dtype=np.float32)
+    client = _make_mock_client_with_collection(ids, vecs)
+
+    with patch(
+        "phentrieve.analysis.embedding_cache.chromadb.PersistentClient",
+        return_value=client,
+    ):
+        got_ids, got_vecs = load_cached_embeddings(
+            model_name="FremyCompany/BioLORD-2023-M",
+            index_dir_override=str(tmp_path),
+        )
+
+    assert got_ids == ids
+    np.testing.assert_allclose(got_vecs, vecs)
+
+    cache_root = tmp_path / "ontology_fidelity_cache"
+    subdirs = list(cache_root.iterdir())
+    assert len(subdirs) == 1
+    cache_dir = subdirs[0]
+    assert (cache_dir / "embeddings.npy").exists()
+    assert (cache_dir / "hpo_ids.json").exists()
+    assert (cache_dir / "meta.json").exists()
+    meta = json.loads((cache_dir / "meta.json").read_text())
+    assert meta["model_name"] == "FremyCompany/BioLORD-2023-M"
+    assert meta["n_terms"] == 3
+    assert meta["dim"] == 2
+
+
+def test_embedding_cache_second_call_skips_chroma(tmp_path):
+    from phentrieve.analysis.embedding_cache import load_cached_embeddings
+
+    ids = ["HP:0000001", "HP:0000002"]
+    vecs = np.array([[1.0, 0.0], [0.0, 1.0]], dtype=np.float32)
+    client = _make_mock_client_with_collection(ids, vecs)
+
+    # Warm the cache.
+    with patch(
+        "phentrieve.analysis.embedding_cache.chromadb.PersistentClient",
+        return_value=client,
+    ):
+        load_cached_embeddings(
+            "FremyCompany/BioLORD-2023-M", index_dir_override=str(tmp_path)
+        )
+
+    # Second call must not construct PersistentClient at all.
+    with patch(
+        "phentrieve.analysis.embedding_cache.chromadb.PersistentClient",
+        side_effect=AssertionError("should not be called"),
+    ):
+        got_ids, got_vecs = load_cached_embeddings(
+            "FremyCompany/BioLORD-2023-M", index_dir_override=str(tmp_path)
+        )
+
+    assert got_ids == ids
+    np.testing.assert_allclose(got_vecs, vecs)
+
+
+def test_embedding_cache_refresh_overwrites(tmp_path):
+    from phentrieve.analysis.embedding_cache import load_cached_embeddings
+
+    ids_v1 = ["HP:0000001", "HP:0000002"]
+    vecs_v1 = np.array([[1.0, 0.0], [0.0, 1.0]], dtype=np.float32)
+    ids_v2 = ["HP:0000001", "HP:0000002", "HP:0000003"]
+    vecs_v2 = np.array([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]], dtype=np.float32)
+
+    with patch(
+        "phentrieve.analysis.embedding_cache.chromadb.PersistentClient",
+        return_value=_make_mock_client_with_collection(ids_v1, vecs_v1),
+    ):
+        load_cached_embeddings(
+            "FremyCompany/BioLORD-2023-M", index_dir_override=str(tmp_path)
+        )
+
+    with patch(
+        "phentrieve.analysis.embedding_cache.chromadb.PersistentClient",
+        return_value=_make_mock_client_with_collection(ids_v2, vecs_v2),
+    ):
+        got_ids, got_vecs = load_cached_embeddings(
+            "FremyCompany/BioLORD-2023-M",
+            refresh=True,
+            index_dir_override=str(tmp_path),
+        )
+
+    assert got_ids == ids_v2
+    assert got_vecs.shape == (3, 2)
+
+
+def test_embedding_cache_missing_collection_raises(tmp_path):
+    from phentrieve.analysis.embedding_cache import load_cached_embeddings
+
+    client = MagicMock()
+    client.get_collection.side_effect = ValueError("not found")
+    with patch(
+        "phentrieve.analysis.embedding_cache.chromadb.PersistentClient",
+        return_value=client,
+    ):
+        with pytest.raises(FileNotFoundError):
+            load_cached_embeddings(
+                "FremyCompany/BioLORD-2023-M", index_dir_override=str(tmp_path)
+            )

--- a/tests/unit/analysis/test_ontology_fidelity.py
+++ b/tests/unit/analysis/test_ontology_fidelity.py
@@ -423,3 +423,18 @@ def test_branch_knn_purity_excludes_root_from_denominator():
     # HP:0000001 excluded from denominator.
     assert result["overall"] == pytest.approx(1.0)
     assert result["n_evaluated"] == 2
+
+
+def test_depth_correlation_returns_scalar_in_expected_range():
+    import numpy as np
+
+    from phentrieve.analysis.ontology_fidelity import depth_correlation
+
+    term_ids = [f"HP:{i:07d}" for i in range(20)]
+    depths = {tid: i % 5 for i, tid in enumerate(term_ids)}
+    rng = np.random.default_rng(0)
+    embeddings = rng.standard_normal((20, 8)).astype(np.float32)
+
+    rho = depth_correlation(term_ids, embeddings, depths)
+    assert isinstance(rho, float)
+    assert -1.0 <= rho <= 1.0

--- a/tests/unit/analysis/test_ontology_fidelity.py
+++ b/tests/unit/analysis/test_ontology_fidelity.py
@@ -103,3 +103,27 @@ def test_information_content_monotone_with_depth(tiny_dag):
 
     # A descendant must have IC >= its ancestor.
     assert ic["HP:0030"] >= ic["HP:0020"] >= ic["HP:0002"] >= ic["HP:0000001"]
+
+
+def test_graph_shortest_path_identical_terms_is_zero(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import graph_shortest_path
+
+    ancestors, depths = tiny_dag
+    assert graph_shortest_path("HP:0030", "HP:0030", ancestors, depths) == 0
+
+
+def test_graph_shortest_path_known_pairs(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import graph_shortest_path
+
+    ancestors, depths = tiny_dag
+
+    # HP:0010 -> HP:0001 -> HP:0011 : distance 2
+    assert graph_shortest_path("HP:0010", "HP:0011", ancestors, depths) == 2
+    # HP:0030 -> HP:0020 -> HP:0002 : distance 2
+    assert graph_shortest_path("HP:0030", "HP:0002", ancestors, depths) == 2
+    # HP:0010 (branch 1) and HP:0020 (branch 2): LCA is root (depth 0).
+    # distance = 2 + 2 - 0 = 4
+    assert graph_shortest_path("HP:0010", "HP:0020", ancestors, depths) == 4
+    # Multi-parent: HP:0011 has two parents; LCA with HP:0020 is HP:0002 (depth 1).
+    # depths: HP:0011=2, HP:0020=2; distance = 2 + 2 - 2*1 = 2
+    assert graph_shortest_path("HP:0011", "HP:0020", ancestors, depths) == 2

--- a/tests/unit/analysis/test_ontology_fidelity.py
+++ b/tests/unit/analysis/test_ontology_fidelity.py
@@ -212,3 +212,38 @@ def test_top_level_branch_multi_parent_picks_lex_smallest(tiny_dag):
     branch, all_branches = top_level_branch("HP:0011", ancestors, depths)
     assert branch == "HP:0001"
     assert all_branches == frozenset({"HP:0001", "HP:0002"})
+
+
+def test_sample_pairs_shape_and_bounds():
+    import numpy as np
+
+    from phentrieve.analysis.ontology_fidelity import sample_pairs
+
+    rng = np.random.default_rng(42)
+    pairs = sample_pairs(n_terms=100, n_pairs=500, rng=rng)
+    assert pairs.shape == (500, 2)
+    assert pairs.min() >= 0
+    assert pairs.max() < 100
+    # No self-pairs.
+    assert (pairs[:, 0] != pairs[:, 1]).all()
+
+
+def test_sample_pairs_deterministic_given_seed():
+    import numpy as np
+
+    from phentrieve.analysis.ontology_fidelity import sample_pairs
+
+    a = sample_pairs(1000, 200, np.random.default_rng(7))
+    b = sample_pairs(1000, 200, np.random.default_rng(7))
+    np.testing.assert_array_equal(a, b)
+
+
+def test_sample_pairs_clamps_when_requested_exceeds_available():
+    import numpy as np
+
+    from phentrieve.analysis.ontology_fidelity import sample_pairs
+
+    # For 5 terms there are only 5*4/2 = 10 unordered distinct pairs.
+    pairs = sample_pairs(5, 100, np.random.default_rng(0))
+    assert pairs.shape[0] <= 10
+    assert (pairs[:, 0] != pairs[:, 1]).all()

--- a/tests/unit/analysis/test_ontology_fidelity.py
+++ b/tests/unit/analysis/test_ontology_fidelity.py
@@ -1,0 +1,105 @@
+"""Unit tests for phentrieve.analysis.ontology_fidelity."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+# ------------------------------------------------------------
+# Shared tiny DAG used across tests.
+#
+#            HP:0000001  (root, depth 0)
+#              /      \
+#        HP:0001      HP:0002         (depth 1; top-level branches)
+#          /  \          |
+#     HP:0010 HP:0011  HP:0020        (depth 2)
+#                        |
+#                     HP:0030         (depth 3)
+#
+# HP:0011 has two parents: HP:0001 AND HP:0002  (multi-parent case).
+# ------------------------------------------------------------
+
+
+@pytest.fixture
+def tiny_dag() -> tuple[dict[str, set[str]], dict[str, int]]:
+    """Return (ancestors, depths) for the fixture DAG above.
+
+    Convention matches HPODatabase.load_graph_data: ancestors[t] does NOT
+    include t itself.
+    """
+    ancestors = {
+        "HP:0000001": set(),
+        "HP:0001": {"HP:0000001"},
+        "HP:0002": {"HP:0000001"},
+        "HP:0010": {"HP:0000001", "HP:0001"},
+        "HP:0011": {"HP:0000001", "HP:0001", "HP:0002"},
+        "HP:0020": {"HP:0000001", "HP:0002"},
+        "HP:0030": {"HP:0000001", "HP:0002", "HP:0020"},
+    }
+    depths = {
+        "HP:0000001": 0,
+        "HP:0001": 1,
+        "HP:0002": 1,
+        "HP:0010": 2,
+        "HP:0011": 2,
+        "HP:0020": 2,
+        "HP:0030": 3,
+    }
+    return ancestors, depths
+
+
+def test_build_descendants_index_matches_manual_inverse(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import build_descendants_index
+
+    ancestors, _ = tiny_dag
+    descendants = build_descendants_index(ancestors)
+
+    # Each term is its own descendant by our convention.
+    assert descendants["HP:0030"] == {"HP:0030"}
+    assert descendants["HP:0020"] == {"HP:0020", "HP:0030"}
+    assert descendants["HP:0002"] == {"HP:0002", "HP:0011", "HP:0020", "HP:0030"}
+    assert descendants["HP:0001"] == {"HP:0001", "HP:0010", "HP:0011"}
+    assert descendants["HP:0000001"] == set(ancestors.keys())
+
+
+def test_information_content_root_is_zero(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import (
+        build_descendants_index,
+        information_content,
+    )
+
+    ancestors, _ = tiny_dag
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants, root="HP:0000001")
+
+    assert ic["HP:0000001"] == pytest.approx(0.0)
+
+
+def test_information_content_leaf_is_log_n(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import (
+        build_descendants_index,
+        information_content,
+    )
+
+    ancestors, _ = tiny_dag
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants, root="HP:0000001")
+
+    n_total = len(ancestors)
+    # HP:0030 is a leaf: |descendants|=1, IC = -log(1/N) = log(N)
+    assert ic["HP:0030"] == pytest.approx(math.log(n_total))
+
+
+def test_information_content_monotone_with_depth(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import (
+        build_descendants_index,
+        information_content,
+    )
+
+    ancestors, _ = tiny_dag
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants, root="HP:0000001")
+
+    # A descendant must have IC >= its ancestor.
+    assert ic["HP:0030"] >= ic["HP:0020"] >= ic["HP:0002"] >= ic["HP:0000001"]

--- a/tests/unit/analysis/test_ontology_fidelity.py
+++ b/tests/unit/analysis/test_ontology_fidelity.py
@@ -389,3 +389,37 @@ def test_per_term_fidelity_identical_embeddings_yields_uniform_baseline():
     rows = per_term_fidelity(term_ids, embeddings, ancestors, descendants, ic, k=2)
     for row in rows:
         assert row["fidelity"] == pytest.approx(1.0)
+
+
+def test_branch_knn_purity_monocluster_equals_one():
+    import numpy as np
+
+    from phentrieve.analysis.ontology_fidelity import branch_knn_purity
+
+    term_ids = ["HP:0010", "HP:0011", "HP:0012"]
+    branch_map = {"HP:0010": "HP:0001", "HP:0011": "HP:0001", "HP:0012": "HP:0001"}
+    # All identical embeddings -> every neighbor in the same branch.
+    embeddings = np.ones((3, 4), dtype=np.float32)
+    result = branch_knn_purity(term_ids, embeddings, branch_map, k=2)
+    assert result["overall"] == pytest.approx(1.0)
+    assert result["per_branch"]["HP:0001"] == pytest.approx(1.0)
+
+
+def test_branch_knn_purity_excludes_root_from_denominator():
+    """Terms whose branch is None (the HPO root) must not appear in per_branch
+    totals and must not contribute to the overall mean."""
+    import numpy as np
+
+    from phentrieve.analysis.ontology_fidelity import branch_knn_purity
+
+    term_ids = ["HP:0000001", "HP:0010", "HP:0011"]
+    branch_map = {"HP:0000001": None, "HP:0010": "HP:0001", "HP:0011": "HP:0001"}
+    embeddings = np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 0.0]], dtype=np.float32)
+    result = branch_knn_purity(term_ids, embeddings, branch_map, k=1)
+    assert "HP:0001" in result["per_branch"]
+    assert None not in result["per_branch"]
+    # HP:0010's 1-NN is HP:0011 (same branch) -> purity 1.0.
+    # HP:0011's 1-NN is HP:0010 (same branch) -> purity 1.0.
+    # HP:0000001 excluded from denominator.
+    assert result["overall"] == pytest.approx(1.0)
+    assert result["n_evaluated"] == 2

--- a/tests/unit/analysis/test_ontology_fidelity.py
+++ b/tests/unit/analysis/test_ontology_fidelity.py
@@ -127,3 +127,53 @@ def test_graph_shortest_path_known_pairs(tiny_dag):
     # Multi-parent: HP:0011 has two parents; LCA with HP:0020 is HP:0002 (depth 1).
     # depths: HP:0011=2, HP:0020=2; distance = 2 + 2 - 2*1 = 2
     assert graph_shortest_path("HP:0011", "HP:0020", ancestors, depths) == 2
+
+
+def test_resnik_similarity_identical_terms_equals_own_ic(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import (
+        build_descendants_index,
+        information_content,
+        resnik_similarity,
+    )
+
+    ancestors, _ = tiny_dag
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants)
+
+    assert resnik_similarity("HP:0030", "HP:0030", ancestors, ic) == pytest.approx(
+        ic["HP:0030"]
+    )
+
+
+def test_resnik_similarity_siblings_is_ic_of_parent(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import (
+        build_descendants_index,
+        information_content,
+        resnik_similarity,
+    )
+
+    ancestors, _ = tiny_dag
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants)
+
+    # HP:0010 and HP:0011 share HP:0001 as a parent; HP:0001 is also their
+    # most-informative common ancestor in the tiny DAG (higher IC than root,
+    # and HP:0011 shares HP:0002 with HP:0010 only via root).
+    got = resnik_similarity("HP:0010", "HP:0011", ancestors, ic)
+    assert got == pytest.approx(ic["HP:0001"])
+
+
+def test_resnik_similarity_cross_branch_is_root_ic(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import (
+        build_descendants_index,
+        information_content,
+        resnik_similarity,
+    )
+
+    ancestors, _ = tiny_dag
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants)
+
+    # HP:0010 is only under HP:0001. HP:0020 is only under HP:0002. The only
+    # common ancestor is the root, so Resnik = IC(root) = 0.
+    assert resnik_similarity("HP:0010", "HP:0020", ancestors, ic) == pytest.approx(0.0)

--- a/tests/unit/analysis/test_ontology_fidelity.py
+++ b/tests/unit/analysis/test_ontology_fidelity.py
@@ -247,3 +247,59 @@ def test_sample_pairs_clamps_when_requested_exceeds_available():
     pairs = sample_pairs(5, 100, np.random.default_rng(0))
     assert pairs.shape[0] <= 10
     assert (pairs[:, 0] != pairs[:, 1]).all()
+
+
+def test_global_distance_correlation_returns_expected_keys(tiny_dag):
+    import numpy as np
+
+    from phentrieve.analysis.ontology_fidelity import (
+        build_descendants_index,
+        global_distance_correlation,
+        information_content,
+    )
+
+    ancestors, depths = tiny_dag
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants)
+
+    term_ids = list(depths.keys())
+    rng = np.random.default_rng(0)
+    embeddings = rng.standard_normal((len(term_ids), 16)).astype(np.float32)
+
+    result = global_distance_correlation(
+        term_ids, embeddings, ancestors, depths, ic, n_pairs=20, seed=0
+    )
+
+    assert set(result) >= {
+        "spearman_shortest_path",
+        "spearman_resnik",
+        "n_pairs",
+    }
+    assert isinstance(result["n_pairs"], int)
+    assert result["n_pairs"] <= 20
+
+
+def test_global_distance_correlation_seeded_is_deterministic(tiny_dag):
+    import numpy as np
+
+    from phentrieve.analysis.ontology_fidelity import (
+        build_descendants_index,
+        global_distance_correlation,
+        information_content,
+    )
+
+    ancestors, depths = tiny_dag
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants)
+
+    term_ids = list(depths.keys())
+    rng = np.random.default_rng(7)
+    embeddings = rng.standard_normal((len(term_ids), 16)).astype(np.float32)
+
+    a = global_distance_correlation(
+        term_ids, embeddings, ancestors, depths, ic, n_pairs=15, seed=11
+    )
+    b = global_distance_correlation(
+        term_ids, embeddings, ancestors, depths, ic, n_pairs=15, seed=11
+    )
+    assert a == b

--- a/tests/unit/analysis/test_ontology_fidelity.py
+++ b/tests/unit/analysis/test_ontology_fidelity.py
@@ -177,3 +177,38 @@ def test_resnik_similarity_cross_branch_is_root_ic(tiny_dag):
     # HP:0010 is only under HP:0001. HP:0020 is only under HP:0002. The only
     # common ancestor is the root, so Resnik = IC(root) = 0.
     assert resnik_similarity("HP:0010", "HP:0020", ancestors, ic) == pytest.approx(0.0)
+
+
+def test_top_level_branch_for_depth_0_term_is_none(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import top_level_branch
+
+    ancestors, depths = tiny_dag
+    assert top_level_branch("HP:0000001", ancestors, depths) == (None, frozenset())
+
+
+def test_top_level_branch_for_depth_1_term_is_self(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import top_level_branch
+
+    ancestors, depths = tiny_dag
+    branch, all_branches = top_level_branch("HP:0001", ancestors, depths)
+    assert branch == "HP:0001"
+    assert all_branches == frozenset({"HP:0001"})
+
+
+def test_top_level_branch_single_parent_chain(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import top_level_branch
+
+    ancestors, depths = tiny_dag
+    branch, all_branches = top_level_branch("HP:0030", ancestors, depths)
+    assert branch == "HP:0002"
+    assert all_branches == frozenset({"HP:0002"})
+
+
+def test_top_level_branch_multi_parent_picks_lex_smallest(tiny_dag):
+    from phentrieve.analysis.ontology_fidelity import top_level_branch
+
+    ancestors, depths = tiny_dag
+    # HP:0011 has depth-1 ancestors HP:0001 and HP:0002; "HP:0001" < "HP:0002".
+    branch, all_branches = top_level_branch("HP:0011", ancestors, depths)
+    assert branch == "HP:0001"
+    assert all_branches == frozenset({"HP:0001", "HP:0002"})

--- a/tests/unit/analysis/test_ontology_fidelity.py
+++ b/tests/unit/analysis/test_ontology_fidelity.py
@@ -303,3 +303,89 @@ def test_global_distance_correlation_seeded_is_deterministic(tiny_dag):
         term_ids, embeddings, ancestors, depths, ic, n_pairs=15, seed=11
     )
     assert a == b
+
+
+def test_per_term_fidelity_bounds_0_to_1(tiny_dag):
+    import numpy as np
+
+    from phentrieve.analysis.ontology_fidelity import (
+        build_descendants_index,
+        information_content,
+        per_term_fidelity,
+    )
+
+    ancestors, depths = tiny_dag
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants)
+
+    term_ids = list(depths.keys())
+    rng = np.random.default_rng(0)
+    embeddings = rng.standard_normal((len(term_ids), 8)).astype(np.float32)
+
+    rows = per_term_fidelity(term_ids, embeddings, ancestors, descendants, ic, k=3)
+    assert len(rows) == len(term_ids)
+    for row in rows:
+        assert 0.0 <= row["fidelity"] <= 1.0
+        assert len(row["nn_embedding"]) == 3
+        assert len(row["nn_dag"]) == 3
+        # Self must be excluded from both neighborhoods.
+        assert row["id"] not in row["nn_embedding"]
+        assert row["id"] not in row["nn_dag"]
+
+
+def test_per_term_fidelity_tiebreak_is_lexicographic():
+    """Equal Resnik scores across candidates break by ascending HPO ID."""
+    import numpy as np
+
+    from phentrieve.analysis.ontology_fidelity import (
+        build_descendants_index,
+        information_content,
+        per_term_fidelity,
+    )
+
+    # Flat DAG: root + three depth-1 children. All sibling pairs have
+    # Resnik = IC(root) = 0, so ties. HP:0010 < HP:0020 < HP:0030.
+    ancestors = {
+        "HP:0000001": set(),
+        "HP:0010": {"HP:0000001"},
+        "HP:0020": {"HP:0000001"},
+        "HP:0030": {"HP:0000001"},
+    }
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants)
+    term_ids = ["HP:0000001", "HP:0010", "HP:0020", "HP:0030"]
+    embeddings = np.eye(4, dtype=np.float32)
+
+    rows = per_term_fidelity(term_ids, embeddings, ancestors, descendants, ic, k=2)
+    by_id = {r["id"]: r for r in rows}
+    # For HP:0030 the two lex-smallest non-self terms are HP:0000001 and HP:0010.
+    assert by_id["HP:0030"]["nn_dag"] == ["HP:0000001", "HP:0010"]
+
+
+def test_per_term_fidelity_identical_embeddings_yields_uniform_baseline():
+    """If all embeddings are identical, embedding k-NN is just the lex-smallest
+    non-self terms, which matches the Resnik-tiebreak fallback for a flat DAG --
+    so fidelity should be 1.0 on every term."""
+    import numpy as np
+
+    from phentrieve.analysis.ontology_fidelity import (
+        build_descendants_index,
+        information_content,
+        per_term_fidelity,
+    )
+
+    ancestors = {
+        "HP:0000001": set(),
+        "HP:0010": {"HP:0000001"},
+        "HP:0020": {"HP:0000001"},
+        "HP:0030": {"HP:0000001"},
+        "HP:0040": {"HP:0000001"},
+    }
+    descendants = build_descendants_index(ancestors)
+    ic = information_content(descendants)
+    term_ids = sorted(ancestors.keys())
+    embeddings = np.ones((len(term_ids), 4), dtype=np.float32)
+
+    rows = per_term_fidelity(term_ids, embeddings, ancestors, descendants, ic, k=2)
+    for row in rows:
+        assert row["fidelity"] == pytest.approx(1.0)

--- a/uv.lock
+++ b/uv.lock
@@ -1616,6 +1616,34 @@ wheels = [
 ]
 
 [[package]]
+name = "llvmlite"
+version = "0.47.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/88/a8952b6d5c21e74cbf158515b779666f692846502623e9e3c39d8e8ba25f/llvmlite-0.47.0.tar.gz", hash = "sha256:62031ce968ec74e95092184d4b0e857e444f8fdff0b8f9213707699570c33ccc", size = 193614, upload-time = "2026-03-31T18:29:53.497Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/0b/b9d1911cfefa61399821dfb37f486d83e0f42630a8d12f7194270c417002/llvmlite-0.47.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:74090f0dcfd6f24ebbef3f21f11e38111c4d7e6919b54c4416e1e357c3446b07", size = 37232770, upload-time = "2026-03-31T18:28:26.765Z" },
+    { url = "https://files.pythonhosted.org/packages/46/27/5799b020e4cdfb25a7c951c06a96397c135efcdc21b78d853bbd9c814c7d/llvmlite-0.47.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ca14f02e29134e837982497959a8e2193d6035235de1cb41a9cb2bd6da4eedbb", size = 56275177, upload-time = "2026-03-31T18:28:31.01Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/51/48a53fedf01cb1f3f43ef200be17ebf83c8d9a04018d3783c1a226c342c2/llvmlite-0.47.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12a69d4bb05f402f30477e21eeabe81911e7c251cecb192bed82cd83c9db10d8", size = 55128631, upload-time = "2026-03-31T18:28:36.046Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/50/59227d06bdc96e23322713c381af4e77420949d8cd8a042c79e0043096cc/llvmlite-0.47.0-cp311-cp311-win_amd64.whl", hash = "sha256:c37d6eb7aaabfa83ab9c2ff5b5cdb95a5e6830403937b2c588b7490724e05327", size = 38138400, upload-time = "2026-03-31T18:28:40.076Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/48/4b7fe0e34c169fa2f12532916133e0b219d2823b540733651b34fdac509a/llvmlite-0.47.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:306a265f408c259067257a732c8e159284334018b4083a9e35f67d19792b164f", size = 37232769, upload-time = "2026-03-31T18:28:43.735Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/4b/e3f2cd17822cf772a4a51a0a8080b0032e6d37b2dbe8cfb724eac4e31c52/llvmlite-0.47.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5853bf26160857c0c2573415ff4efe01c4c651e59e2c55c2a088740acfee51cd", size = 56275178, upload-time = "2026-03-31T18:28:48.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/55/a3b4a543185305a9bdf3d9759d53646ed96e55e7dfd43f53e7a421b8fbae/llvmlite-0.47.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:003bcf7fa579e14db59c1a1e113f93ab8a06b56a4be31c7f08264d1d4072d077", size = 55128632, upload-time = "2026-03-31T18:28:52.901Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f5/d281ae0f79378a5a91f308ea9fdb9f9cc068fddd09629edc0725a5a8fde1/llvmlite-0.47.0-cp312-cp312-win_amd64.whl", hash = "sha256:f3079f25bdc24cd9d27c4b2b5e68f5f60c4fdb7e8ad5ee2b9b006007558f9df7", size = 38138692, upload-time = "2026-03-31T18:28:57.147Z" },
+    { url = "https://files.pythonhosted.org/packages/77/6f/4615353e016799f80fa52ccb270a843c413b22361fadda2589b2922fb9b0/llvmlite-0.47.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:a3c6a735d4e1041808434f9d440faa3d78d9b4af2ee64d05a66f351883b6ceec", size = 37232771, upload-time = "2026-03-31T18:29:01.324Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b8/69f5565f1a280d032525878a86511eebed0645818492feeb169dfb20ae8e/llvmlite-0.47.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2699a74321189e812d476a43d6d7f652f51811e7b5aad9d9bba842a1c7927acb", size = 56275178, upload-time = "2026-03-31T18:29:05.748Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/da/b32cafcb926fb0ce2aa25553bf32cb8764af31438f40e2481df08884c947/llvmlite-0.47.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c6951e2b29930227963e53ee152441f0e14be92e9d4231852102d986c761e40", size = 55128632, upload-time = "2026-03-31T18:29:11.235Z" },
+    { url = "https://files.pythonhosted.org/packages/46/9f/4898b44e4042c60fafcb1162dfb7014f6f15b1ec19bf29cfea6bf26df90d/llvmlite-0.47.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2e9adf8698d813a9a5efb2d4370caf344dbc1e145019851fee6a6f319ba760e", size = 38138695, upload-time = "2026-03-31T18:29:15.43Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/d4/33c8af00f0bf6f552d74f3a054f648af2c5bc6bece97972f3bfadce4f5ec/llvmlite-0.47.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:de966c626c35c9dff5ae7bf12db25637738d0df83fc370cf793bc94d43d92d14", size = 37232773, upload-time = "2026-03-31T18:29:19.453Z" },
+    { url = "https://files.pythonhosted.org/packages/64/1d/a760e993e0c0ba6db38d46b9f48f6c7dceb8ac838824997fb9e25f97bc04/llvmlite-0.47.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ddbccff2aeaff8670368340a158abefc032fe9b3ccf7d9c496639263d00151aa", size = 56275176, upload-time = "2026-03-31T18:29:24.149Z" },
+    { url = "https://files.pythonhosted.org/packages/84/3b/e679bc3b29127182a7f4aa2d2e9e5bea42adb93fb840484147d59c236299/llvmlite-0.47.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4a7b778a2e144fc64468fb9bf509ac1226c9813a00b4d7afea5d988c4e22fca", size = 55128631, upload-time = "2026-03-31T18:29:29.536Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f7/19e2a09c62809c9e63bbd14ce71fb92c6ff7b7b3045741bb00c781efc3c9/llvmlite-0.47.0-cp314-cp314-win_amd64.whl", hash = "sha256:694e3c2cdc472ed2bd8bd4555ca002eec4310961dd58ef791d508f57b5cc4c94", size = 39153826, upload-time = "2026-03-31T18:29:33.681Z" },
+    { url = "https://files.pythonhosted.org/packages/40/a1/581a8c707b5e80efdbbe1dd94527404d33fe50bceb71f39d5a7e11bd57b7/llvmlite-0.47.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:92ec8a169a20b473c1c54d4695e371bde36489fc1efa3688e11e99beba0abf9c", size = 37232772, upload-time = "2026-03-31T18:29:37.952Z" },
+    { url = "https://files.pythonhosted.org/packages/11/03/16090dd6f74ba2b8b922276047f15962fbeea0a75d5601607edb301ba945/llvmlite-0.47.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa1cbd800edd3b20bc141521f7fd45a6185a5b84109aa6855134e81397ffe72b", size = 56275178, upload-time = "2026-03-31T18:29:42.58Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/cb/0abf1dd4c5286a95ffe0c1d8c67aec06b515894a0dd2ac97f5e27b82ab0b/llvmlite-0.47.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6725179b89f03b17dabe236ff3422cb8291b4c1bf40af152826dfd34e350ae8", size = 55128632, upload-time = "2026-03-31T18:29:46.939Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/79/d3bbab197e86e0ff4f9c07122895b66a3e0d024247fcff7f12c473cb36d9/llvmlite-0.47.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6842cf6f707ec4be3d985a385ad03f72b2d724439e118fcbe99b2929964f0453", size = 39153839, upload-time = "2026-03-31T18:29:51.004Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2075,12 +2103,53 @@ wheels = [
 ]
 
 [[package]]
+name = "narwhals"
+version = "2.19.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/1a/bd3317c0bdbcd9ffb710ddf5250b32898f8f2c240be99494fe137feb77a7/narwhals-2.19.0.tar.gz", hash = "sha256:14fd7040b5ff211d415a82e4827b9d04c354e213e72a6d0730205ffd72e3b7ff", size = 623698, upload-time = "2026-04-06T15:50:58.786Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl", hash = "sha256:1f8dfa4a33a6dbff878c3e9be4c3b455dfcaf2a9322f1357db00e4e92e95b84b", size = 446991, upload-time = "2026-04-06T15:50:57.046Z" },
+]
+
+[[package]]
 name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
+name = "numba"
+version = "0.65.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llvmlite" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/61/7299643b9c18d669e04be7c5bcb64d985070d07553274817b45b049e7bfe/numba-0.65.0.tar.gz", hash = "sha256:edad0d9f6682e93624c00125a471ae4df186175d71fd604c983c377cdc03e68b", size = 2764131, upload-time = "2026-04-01T03:52:01.946Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/ce/d67c499703eb5479ce02420e8ccd65c5753d87d2e16d563f152d71405346/numba-0.65.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:28e547d0b18024f19cbaf9de02fc5c145790213d9be8a2c95b43f93ec162b9e4", size = 2680228, upload-time = "2026-04-01T03:51:25.401Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/a7/11e2b24251d57cf41fc9ad83f378d890d61a890e3f8eb6338b39833f67a4/numba-0.65.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:032b0b8e879512cd424d79eed6d772a1399c6387ded184c2cf3cc22c08d750a6", size = 3744674, upload-time = "2026-04-01T03:51:27.311Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/0b/7c63eb742859a6243f42288441f65ac9dac96ea59f409e43b713aafbe867/numba-0.65.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:af143d823624033a128b5950c0aaf9ffc2386dfe954eb757119cf0432335534c", size = 3450620, upload-time = "2026-04-01T03:51:29.092Z" },
+    { url = "https://files.pythonhosted.org/packages/53/ff/1371cbbe955be340a46093a10b61462437e0fadc7a63290473a0e584cb03/numba-0.65.0-cp311-cp311-win_amd64.whl", hash = "sha256:15d159578e59a39df246b83480f78d7794b0fca40153b5684d3849a99c48a0fb", size = 2747081, upload-time = "2026-04-01T03:51:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/2f/8bd31a1ea43c01ac215283d83aa5f8d5acbe7a36c85b82f1757bfe9ccb31/numba-0.65.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:b27ee4847e1bfb17e9604d100417ee7c1d10f15a6711c6213404b3da13a0b2aa", size = 2680705, upload-time = "2026-04-01T03:51:32.597Z" },
+    { url = "https://files.pythonhosted.org/packages/73/36/88406bd58600cc696417b8e5dd6a056478da808f3eaf48d18e2421e0c2d9/numba-0.65.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a52d92ffd297c10364bce60cd1fcb88f99284ab5df085f2c6bcd1cb33b529a6f", size = 3801411, upload-time = "2026-04-01T03:51:34.321Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/61/ce753a1d7646dd477e16d15e89473703faebb8995d2f71d7ad69a540b565/numba-0.65.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da8e371e328c06d0010c3d8b44b21858652831b85bcfba78cb22c042e22dbd8e", size = 3501622, upload-time = "2026-04-01T03:51:36.348Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/86/db87a5393f1b1fabef53ac3ba4e6b938bb27e40a04ad7cc512098fcae032/numba-0.65.0-cp312-cp312-win_amd64.whl", hash = "sha256:59bb9f2bb9f1238dfd8e927ba50645c18ae769fef4f3d58ea0ea22a2683b91f5", size = 2749979, upload-time = "2026-04-01T03:51:37.88Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/eee0f1ff456218db036bfc9023995ec1f85a9dc8f2422f1594f6a87829e0/numba-0.65.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:c6334094563a456a695c812e6846288376ca02327cf246cdcc83e1bb27862367", size = 2680679, upload-time = "2026-04-01T03:51:39.491Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8f/3d116e4b8e92f6abace431afa4b2b944f4d65bdee83af886f5c4b263df95/numba-0.65.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b8a9008411615c69d083d1dcf477f75a5aa727b30beb16e139799e2be945cdfd", size = 3809537, upload-time = "2026-04-01T03:51:41.42Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2c/6a3ca4128e253cb67affe06deb47688f51ce968f5111e2a06d010e6f1fa6/numba-0.65.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:af96c0cba53664efcb361528b8c75e011a6556c859c7e08424c2715201c6cf7a", size = 3508615, upload-time = "2026-04-01T03:51:43.444Z" },
+    { url = "https://files.pythonhosted.org/packages/96/0e/267f9a36fb282c104a971d7eecb685b411c47dce2a740fe69cf5fc2945d9/numba-0.65.0-cp313-cp313-win_amd64.whl", hash = "sha256:6254e73b9c929dc736a1fbd3d6f5680789709a5067cae1fa7198707385129c04", size = 2749938, upload-time = "2026-04-01T03:51:45.218Z" },
+    { url = "https://files.pythonhosted.org/packages/56/a4/90edb01e9176053578e343d7a7276bc28356741ee67059aed8ed2c1a4e59/numba-0.65.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:ee336b398a6fca51b1f626034de99f50cb1bd87d537a166275158a3cee744b82", size = 2680878, upload-time = "2026-04-01T03:51:46.91Z" },
+    { url = "https://files.pythonhosted.org/packages/24/8d/e12d6ff4b9119db3cbf7b2db1ce257576441bd3c76388c786dea74f20b02/numba-0.65.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:05c0a9fdf75d85f57dee47b719e8d6415707b80aae45d75f63f9dc1b935c29f7", size = 3778456, upload-time = "2026-04-01T03:51:48.552Z" },
+    { url = "https://files.pythonhosted.org/packages/17/89/abcd83e76f6a773276fe76244140671bcc5bf820f6e2ae1a15362ae4c8c9/numba-0.65.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:583680e0e8faf124d362df23b4b593f3221a8996341a63d1b664c122401bec2f", size = 3478464, upload-time = "2026-04-01T03:51:50.527Z" },
+    { url = "https://files.pythonhosted.org/packages/73/5b/fbce55ce3d933afbc7ade04df826853e4a846aaa47d58d2fbb669b8f2d08/numba-0.65.0-cp314-cp314-win_amd64.whl", hash = "sha256:add297d3e1c08dd884f44100152612fa41e66a51d15fdf91307f9dde31d06830", size = 2752012, upload-time = "2026-04-01T03:51:52.691Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/ab/af705f4257d9388fb2fd6d7416573e98b6ca9c786e8b58f02720978557bd/numba-0.65.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:194a243ba53a9157c8538cbb3166ec015d785a8c5d584d06cdd88bee902233c7", size = 2683961, upload-time = "2026-04-01T03:51:54.281Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e5/8267b0adb0c01b52b553df5062fbbb42c30ed5362d08b85cc913a36f838f/numba-0.65.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c7fa502960f7a2f3f5cb025bc7bff888a3551277b92431bfdc5ba2f11a375749", size = 3816373, upload-time = "2026-04-01T03:51:56.18Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/f5/b8397ca360971669a93706b9274592b6864e4367a37d498fbbcb62aa2d48/numba-0.65.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5046c63f783ca3eb6195f826a50797465e7c4ce811daa17c9bea47e310c9b964", size = 3532782, upload-time = "2026-04-01T03:51:58.387Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1e73fa16bf0393ebb74c5bb208d712152ffdfc84600a8e93a3180317856e/numba-0.65.0-cp314-cp314t-win_amd64.whl", hash = "sha256:46fd679ae4f68c7a5d5721efbd29ecee0b0f3013211591891d79b51bfdf73113", size = 2757611, upload-time = "2026-04-01T03:52:00.083Z" },
 ]
 
 [[package]]
@@ -2658,6 +2727,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+analysis = [
+    { name = "plotly" },
+    { name = "umap-learn" },
+]
 api = [
     { name = "fastapi" },
     { name = "python-dotenv" },
@@ -2706,6 +2779,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.0.0,<3.0.0" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "phenopackets", specifier = ">=2.0.2.post5,<3.0.0" },
+    { name = "plotly", marker = "extra == 'analysis'", specifier = ">=5.22.0" },
     { name = "protobuf", specifier = ">=4.25.3" },
     { name = "pydantic-settings", marker = "extra == 'mcp'", specifier = ">=2.0.0" },
     { name = "pysbd", specifier = ">=0.3.4" },
@@ -2722,11 +2796,12 @@ requires-dist = [
     { name = "torch", specifier = ">=2.11.0,<3.0.0" },
     { name = "tqdm", specifier = ">=4.66.1" },
     { name = "typer", specifier = ">=0.24.1,<0.25.0" },
+    { name = "umap-learn", marker = "extra == 'analysis'", specifier = ">=0.5.6" },
     { name = "urllib3", specifier = ">=2.5.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'api'", specifier = ">=0.32.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'mcp'", specifier = ">=0.32.0" },
 ]
-provides-extras = ["api", "mcp", "llm"]
+provides-extras = ["api", "mcp", "llm", "analysis"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2895,6 +2970,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "plotly"
+version = "6.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "narwhals" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/7f/0f100df1172aadf88a929a9dbb902656b0880ba4b960fe5224867159d8f4/plotly-6.7.0.tar.gz", hash = "sha256:45eea0ff27e2a23ccd62776f77eb43aa1ca03df4192b76036e380bb479b892c6", size = 6911286, upload-time = "2026-04-09T20:36:45.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/ad/cba91b3bcf04073e4d1655a5c1710ef3f457f56f7d1b79dcc3d72f4dd912/plotly-6.7.0-py3-none-any.whl", hash = "sha256:ac8aca1c25c663a59b5b9140a549264a5badde2e057d79b8c772ae2920e32ff0", size = 9898444, upload-time = "2026-04-09T20:36:39.812Z" },
 ]
 
 [[package]]
@@ -3315,6 +3403,22 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pynndescent"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "llvmlite" },
+    { name = "numba" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4a/fb/7f58c397fb31666756457ee2ac4c0289ef2daad57f4ae4be8dec12f80b03/pynndescent-0.6.0.tar.gz", hash = "sha256:7ffde0fb5b400741e055a9f7d377e3702e02250616834231f6c209e39aac24f5", size = 2992987, upload-time = "2026-01-08T21:29:58.943Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/e6/94145d714402fd5ade00b5661f2d0ab981219e07f7db9bfa16786cdb9c04/pynndescent-0.6.0-py3-none-any.whl", hash = "sha256:dc8c74844e4c7f5cbd1e0cd6909da86fdc789e6ff4997336e344779c3d5538ef", size = 73511, upload-time = "2026-01-08T21:29:57.306Z" },
 ]
 
 [[package]]
@@ -4577,6 +4681,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
+]
+
+[[package]]
+name = "umap-learn"
+version = "0.5.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "pynndescent" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/ee/af4171241117f85c74b5ca6448ea1033cc28d599c13651d67289bacd4083/umap_learn-0.5.12.tar.gz", hash = "sha256:6aff02ecac5f2aad9f3c65ee518d7ae93e1a985ae38721fdcffceee4232c33c7", size = 96672, upload-time = "2026-04-08T20:03:54.012Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/98/f63318ccbe75c810011fe9233884c5d348d94d90005de1b79e5f93bef9c0/umap_learn-0.5.12-py3-none-any.whl", hash = "sha256:f2a85d2a2adcb52b541bed9b27a23ca169b56bb1b23283abeebfb8dfb8a42fe5", size = 91849, upload-time = "2026-04-08T20:03:52.561Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds `scripts/analyze_embedding_ontology.py`, a standalone research script that quantifies how well BioLORD-2023-M's embedding geometry recapitulates the curated HPO DAG. Ships alongside a pure-function library (`phentrieve/analysis/ontology_fidelity.py`) and a ChromaDB→`.npy` cache (`phentrieve/analysis/embedding_cache.py`).

Extends issue #34 beyond the originally-proposed UMAP visualization: we produce both visualizations **and** four quantitative correlation metrics, surfacing per-term fidelity so specific ontology↔embedding disagreements can be inspected by HPO ID.

Closes #34.

## What ships

- `phentrieve/analysis/ontology_fidelity.py` — pure functions (build_descendants_index, information_content, graph_shortest_path, resnik_similarity, top_level_branch, sample_pairs, global_distance_correlation, per_term_fidelity, branch_knn_purity, depth_correlation). 93% unit-test coverage.
- `phentrieve/analysis/embedding_cache.py` — reads BioLORD embeddings from ChromaDB on first call, caches to `data/indexes/ontology_fidelity_cache/<collection>/{embeddings.npy, hpo_ids.json, meta.json}`. 87% coverage.
- `scripts/analyze_embedding_ontology.py` — orchestrator. ~6 min end-to-end on 19k terms, CPU only.
- `tests/unit/analysis/` — 28 unit tests covering determinism rules (k-NN self-exclusion, Resnik tie-break, multi-parent branch resolution, seed reproducibility, branch-purity root exclusion).
- `tests/integration/analysis/test_analyze_script_smoke.py` — slow-marked end-to-end smoke test with stubbed cache.
- `pyproject.toml` — new `[project.optional-dependencies]` extra `analysis = ["umap-learn>=0.5.6", "plotly>=5.22.0"]`. `matplotlib`, `scikit-learn`, `scipy` are already core.
- `scripts/README.md` — usage docs.

## Usage

```bash
uv sync --extra analysis
export PHENTRIEVE_INDEX_DIR=$PWD/data/indexes  # dev checkouts only
python scripts/analyze_embedding_ontology.py --model-name FremyCompany/BioLORD-2023-M --k 10 --n-pairs 50000
```

Outputs timestamped dir under `data/results/ontology_fidelity/<slug>_<YYYYMMDD-HHMMSS>/` with 8 artifacts: `summary.json`, `per_term_fidelity.csv`, `umap_coords.csv`, `umap_by_branch.png`, `umap_by_fidelity.png`, `distance_correlation.png`, `branch_fidelity.png`, `umap_interactive.html`.

## Findings — full run on BioLORD-2023-M × HPO v2025-11-24 (19,393 terms)

### Global distance correlation (50k sampled pairs)

| Metric | Spearman ρ |
|---|---:|
| cosine vs shortest-path | 0.12 |
| cosine vs Resnik similarity | 0.27 |

The **~2× gap** between the two is the diagnostic finding. BioLORD's cosine ordering agrees with Resnik (information-content-weighted) distance substantially more than with raw shortest-path. This suggests the embedding has implicitly absorbed an IC-like signal from biomedical text co-occurrence statistics — a known-but-fragile claim in the embedding-hierarchy literature, here supported at 19k-term scale.

### Per-term fidelity (k=10)

Mean 0.315, median 0.30.

| Fidelity bucket | Terms | % |
|---|---:|---:|
| 0.0 | 2,630 | 13.6% |
| 0.0–0.2 | 2,538 | 13.1% |
| 0.2–0.4 | 6,152 | 31.7% |
| 0.4–0.6 | 4,890 | 25.2% |
| 0.6–0.8 | 2,596 | 13.4% |
| 0.8–1.0 | 571 | 2.9% |
| 1.0 | 16 | 0.1% |

For ~14% of HPO, BioLORD's 10 nearest embedding-neighbors share **zero** terms with the top-10 Resnik-similar DAG neighbors. The `per_term_fidelity.csv` is sorted worst-first, making the 2,630 zero-fidelity terms directly inspectable.

### k-NN branch purity

| Branch | Purity |
|---|---:|
| Phenotypic abnormality (HP:0000118) | 0.99 |
| Mode of inheritance (HP:0000005) | 0.71 |
| Biospecimen phenotypic feature (HP:0020228) | 0.63 |
| Clinical modifier (HP:0012823) | 0.40 |
| Past medical history (HP:0032443) | 0.38 |
| Blood group (HP:0032223) | 0.37 |
| Frequency (HP:0040279) | 0.20 |
| **Overall** | **0.97** |

The 0.97 headline is dominated by Phenotypic abnormality (~96% of HPO) clustering at 0.99. **Modifier branches leak heavily** into the main phenotype cluster — BioLORD does not separate modifier vocabulary (Frequency, Clinical modifier) from phenotype vocabulary. For Phentrieve's primary use case (extracting phenotypes), this is the safe direction; for modifier-extraction workflows it is a named weakness.

### Depth correlation

Spearman ρ(depth, distance-from-centroid) = **−0.18**.

Counter to the naive prediction (deeper = more specific = more peripheral in embedding). Likely mechanism: specific phenotypes have dense descriptive definitions loaded with biomedical vocabulary and land in the center of the biomedical language manifold; shallow category labels have sparse abstract definitions and drift to the periphery. The embedding encodes **linguistic density, not ontological specificity**.

## Important: what fidelity does NOT measure

The per-term fidelity metric compares term↔term embedding neighborhoods to term↔term DAG neighborhoods. This is **not** a retrieval-quality signal for Phentrieve's primary pipeline:

- **Phentrieve retrieves**: clinical **text** → HPO **term**.
- **Fidelity measures**: HPO **term** → HPO **term** alignment with the DAG.

Empirically (observed during review of this analysis), Phentrieve retrieves zero-fidelity terms correctly even from paraphrased queries and German clinical text. That is because BioLORD's training explicitly aligns (concept, description) pairs, producing robust text-to-term projection regardless of whether the *term-to-term* geometry mirrors the DAG.

The fidelity metric remains useful for:
- Candidate-list diversity (what gets retrieved *around* a hit)
- Semantic term expansion (ontology-aware "see also")
- Cross-model comparison on an ontology-structure axis
- Quantifying the language↔curation gap scientifically

It is **not** a proxy for retrieval MRR.

## Why ship this anyway

- Provides a reproducible, scalable way to compare embedding models against the HPO DAG — future model swaps (PubMedBERT, ClinicalBERT, MedEmbed, bge-m3, fine-tuned variants) can be measured in ~6 minutes.
- The per-term fidelity CSV is a concrete artifact for ontology-aware research (term expansion, fine-tune targets, audit of cross-ontology alignment).
- The 2× Spearman ratio (Resnik over shortest-path) is a non-trivial scientific observation about biomedical sentence encoders that's worth having on record.

## Test plan

- [x] `make check` (ruff format + ruff check) — green
- [x] `make typecheck-fast` — green
- [x] `make test` (full suite with all extras) — 1169 passed, 3 skipped, 0 failed/errors
- [x] `uv run pytest tests/unit/analysis/ --cov=phentrieve.analysis` — 28 passed, ontology_fidelity.py 93% coverage, embedding_cache.py 87% coverage
- [x] `uv run pytest tests/integration/analysis/ -m slow` — 1 passed
- [x] Full-dataset run produces all 8 expected artifacts (`data/results/ontology_fidelity/biolord_2023_m_20260418-083357/`)
- [x] `--skip-interactive` correctly omits Plotly HTML output

## Not in scope (explicit)

- No `phentrieve` CLI subcommand — standalone script only.
- No multi-vector collection support.
- No model-vs-model comparison dashboard (but the script is cheap enough to run per-model manually).
- No Vue frontend integration.
- No ontology-aware fine-tuning — follow-up issue if desired.

## Links

- Design spec: `.planning/specs/2026-04-17-ontology-embedding-fidelity-design.md`
- Implementation plan: `.planning/active/2026-04-17-ontology-embedding-fidelity-implementation-plan.md`
- Issue: #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)