### PR TITLE
Improve phase 1 traceability and retrieval query handling

### DIFF
--- a/.github/workflows/build-data-bundles.yml
+++ b/.github/workflows/build-data-bundles.yml
@@ -119,7 +119,7 @@ jobs:
           "
 
       - name: Upload minimal bundle artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: bundle-minimal
           path: dist/bundles/*.tar.gz
@@ -203,7 +203,7 @@ jobs:
           echo "slug=$SLUG" >> $GITHUB_OUTPUT
 
       - name: Upload bundle artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: bundle-${{ steps.slug.outputs.slug }}
           path: dist/bundles/*.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -216,7 +216,7 @@ jobs:
           docker system prune -af
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build ${{ matrix.service }} image
         uses: docker/build-push-action@v6

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -46,7 +46,7 @@ jobs:
         run: mkdocs build --clean --strict
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
@@ -55,4 +55,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -77,7 +77,7 @@ jobs:
           tool-cache: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
@@ -189,7 +189,7 @@ jobs:
           tool-cache: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.3",
       "dependencies": {
         "@berntpopp/phenopackets-js": "^1.0.2",
-        "axios": "^1.15.0",
+        "axios": "^1.15.1",
         "google-protobuf": "^4.0.2",
         "pinia": "^3.0.4",
         "pinia-plugin-persistedstate": "^4.7.1",
@@ -29,7 +29,7 @@
         "@vitest/ui": "^4.0.9",
         "@vue/test-utils": "^2.4.6",
         "autoprefixer": "^10.4.23",
-        "eslint": "^10.2.0",
+        "eslint": "^10.2.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.5",
         "eslint-plugin-security": "^4.0.0",
@@ -1949,9 +1949,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -2623,18 +2623,18 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
-      "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
+      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.4",
-        "@eslint/config-helpers": "^0.5.4",
-        "@eslint/core": "^1.2.0",
-        "@eslint/plugin-kit": "^0.7.0",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@berntpopp/phenopackets-js": "^1.0.2",
-    "axios": "^1.15.0",
+    "axios": "^1.15.1",
     "google-protobuf": "^4.0.2",
     "pinia": "^3.0.4",
     "pinia-plugin-persistedstate": "^4.7.1",
@@ -45,7 +45,7 @@
     "@vitest/ui": "^4.0.9",
     "@vue/test-utils": "^2.4.6",
     "autoprefixer": "^10.4.23",
-    "eslint": "^10.2.0",
+    "eslint": "^10.2.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-vue": "^10.8.0",

--- a/phentrieve/benchmark/llm_benchmark.py
+++ b/phentrieve/benchmark/llm_benchmark.py
@@ -237,6 +237,7 @@ def run_llm_benchmark(
     input_cost_per_1m_tokens: float | None = None,
     output_cost_per_1m_tokens: float | None = None,
     cached_input_cost_per_1m_tokens: float | None = None,
+    capture_phase1_debug: bool = False,
     accounting_config: BenchmarkAccountingConfig | None = None,
     checkpoint_state: dict[str, Any] | None = None,
     progress_callback: Callable[[dict[str, Any]], None] | None = None,
@@ -350,6 +351,7 @@ def run_llm_benchmark(
             mode=llm_mode,
             language=language,
             seed=llm_seed,
+            capture_phase1_debug=capture_phase1_debug,
         )
         if len(completed_case_indexes) < len(documents) and hasattr(pipeline, "warmup"):
             logger.info("Benchmark warmup start: language=%s", language)

--- a/phentrieve/benchmark/llm_cli.py
+++ b/phentrieve/benchmark/llm_cli.py
@@ -69,6 +69,7 @@ def run_llm_benchmark_cli(
     input_cost_per_1m_tokens: float | None = None,
     output_cost_per_1m_tokens: float | None = None,
     cached_input_cost_per_1m_tokens: float | None = None,
+    capture_phase1_debug: bool = False,
     measure_energy: bool = False,
     per_document_energy: bool = False,
     electricity_cost_per_kwh: float | None = None,
@@ -136,6 +137,7 @@ def run_llm_benchmark_cli(
                 "llm_mode": llm_mode,
                 "llm_internal_mode": llm_internal_mode,
                 "language": language,
+                "capture_phase1_debug": capture_phase1_debug,
                 "prompt_templates_dir": prompt_templates_dir,
                 "requested_doc_ids": list(doc_ids) if doc_ids else None,
             },
@@ -172,6 +174,7 @@ def run_llm_benchmark_cli(
         input_cost_per_1m_tokens=input_cost_per_1m_tokens,
         output_cost_per_1m_tokens=output_cost_per_1m_tokens,
         cached_input_cost_per_1m_tokens=cached_input_cost_per_1m_tokens,
+        capture_phase1_debug=capture_phase1_debug,
         accounting_config=accounting_config,
         checkpoint_state=existing_checkpoint,
         progress_callback=_persist_checkpoint,
@@ -483,6 +486,13 @@ def benchmark_llm(
             help="Optional cached-input token price used for estimated benchmark cost reporting.",
         ),
     ] = None,
+    capture_phase1_debug: Annotated[
+        bool,
+        typer.Option(
+            "--capture-phase1-debug/--no-capture-phase1-debug",
+            help="Capture phase 1 source text, prompt, and raw structured outputs in per-case traces.",
+        ),
+    ] = False,
     measure_energy: Annotated[
         bool,
         typer.Option(
@@ -545,6 +555,7 @@ def benchmark_llm(
             input_cost_per_1m_tokens=input_cost_per_1m_tokens,
             output_cost_per_1m_tokens=output_cost_per_1m_tokens,
             cached_input_cost_per_1m_tokens=cached_input_cost_per_1m_tokens,
+            capture_phase1_debug=capture_phase1_debug,
             measure_energy=measure_energy,
             per_document_energy=per_document_energy,
             electricity_cost_per_kwh=electricity_cost_per_kwh,

--- a/phentrieve/llm/pipeline.py
+++ b/phentrieve/llm/pipeline.py
@@ -953,6 +953,7 @@ class TwoPhaseLLMPipeline:
         grounded_chunks: list[dict[str, Any]],
         extraction_prompt,
         chunk_index_text: str | None = None,
+        capture_debug: bool = False,
     ) -> tuple[list[dict[str, Any]], dict[str, int], int, dict[str, Any] | None]:
         user_prompt = _render_phase1_user_prompt(
             extraction_prompt=extraction_prompt,
@@ -995,9 +996,6 @@ class TwoPhaseLLMPipeline:
 
         usage = dict(getattr(self.provider, "last_usage", {}) or {})
         request_count = int(getattr(self.provider, "last_request_count", 0) or 0)
-        structured_payload = (
-            dict(getattr(self.provider, "last_structured_payload", {}) or {}) or None
-        )
         parsed: list[dict[str, Any]] = []
         for phenotype in response.phenotypes:
             parsed.append(
@@ -1010,18 +1008,25 @@ class TwoPhaseLLMPipeline:
                     "end_char": getattr(phenotype, "end_char", None),
                 }
             )
-        return (
-            parsed,
-            usage,
-            request_count,
-            {
+        debug_payload: dict[str, Any] | None = None
+        if capture_debug:
+            structured_payload = (
+                dict(getattr(self.provider, "last_structured_payload", {}) or {})
+                or None
+            )
+            debug_payload = {
                 "source_text": chunk_index_text
                 if chunk_index_text is not None
                 else text,
                 "user_prompt": user_prompt,
                 "structured_response": structured_payload,
                 "parsed_extracted": list(parsed),
-            },
+            }
+        return (
+            parsed,
+            usage,
+            request_count,
+            debug_payload,
         )
 
     def _extract_grouped_phase1_phenotypes(
@@ -1073,23 +1078,13 @@ class TwoPhaseLLMPipeline:
                 group = futures[future]
                 group_index = int(group.get("group_index", 0))
                 try:
-                    result = future.result()
-                    if len(result) == 4:
-                        (
-                            group_extracted,
-                            group_usage,
-                            group_request_count,
-                            group_elapsed,
-                        ) = result
-                        phase1_debug = None
-                    else:
-                        (
-                            group_extracted,
-                            group_usage,
-                            group_request_count,
-                            group_elapsed,
-                            phase1_debug,
-                        ) = result
+                    (
+                        group_extracted,
+                        group_usage,
+                        group_request_count,
+                        group_elapsed,
+                        phase1_debug,
+                    ) = future.result()
                     indexed_results.append(
                         (
                             group_index,
@@ -1259,6 +1254,7 @@ class TwoPhaseLLMPipeline:
                         grounded_chunks=group_grounded_chunks,
                     ),
                     extraction_prompt=extraction_prompt,
+                    capture_debug=capture_debug,
                 )
             )
         except LLMPipelinePhaseError as exc:
@@ -1297,6 +1293,7 @@ class TwoPhaseLLMPipeline:
                         text=text,
                         grounded_chunks=grounded_chunks,
                         extraction_prompt=extraction_prompt,
+                        capture_debug=capture_phase1_debug,
                     )
                 )
                 groups_trace: list[dict[str, Any]] = []
@@ -1620,23 +1617,26 @@ class TwoPhaseLLMPipeline:
         )
 
         shared_results: dict[tuple[str, str, tuple[str, ...]], dict[str, Any]] = {}
-        variant_index = 0
+        grouped_variant_results: dict[
+            tuple[str, str, tuple[str, ...]], list[tuple[str, dict[str, Any]]]
+        ] = {}
+        for index, dedupe_key in enumerate(expanded_query_keys):
+            query = expanded_queries[index]
+            batch_result = (
+                batched_variant_results[index]
+                if index < len(batched_variant_results)
+                else {}
+            )
+            grouped_variant_results.setdefault(dedupe_key, []).append(
+                (query, batch_result)
+            )
+
         for item in unique_actionable:
             phrase = str(item["phrase"])
             category = str(item["category"])
             dedupe_key = _downstream_dedupe_key(item, include_candidate_ids=False)
-            query_variants = prepare_retrieval_queries(phrase)
-            if not query_variants:
-                query_variants = [phrase]
-
             merged_candidates: dict[str, dict[str, Any]] = {}
-            for query in query_variants:
-                batch_result = (
-                    batched_variant_results[variant_index]
-                    if variant_index < len(batched_variant_results)
-                    else {}
-                )
-                variant_index += 1
+            for query, batch_result in grouped_variant_results.get(dedupe_key, []):
                 if "candidates" in batch_result:
                     candidates = [
                         {

--- a/phentrieve/llm/pipeline.py
+++ b/phentrieve/llm/pipeline.py
@@ -54,6 +54,9 @@ logger = logging.getLogger(__name__)
 
 WORD_PATTERN = re.compile(r"\w+")
 PHRASE_PARENTHESES_PATTERN = re.compile(r"\(.*?\)")
+UNIT_TOKEN_PATTERN = re.compile(
+    r"\b(?:mg/dl|mg/dL|mg/l|mg/L|g/dl|g/dL|g/l|g/L|mmol/l|mmol/L|μmol/l|μmol/L|umol/l|umol/L)\b"
+)
 
 CATEGORY_TO_ASSERTION = {
     "abnormal": PRESENT_ASSERTION,
@@ -225,6 +228,18 @@ def _clean_text(text: str) -> str:
     return " ".join(text.split())
 
 
+def prepare_retrieval_queries(phrase: str) -> list[str]:
+    original = " ".join(str(phrase or "").split()).strip()
+    if not original:
+        return []
+
+    variants = [original]
+    stripped_units = " ".join(UNIT_TOKEN_PATTERN.sub(" ", original).split())
+    if stripped_units and stripped_units != original:
+        variants.append(stripped_units)
+    return variants
+
+
 def _candidate_match_text(candidate: dict[str, Any]) -> str:
     matched_text = str(candidate.get("matched_text", "") or "").strip()
     if matched_text:
@@ -290,16 +305,95 @@ def _render_phase1_user_prompt(
     return extraction_prompt.render_user_prompt(text, chunk_index="[]")
 
 
+_CHUNK_INDEX_LINE_PATTERN = re.compile(r"^-?\s*chunk_id=(\d+):\s*(.*)$")
+
+
+def _parse_chunk_index_lines(chunk_index_text: str) -> list[tuple[list[int], str]]:
+    rows: list[tuple[list[int], str]] = []
+    for raw_line in chunk_index_text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        match = _CHUNK_INDEX_LINE_PATTERN.match(line)
+        if not match:
+            continue
+        rows.append(([int(match.group(1))], match.group(2).strip()))
+    return rows
+
+
+def _has_unmatched_open_paren(text: str) -> bool:
+    return text.count("(") > text.count(")")
+
+
+def _looks_like_uppercase_fragment(text: str) -> bool:
+    token = text.strip()
+    return bool(token) and token.replace("-", "").replace("/", "").isupper()
+
+
+def _should_merge_chunk_rows(current_text: str, next_text: str) -> bool:
+    current = current_text.strip()
+    following = next_text.strip()
+    if not current or not following:
+        return False
+    if re.search(r"[.!?]$", current):
+        return False
+    following_word_count = len(WORD_PATTERN.findall(following))
+    continuation_start = bool(re.match(r"^[0-9(\[\]±<>/%-]", following))
+    if _has_unmatched_open_paren(current) and (
+        continuation_start or following_word_count <= 3
+    ):
+        return True
+    if _looks_like_uppercase_fragment(current) and following_word_count <= 3:
+        return True
+    if current[-1].isdigit() and following_word_count <= 3:
+        return True
+    return continuation_start
+
+
+def _merge_chunk_index_rows(
+    rows: list[tuple[list[int], str]],
+) -> list[tuple[list[int], str]]:
+    if not rows:
+        return []
+    merged: list[tuple[list[int], str]] = []
+    current_ids, current_text = list(rows[0][0]), rows[0][1]
+    for next_ids, next_text in rows[1:]:
+        if _should_merge_chunk_rows(current_text, next_text):
+            current_ids.extend(next_ids)
+            current_text = f"{current_text.rstrip()} {next_text.lstrip()}".strip()
+            continue
+        merged.append((current_ids, current_text))
+        current_ids, current_text = list(next_ids), next_text
+    merged.append((current_ids, current_text))
+    return merged
+
+
+def _render_chunk_index_rows(rows: list[tuple[list[int], str]]) -> str:
+    rendered_lines: list[str] = []
+    for chunk_ids, text in rows:
+        chunk_key = "chunk_id" if len(chunk_ids) == 1 else "chunk_ids"
+        rendered_lines.append(
+            f"{chunk_key}={','.join(str(chunk_id) for chunk_id in chunk_ids)}: {text}"
+        )
+    return "\n".join(rendered_lines)
+
+
 def _render_group_chunk_index_text(
     *, group: dict[str, Any], grounded_chunks: list[dict[str, Any]]
 ) -> str:
     group_text = group.get("text")
-    if isinstance(group_text, str) and group_text.strip():
-        return group_text
-    return "\n".join(
-        f"chunk_id={chunk['chunk_id']}: {chunk.get('text', '')}"
-        for chunk in grounded_chunks
+    raw_chunk_index = (
+        group_text
+        if isinstance(group_text, str) and group_text.strip()
+        else "\n".join(
+            f"chunk_id={chunk['chunk_id']}: {chunk.get('text', '')}"
+            for chunk in grounded_chunks
+        )
     )
+    parsed_rows = _parse_chunk_index_lines(raw_chunk_index)
+    if not parsed_rows:
+        return raw_chunk_index
+    return _render_chunk_index_rows(_merge_chunk_index_rows(parsed_rows))
 
 
 def _normalize_grounded_text(text: Any) -> str:
@@ -336,6 +430,8 @@ def _compact_mapping_item(
             "term": candidate["term_name"],
             "retrieval_score": candidate.get("score"),
         }
+        if candidate.get("retrieval_query"):
+            compact_candidate["retrieval_query"] = candidate.get("retrieval_query")
         if candidate.get("matched_text"):
             compact_candidate["matched_text"] = candidate.get("matched_text")
         if candidate.get("matched_component"):
@@ -490,6 +586,7 @@ class TwoPhaseLLMPipeline:
                     grounded_chunks=current_grounded_chunks,
                     extraction_groups=current_extraction_groups,
                     extraction_prompt=extraction_prompt,
+                    capture_phase1_debug=config.capture_phase1_debug,
                 )
                 phase1_usage = _sum_usage_dicts(phase1_usage, attempt_phase1_usage)
                 phase1_request_count += attempt_phase1_request_count
@@ -708,6 +805,7 @@ class TwoPhaseLLMPipeline:
                                 "score": float(candidate.get("score", 0.0) or 0.0),
                                 "matched_text": candidate.get("matched_text"),
                                 "matched_component": candidate.get("matched_component"),
+                                "retrieval_query": candidate.get("retrieval_query"),
                             }
                             for candidate in item.get("candidates", [])
                         ],
@@ -855,7 +953,7 @@ class TwoPhaseLLMPipeline:
         grounded_chunks: list[dict[str, Any]],
         extraction_prompt,
         chunk_index_text: str | None = None,
-    ) -> tuple[list[dict[str, Any]], dict[str, int], int]:
+    ) -> tuple[list[dict[str, Any]], dict[str, int], int, dict[str, Any] | None]:
         user_prompt = _render_phase1_user_prompt(
             extraction_prompt=extraction_prompt,
             text=text,
@@ -897,6 +995,9 @@ class TwoPhaseLLMPipeline:
 
         usage = dict(getattr(self.provider, "last_usage", {}) or {})
         request_count = int(getattr(self.provider, "last_request_count", 0) or 0)
+        structured_payload = (
+            dict(getattr(self.provider, "last_structured_payload", {}) or {}) or None
+        )
         parsed: list[dict[str, Any]] = []
         for phenotype in response.phenotypes:
             parsed.append(
@@ -909,7 +1010,19 @@ class TwoPhaseLLMPipeline:
                     "end_char": getattr(phenotype, "end_char", None),
                 }
             )
-        return parsed, usage, request_count
+        return (
+            parsed,
+            usage,
+            request_count,
+            {
+                "source_text": chunk_index_text
+                if chunk_index_text is not None
+                else text,
+                "user_prompt": user_prompt,
+                "structured_response": structured_payload,
+                "parsed_extracted": list(parsed),
+            },
+        )
 
     def _extract_grouped_phase1_phenotypes(
         self,
@@ -918,6 +1031,7 @@ class TwoPhaseLLMPipeline:
         grounded_chunks: list[dict[str, Any]],
         extraction_groups: list[dict[str, Any]],
         extraction_prompt,
+        capture_debug: bool = False,
     ) -> tuple[list[dict[str, Any]], dict[str, int], int, float, list[dict[str, Any]]]:
         extracted: list[dict[str, Any]] = []
         prompt_tokens_total = 0
@@ -938,6 +1052,7 @@ class TwoPhaseLLMPipeline:
                 dict[str, int] | None,
                 int,
                 float,
+                dict[str, Any] | None,
                 LLMPipelinePhaseError | None,
             ]
         ] = []
@@ -950,6 +1065,7 @@ class TwoPhaseLLMPipeline:
                     text=text,
                     extraction_prompt=extraction_prompt,
                     chunk_lookup=chunk_lookup,
+                    capture_debug=capture_debug,
                 ): group
                 for group in indexed_groups
             }
@@ -957,12 +1073,23 @@ class TwoPhaseLLMPipeline:
                 group = futures[future]
                 group_index = int(group.get("group_index", 0))
                 try:
-                    (
-                        group_extracted,
-                        group_usage,
-                        group_request_count,
-                        group_elapsed,
-                    ) = future.result()
+                    result = future.result()
+                    if len(result) == 4:
+                        (
+                            group_extracted,
+                            group_usage,
+                            group_request_count,
+                            group_elapsed,
+                        ) = result
+                        phase1_debug = None
+                    else:
+                        (
+                            group_extracted,
+                            group_usage,
+                            group_request_count,
+                            group_elapsed,
+                            phase1_debug,
+                        ) = result
                     indexed_results.append(
                         (
                             group_index,
@@ -971,6 +1098,7 @@ class TwoPhaseLLMPipeline:
                             group_usage,
                             group_request_count,
                             group_elapsed,
+                            phase1_debug,
                             None,
                         )
                     )
@@ -983,6 +1111,7 @@ class TwoPhaseLLMPipeline:
                             exc.usage,
                             exc.request_count,
                             float(exc.elapsed_seconds or 0.0),
+                            None,
                             exc,
                         )
                     )
@@ -997,6 +1126,7 @@ class TwoPhaseLLMPipeline:
             group_usage_opt,
             group_request_count,
             group_elapsed,
+            phase1_debug,
             group_error,
         ) in indexed_results:
             group_chunk_ids = [int(chunk_id) for chunk_id in group.get("chunk_ids", [])]
@@ -1028,6 +1158,7 @@ class TwoPhaseLLMPipeline:
                         "extracted_count": 0,
                         "extracted": [],
                         "elapsed_seconds": group_elapsed,
+                        **({"debug": phase1_debug} if phase1_debug else {}),
                     }
                 )
                 continue
@@ -1065,6 +1196,7 @@ class TwoPhaseLLMPipeline:
                     "request_count": group_request_count,
                     "elapsed_seconds": group_elapsed,
                     "extracted": group_trace_extracted,
+                    **({"debug": phase1_debug} if phase1_debug else {}),
                 }
             )
 
@@ -1106,7 +1238,8 @@ class TwoPhaseLLMPipeline:
         text: str,
         extraction_prompt: PromptTemplate,
         chunk_lookup: dict[int, dict[str, Any]],
-    ) -> tuple[list[dict[str, Any]], dict[str, int], int, float]:
+        capture_debug: bool = False,
+    ) -> tuple[list[dict[str, Any]], dict[str, int], int, float, dict[str, Any] | None]:
         group_chunk_ids = [
             int(chunk_id) for chunk_id in extraction_group.get("chunk_ids", [])
         ]
@@ -1117,7 +1250,7 @@ class TwoPhaseLLMPipeline:
         ]
         group_started = time.perf_counter()
         try:
-            group_extracted, group_usage, group_request_count = (
+            group_extracted, group_usage, group_request_count, phase1_debug = (
                 self._extract_phase1_phenotypes(
                     text=text,
                     grounded_chunks=group_grounded_chunks,
@@ -1136,6 +1269,7 @@ class TwoPhaseLLMPipeline:
             group_usage,
             group_request_count,
             round(time.perf_counter() - group_started, 6),
+            phase1_debug if capture_debug else None,
         )
 
     def _resolve_initial_phase1_mode(
@@ -1153,23 +1287,69 @@ class TwoPhaseLLMPipeline:
         grounded_chunks: list[dict[str, Any]],
         extraction_groups: list[dict[str, Any]],
         extraction_prompt: PromptTemplate,
+        capture_phase1_debug: bool = False,
     ) -> tuple[list[dict[str, Any]], dict[str, int], int, float, list[dict[str, Any]]]:
         phase1_started = time.perf_counter()
         try:
             if mode == "ungrouped":
-                extracted, phase1_usage, phase1_request_count = (
+                extracted, phase1_usage, phase1_request_count, phase1_debug = (
                     self._extract_phase1_phenotypes(
                         text=text,
                         grounded_chunks=grounded_chunks,
                         extraction_prompt=extraction_prompt,
                     )
                 )
+                groups_trace: list[dict[str, Any]] = []
+                if capture_phase1_debug and phase1_debug is not None:
+                    groups_trace = [
+                        {
+                            "group_id": 1,
+                            "chunk_ids": [
+                                int(chunk["chunk_id"])
+                                for chunk in grounded_chunks
+                                if "chunk_id" in chunk
+                            ],
+                            "source_chunk_ids": [
+                                int(chunk["chunk_id"])
+                                for chunk in grounded_chunks
+                                if "chunk_id" in chunk
+                            ],
+                            "status": "completed",
+                            "extracted_count": len(extracted),
+                            "prompt_tokens": int(
+                                phase1_usage.get("prompt_tokens", 0) or 0
+                            ),
+                            "completion_tokens": int(
+                                phase1_usage.get("completion_tokens", 0) or 0
+                            ),
+                            "request_count": phase1_request_count,
+                            "elapsed_seconds": round(
+                                time.perf_counter() - phase1_started, 6
+                            ),
+                            "extracted": [
+                                {
+                                    "phrase": str(item["phrase"]),
+                                    "category": _normalize_category(
+                                        str(item["category"])
+                                    ),
+                                    "chunk_ids": list(item.get("chunk_ids", [])),
+                                    "evidence_text": item.get("evidence_text"),
+                                    "actionable": _normalize_category(
+                                        str(item["category"])
+                                    )
+                                    in ACTIONABLE_CATEGORIES,
+                                }
+                                for item in extracted
+                            ],
+                            "debug": phase1_debug,
+                        }
+                    ]
                 return (
                     extracted,
                     phase1_usage,
                     phase1_request_count,
                     round(time.perf_counter() - phase1_started, 6),
-                    [],
+                    groups_trace,
                 )
 
             active_extraction_groups = (
@@ -1190,6 +1370,7 @@ class TwoPhaseLLMPipeline:
                 grounded_chunks=grounded_chunks,
                 extraction_groups=active_extraction_groups,
                 extraction_prompt=extraction_prompt,
+                capture_debug=capture_phase1_debug,
             )
         except LLMPipelinePhaseError as exc:
             if exc.elapsed_seconds is None:
@@ -1421,36 +1602,88 @@ class TwoPhaseLLMPipeline:
             if len(actionable_groups[dedupe_key]) == 1:
                 unique_actionable.append(item)
 
-        phrases = [str(item["phrase"]) for item in unique_actionable]
-        raw_results = self.tool_executor.query_batch_hpo_terms(
-            phrases=phrases,
+        expanded_queries: list[str] = []
+        expanded_query_keys: list[tuple[str, str, tuple[str, ...]]] = []
+        for item in unique_actionable:
+            dedupe_key = _downstream_dedupe_key(item, include_candidate_ids=False)
+            query_variants = prepare_retrieval_queries(str(item["phrase"]))
+            if not query_variants:
+                query_variants = [str(item["phrase"])]
+            for query in query_variants:
+                expanded_queries.append(query)
+                expanded_query_keys.append(dedupe_key)
+
+        batched_variant_results = self.tool_executor.query_batch_hpo_terms(
+            phrases=expanded_queries,
             language=language,
             n_results=self.n_results_per_phrase,
         )
 
         shared_results: dict[tuple[str, str, tuple[str, ...]], dict[str, Any]] = {}
-        for index, item in enumerate(unique_actionable):
+        variant_index = 0
+        for item in unique_actionable:
             phrase = str(item["phrase"])
             category = str(item["category"])
             dedupe_key = _downstream_dedupe_key(item, include_candidate_ids=False)
-            if index < len(raw_results) and "candidates" in raw_results[index]:
-                raw_result = dict(raw_results[index])
-                raw_result.setdefault("phrase", phrase)
-                raw_result.setdefault("category", category)
-                shared_results[dedupe_key] = raw_result
-                continue
+            query_variants = prepare_retrieval_queries(phrase)
+            if not query_variants:
+                query_variants = [phrase]
 
-            batch_result = raw_results[index] if index < len(raw_results) else {}
-            metadatas = self._extract_first_result_list(batch_result, "metadatas")
-            similarities = self._extract_first_result_list(batch_result, "similarities")
+            merged_candidates: dict[str, dict[str, Any]] = {}
+            for query in query_variants:
+                batch_result = (
+                    batched_variant_results[variant_index]
+                    if variant_index < len(batched_variant_results)
+                    else {}
+                )
+                variant_index += 1
+                if "candidates" in batch_result:
+                    candidates = [
+                        {
+                            **dict(candidate),
+                            "retrieval_query": query,
+                        }
+                        for candidate in batch_result.get("candidates", [])
+                        if isinstance(candidate, dict)
+                    ]
+                else:
+                    metadatas = self._extract_first_result_list(
+                        batch_result, "metadatas"
+                    )
+                    similarities = self._extract_first_result_list(
+                        batch_result, "similarities"
+                    )
+                    candidates = [
+                        {
+                            **candidate,
+                            "retrieval_query": query,
+                        }
+                        for candidate in self._hybrid_select_candidates(
+                            phrase=query,
+                            metadatas=metadatas,
+                            similarities=similarities,
+                        )
+                    ]
+
+                for candidate in candidates:
+                    hpo_id = str(candidate.get("hpo_id", "")).strip()
+                    if not hpo_id:
+                        continue
+                    existing = merged_candidates.get(hpo_id)
+                    if existing is None or float(
+                        candidate.get("score", 0.0) or 0.0
+                    ) > float(existing.get("score", 0.0) or 0.0):
+                        merged_candidates[hpo_id] = candidate
+
+            merged = sorted(
+                merged_candidates.values(),
+                key=lambda candidate: float(candidate.get("score", 0.0) or 0.0),
+                reverse=True,
+            )[: self.n_results_per_phrase]
             shared_results[dedupe_key] = {
                 "phrase": phrase,
                 "category": category,
-                "candidates": self._hybrid_select_candidates(
-                    phrase=phrase,
-                    metadatas=metadatas,
-                    similarities=similarities,
-                ),
+                "candidates": merged,
             }
             logger.debug(
                 "Phase 2A candidate retrieval: phrase=%r candidates=%d",

--- a/phentrieve/llm/prompts/templates/two_phase/en.yaml
+++ b/phentrieve/llm/prompts/templates/two_phase/en.yaml
@@ -3,7 +3,7 @@ version: "v3.0.0"
 system_prompt: |
   You are an expert clinical geneticist. Extract source-faithful phenotype phrases
   from the full note. Each phenotype must reference one or more chunk_ids from the
-  provided chunk index. Preserve source wording.
+  provided chunk index. Preserve source wording while keeping the phrase clinically meaningful.
 
   Read the note sentence by sentence. For each sentence, identify every phenotype-relevant phrase and assign one category:
   - Abnormal: the phenotype is present in the patient
@@ -14,10 +14,14 @@ system_prompt: |
 
   Extraction rules:
   - Preserve the wording from the note whenever possible
+  - Keep clinically important modifiers such as anatomy, laterality, morphology, location, distribution, and severity when they change the meaning
   - Every extracted phenotype must include one or more chunk_ids from the provided chunk index
   - Split combined mentions into individual phenotype phrases
   - Do not duplicate the same concept multiple times
-  - Do not emit onset modifiers, inheritance patterns, ages, or measurements as phenotypes
+  - Prefer the smallest phrase that still preserves the clinically essential context
+  - If the note clearly describes an abnormality indirectly, you may extract a short normalized clinical phrase supported by the evidence_text
+  - Do not emit onset modifiers, inheritance patterns, ages, or measurements as standalone phenotypes
+  - Do not infer percentile- or threshold-based abnormalities from raw numbers alone unless the note itself indicates the abnormal interpretation
   - Be exhaustive for present abnormalities
 
   Output JSON only:
@@ -58,5 +62,31 @@ few_shot_examples:
           {"phrase": "retinitis pigmentosa", "category": "Abnormal", "chunk_ids": [1], "evidence_text": "retinitis pigmentosa"},
           {"phrase": "skeletal anomalies", "category": "Normal", "chunk_ids": [1], "evidence_text": "skeletal anomalies"},
           {"phrase": "hearing loss", "category": "Family_History", "chunk_ids": [1], "evidence_text": "hearing loss"}
+        ]
+      }
+  - input: |
+      Extract all phenotype phrases from the following clinical text.
+
+      ---
+      Blood tests showed lactate dehydrogenase was markedly elevated, and urine output remained low.
+      ---
+    output: |
+      {
+        "phenotypes": [
+          {"phrase": "elevated lactate dehydrogenase", "category": "Abnormal", "chunk_ids": [1], "evidence_text": "lactate dehydrogenase was markedly elevated"},
+          {"phrase": "low urine output", "category": "Abnormal", "chunk_ids": [1], "evidence_text": "urine output remained low"}
+        ]
+      }
+  - input: |
+      Extract all phenotype phrases from the following clinical text.
+
+      ---
+      Chest imaging revealed enlarged mediastinal lymph nodes and bilateral pleural effusions.
+      ---
+    output: |
+      {
+        "phenotypes": [
+          {"phrase": "enlarged mediastinal lymph nodes", "category": "Abnormal", "chunk_ids": [1], "evidence_text": "enlarged mediastinal lymph nodes"},
+          {"phrase": "bilateral pleural effusions", "category": "Abnormal", "chunk_ids": [1], "evidence_text": "bilateral pleural effusions"}
         ]
       }

--- a/phentrieve/llm/provider.py
+++ b/phentrieve/llm/provider.py
@@ -55,6 +55,7 @@ class LLMProvider(ABC):
         self.last_usage = {}
         self.last_finish_reason = None
         self.last_request_count = 0
+        self.last_structured_payload = None
         self.structured_retries = DEFAULT_PROVIDER_STRUCTURED_RETRIES
         self.structured_retry_token_multiplier = (
             DEFAULT_PROVIDER_STRUCTURED_RETRY_TOKEN_MULTIPLIER
@@ -83,6 +84,17 @@ class LLMProvider(ABC):
     @last_request_count.setter
     def last_request_count(self, value: int) -> None:
         self._thread_state.last_request_count = int(value or 0)
+
+    @property
+    def last_structured_payload(self) -> dict[str, Any] | None:
+        payload = getattr(self._thread_state, "last_structured_payload", None)
+        return dict(payload) if isinstance(payload, dict) else None
+
+    @last_structured_payload.setter
+    def last_structured_payload(self, value: dict[str, Any] | None) -> None:
+        self._thread_state.last_structured_payload = (
+            dict(value) if isinstance(value, dict) else None
+        )
 
     @abstractmethod
     def complete(self, messages: list[dict[str, Any]]) -> LLMResponse:
@@ -122,6 +134,7 @@ class LLMProvider(ABC):
         self.last_usage = {}
         self.last_finish_reason = None
         self.last_request_count = 0
+        self.last_structured_payload = None
 
         for attempt in range(1, structured_retries + 2):
             response, request_count = invoke(current_output_tokens)
@@ -131,7 +144,9 @@ class LLMProvider(ABC):
                 aggregate_usage=aggregate_usage,
             )
             try:
-                return parse(response)
+                parsed = parse(response)
+                self.last_structured_payload = parsed.model_dump(mode="json")
+                return parsed
             except Exception as exc:
                 last_exception = exc
                 if (

--- a/phentrieve/llm/types.py
+++ b/phentrieve/llm/types.py
@@ -144,6 +144,7 @@ class LLMPipelineConfig(BaseModel):
     mode: str = DEFAULT_LLM_MODE
     language: str | None = DEFAULT_LLM_LANGUAGE
     seed: int | None = None
+    capture_phase1_debug: bool = False
 
 
 class LLMExtractionResult(BaseModel):

--- a/tests/unit/llm/test_pipeline.py
+++ b/tests/unit/llm/test_pipeline.py
@@ -1624,12 +1624,14 @@ def test_pipeline_retries_only_failed_grouped_large_windows_in_grouped_small(
                 {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12},
                 1,
                 0.1,
+                None,
             )
         return (
             [],
             {"prompt_tokens": 6, "completion_tokens": 1, "total_tokens": 7},
             1,
             0.1,
+            None,
         )
 
     run_group = mocker.patch.object(
@@ -1852,6 +1854,7 @@ def test_two_phase_pipeline_grouped_phase1_keeps_stable_merge_order(mocker) -> N
             {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12},
             1,
             0.1,
+            None,
         )
 
     run_group = mocker.patch.object(
@@ -1907,6 +1910,7 @@ def test_two_phase_pipeline_grouped_phase1_tracks_partial_failures_under_concurr
             {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12},
             1,
             0.1,
+            None,
         )
 
     run_group = mocker.patch.object(

--- a/tests/unit/llm/test_pipeline.py
+++ b/tests/unit/llm/test_pipeline.py
@@ -86,7 +86,9 @@ class FakeProvider(LLMProvider):
         }
         self.last_request_count = response.get("request_count", 1)
         payload = response.get("parsed", response)
-        return response_model.model_validate(payload)
+        parsed = response_model.model_validate(payload)
+        self.last_structured_payload = parsed.model_dump(mode="json")
+        return parsed
 
     def count_tokens(self, *, system_prompt: str, user_prompt: str) -> dict[str, int]:
         self.count_token_calls.append(
@@ -359,6 +361,55 @@ def test_phase1_uses_legacy_schema_without_grounding() -> None:
     assert result[0][0]["evidence_text"] is None
 
 
+def test_ungrouped_phase1_debug_capture_persists_in_trace() -> None:
+    provider = FakeProvider(
+        responses=[
+            {
+                "parsed": {
+                    "phenotypes": [
+                        {
+                            "phrase": "recurrent seizures",
+                            "category": "Abnormal",
+                            "chunk_ids": [1],
+                            "evidence_text": "recurrent seizures",
+                        }
+                    ]
+                }
+            }
+        ]
+    )
+    pipeline = TwoPhaseLLMPipeline(
+        provider=provider,
+        tool_executor=FakeToolExecutor([]),
+    )
+
+    result = pipeline.run(
+        text="Patient had recurrent seizures.",
+        grounded_chunks=[{"chunk_id": 1, "text": "Patient had recurrent seizures."}],
+        config=LLMPipelineConfig(
+            model="gemini-2.5-flash",
+            mode="two_phase",
+            capture_phase1_debug=True,
+        ),
+    )
+
+    groups = result.meta.trace["phase1"]["groups"]
+    assert len(groups) == 1
+    assert groups[0]["debug"]["source_text"] == "Patient had recurrent seizures."
+    assert groups[0]["debug"]["structured_response"] == {
+        "phenotypes": [
+            {
+                "phrase": "recurrent seizures",
+                "category": "Abnormal",
+                "chunk_ids": [1],
+                "evidence_text": "recurrent seizures",
+                "start_char": None,
+                "end_char": None,
+            }
+        ]
+    }
+
+
 def test_phase1_runs_once_per_extraction_group() -> None:
     provider = FakeProvider(
         responses=[
@@ -485,6 +536,192 @@ def test_grouped_phase1_uses_budgeted_group_payload_text() -> None:
     )
     assert "Canonical chunk one." not in provider.structured_calls[0]["user_prompt"]
     assert "Canonical chunk two." not in provider.structured_calls[0]["user_prompt"]
+
+
+def test_grouped_phase1_merges_continuation_chunks_in_payload_text() -> None:
+    provider = FakeProvider(
+        responses=[
+            {
+                "parsed": {
+                    "phenotypes": [
+                        grounded_phenotype(
+                            "elevated inflammatory marker",
+                            "Abnormal",
+                            chunk_ids=[1, 2],
+                        ),
+                        grounded_phenotype(
+                            "ESR 50",
+                            "Abnormal",
+                            chunk_ids=[3, 4],
+                        ),
+                    ]
+                }
+            }
+        ]
+    )
+    pipeline = TwoPhaseLLMPipeline(
+        provider=provider,
+        tool_executor=FakeToolExecutor([]),
+    )
+
+    pipeline.run(
+        text="Laboratory findings were abnormal.",
+        grounded_chunks=[
+            {"chunk_id": 1, "text": "Marker was 152 mg/l (normal"},
+            {"chunk_id": 2, "text": "0-10)"},
+            {"chunk_id": 3, "text": "ESR"},
+            {"chunk_id": 4, "text": "50 mm/h"},
+        ],
+        extraction_groups=[
+            {
+                "group_id": 1,
+                "chunk_ids": [1, 2, 3, 4],
+                "text": (
+                    "chunk_id=1: Marker was 152 mg/l (normal\n"
+                    "chunk_id=2: 0-10)\n"
+                    "chunk_id=3: ESR\n"
+                    "chunk_id=4: 50 mm/h"
+                ),
+                "estimated_prompt_tokens": 12,
+            }
+        ],
+        config=LLMPipelineConfig(model="gemini-2.5-flash", mode="two_phase"),
+    )
+
+    assert len(provider.structured_calls) == 1
+    assert (
+        "chunk_ids=1,2: Marker was 152 mg/l (normal 0-10)"
+        in provider.structured_calls[0]["user_prompt"]
+    )
+    assert "chunk_ids=3,4: ESR 50 mm/h" in provider.structured_calls[0]["user_prompt"]
+
+
+def test_grouped_phase1_does_not_runaway_merge_after_open_paren() -> None:
+    provider = FakeProvider(
+        responses=[
+            {
+                "parsed": {
+                    "phenotypes": [
+                        grounded_phenotype("platelet count", "Abnormal", chunk_ids=[1])
+                    ]
+                }
+            }
+        ]
+    )
+    pipeline = TwoPhaseLLMPipeline(
+        provider=provider,
+        tool_executor=FakeToolExecutor([]),
+    )
+
+    pipeline.run(
+        text="Laboratory findings were abnormal.",
+        grounded_chunks=[
+            {"chunk_id": 1, "text": "platelet count of 842 (table 1"},
+            {
+                "chunk_id": 2,
+                "text": "peripheral blood smear was suggestive of abnormal cells",
+            },
+            {"chunk_id": 3, "text": "ESR"},
+            {"chunk_id": 4, "text": "50 mm/h"},
+        ],
+        extraction_groups=[
+            {
+                "group_id": 1,
+                "chunk_ids": [1, 2, 3, 4],
+                "text": (
+                    "chunk_id=1: platelet count of 842 (table 1\n"
+                    "chunk_id=2: peripheral blood smear was suggestive of abnormal cells\n"
+                    "chunk_id=3: ESR\n"
+                    "chunk_id=4: 50 mm/h"
+                ),
+                "estimated_prompt_tokens": 12,
+            }
+        ],
+        config=LLMPipelineConfig(model="gemini-2.5-flash", mode="two_phase"),
+    )
+
+    prompt = provider.structured_calls[0]["user_prompt"]
+    assert "chunk_id=1: platelet count of 842 (table 1" in prompt
+    assert (
+        "chunk_id=2: peripheral blood smear was suggestive of abnormal cells" in prompt
+    )
+    assert "chunk_ids=1,2:" not in prompt
+    assert "chunk_ids=3,4: ESR 50 mm/h" in prompt
+
+
+def test_grouped_phase1_debug_capture_is_additive_and_opt_in() -> None:
+    provider = FakeProvider(
+        responses=[
+            {
+                "parsed": {
+                    "phenotypes": [
+                        grounded_phenotype(
+                            "recurrent seizures",
+                            "Abnormal",
+                            chunk_ids=[1, 2],
+                        )
+                    ]
+                }
+            }
+        ]
+    )
+    pipeline = TwoPhaseLLMPipeline(
+        provider=provider,
+        tool_executor=FakeToolExecutor([]),
+    )
+
+    result = pipeline.run(
+        text="Patient had recurrent seizures.",
+        grounded_chunks=[
+            {"chunk_id": 1, "text": "Chunk one."},
+            {"chunk_id": 2, "text": "Chunk two."},
+        ],
+        extraction_groups=[
+            {
+                "group_id": 1,
+                "chunk_ids": [1, 2],
+                "text": "chunk_id=1: Budgeted chunk one.\nchunk_id=2: Budgeted chunk two.",
+                "estimated_prompt_tokens": 12,
+            }
+        ],
+        config=LLMPipelineConfig(
+            model="gemini-2.5-flash",
+            mode="two_phase",
+            capture_phase1_debug=True,
+        ),
+    )
+
+    group_trace = result.meta.trace["phase1"]["groups"][0]
+
+    assert group_trace["group_id"] == 1
+    assert group_trace["status"] == "completed"
+    assert group_trace["extracted"][0]["phrase"] == "recurrent seizures"
+    assert group_trace["debug"]["source_text"] == (
+        "chunk_id=1: Budgeted chunk one.\nchunk_id=2: Budgeted chunk two."
+    )
+    assert "Budgeted chunk one." in group_trace["debug"]["user_prompt"]
+    assert group_trace["debug"]["structured_response"] == {
+        "phenotypes": [
+            {
+                "phrase": "recurrent seizures",
+                "category": "Abnormal",
+                "chunk_ids": [1, 2],
+                "evidence_text": "recurrent seizures",
+                "start_char": None,
+                "end_char": None,
+            }
+        ]
+    }
+    assert group_trace["debug"]["parsed_extracted"] == [
+        {
+            "phrase": "recurrent seizures",
+            "category": "abnormal",
+            "chunk_ids": [1, 2],
+            "evidence_text": "recurrent seizures",
+            "start_char": None,
+            "end_char": None,
+        }
+    ]
 
 
 def test_grouped_phase1_aggregates_mentions_before_retrieval() -> None:
@@ -2832,11 +3069,13 @@ def test_two_phase_pipeline_batch_mapping_disambiguates_duplicate_phrase_text() 
                     "id": "HP:0001251",
                     "term": "Ataxia",
                     "retrieval_score": 0.95,
+                    "retrieval_query": "motor issues",
                 },
                 {
                     "id": "HP:0002066",
                     "term": "Gait ataxia",
                     "retrieval_score": 0.88,
+                    "retrieval_query": "motor issues",
                 },
             ],
         },
@@ -2851,11 +3090,13 @@ def test_two_phase_pipeline_batch_mapping_disambiguates_duplicate_phrase_text() 
                     "id": "HP:0033894",
                     "term": "Episodic ataxia",
                     "retrieval_score": 0.93,
+                    "retrieval_query": "motor issues",
                 },
                 {
                     "id": "HP:0001251",
                     "term": "Ataxia",
                     "retrieval_score": 0.89,
+                    "retrieval_query": "motor issues",
                 },
             ],
         },
@@ -3478,6 +3719,7 @@ def test_two_phase_pipeline_uses_single_mapping_prompt_for_final_one_item_slice(
                         "id": "HP:0002355",
                         "term": "Difficulty walking",
                         "retrieval_score": 0.81,
+                        "retrieval_query": "frequent falls",
                     }
                 ],
             },
@@ -3495,6 +3737,7 @@ def test_two_phase_pipeline_uses_single_mapping_prompt_for_final_one_item_slice(
                         "id": "HP:0002360",
                         "term": "Sleep abnormality",
                         "retrieval_score": 0.85,
+                        "retrieval_query": "sleep disturbances",
                     }
                 ],
             },
@@ -3510,7 +3753,14 @@ def test_two_phase_pipeline_uses_single_mapping_prompt_for_final_one_item_slice(
         "neighbor_chunk_texts": ["Sleep disturbances were reported."],
         "phrase": "balance issues",
         "category": "abnormal",
-        "candidates": [{"id": "HP:0001251", "term": "Ataxia", "retrieval_score": 0.95}],
+        "candidates": [
+            {
+                "id": "HP:0001251",
+                "term": "Ataxia",
+                "retrieval_score": 0.95,
+                "retrieval_query": "balance issues",
+            }
+        ],
     }
     assert result.meta.phase_request_counts["phase2b_llm_requests"] == 2
     assert [term.term_id for term in result.terms] == [

--- a/tests/unit/llm/test_two_phase.py
+++ b/tests/unit/llm/test_two_phase.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from phentrieve.llm.pipeline import TwoPhaseLLMPipeline
-from phentrieve.llm.prompts.loader import get_mapping_prompt
+from phentrieve.llm.pipeline import TwoPhaseLLMPipeline, prepare_retrieval_queries
+from phentrieve.llm.prompts.loader import get_mapping_prompt, get_prompt
 from phentrieve.llm.provider import LLMProvider
+from phentrieve.llm.types import AnnotationMode
 
 
 class FakeProvider(LLMProvider):
@@ -34,7 +35,9 @@ class FakeProvider(LLMProvider):
             "completion_tokens": 5,
             "total_tokens": 15,
         }
-        return response_model.model_validate(response.get("parsed", response))
+        parsed = response_model.model_validate(response.get("parsed", response))
+        self.last_structured_payload = parsed.model_dump(mode="json")
+        return parsed
 
 
 def test_try_local_match_requires_multiword_substring_boundary():
@@ -146,3 +149,40 @@ def test_resolve_with_mapping_prompt_normalizes_phrase_before_llm_call():
         '"matched_text": "Difficulty walking"'
         in provider.structured_calls[0]["user_prompt"]
     )
+
+
+def test_prepare_retrieval_queries_strips_unit_suffixes_without_losing_core_phrase():
+    queries = prepare_retrieval_queries("serum creatinine 11.2 mg/dL")
+
+    assert "serum creatinine 11.2 mg/dL" in queries
+    assert "serum creatinine 11.2" in queries
+    assert queries[-1] == "serum creatinine 11.2"
+
+    marker_queries = prepare_retrieval_queries("inflammatory marker 152 mg/l")
+    assert "inflammatory marker 152 mg/l" in marker_queries
+    assert "inflammatory marker 152" in marker_queries
+
+
+def test_prepare_retrieval_queries_keeps_location_and_morphology_modifiers():
+    queries = prepare_retrieval_queries("swelling in the right lower leg")
+
+    assert queries[0] == "swelling in the right lower leg"
+    assert any("right lower leg" in query for query in queries)
+    assert "swelling" not in queries[1:]
+
+
+def test_prepare_retrieval_queries_does_not_invent_hand_written_paraphrases():
+    queries = prepare_retrieval_queries("tongue biting")
+
+    assert "self biting" not in queries
+    assert "self-biting" not in queries
+
+
+def test_phase1_prompt_mentions_normalized_clinical_phrase_for_lab_or_event_evidence():
+    prompt = get_prompt(AnnotationMode.TWO_PHASE, "en")
+    system = prompt.render_system_prompt()
+
+    assert "normalized" in system.lower()
+    assert "measurement" in system.lower()
+    assert "indirectly" in system.lower()
+    assert "context" in system.lower()


### PR DESCRIPTION
## Summary
- add optional benchmark trace capture for phase 1 source text, prompt, and structured outputs
- improve grouped phase 1 chunk rendering for fragmented continuation lines
- expand retrieval query normalization for unit-bearing phrases and preserve the originating retrieval query in traces
- refine phase 1 prompt guidance and tests around clinically meaningful phrase extraction

## Validation
- `make check`
- `make typecheck-fast`
- `make test`

## Notes
- this PR intentionally excludes earlier experimental judge scripts and planning artifacts
- local-only exploratory benchmark/debug work was not included