### PR TITLE
[codex] add ontology-aware benchmark metrics option

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -66,13 +66,13 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --dev
 
+      - name: Export locked Python dependencies
+        run: |
+          uv export --format requirements-txt --all-extras --dev --no-emit-project --no-hashes > audit-requirements.txt
+
       - name: Run pip-audit
-        uses: pypa/gh-action-pip-audit@v1.1.0
-        with:
-          vulnerability-service: pypi
-          # Uncomment to ignore specific vulns if needed:
-          # ignore-vulns: |
-          #   GHSA-xxxx-xxxx-xxxx
+        run: |
+          uv run pip-audit --requirement audit-requirements.txt --vulnerability-service pypi
 
   # Python SAST with Bandit (run directly with uv for proper pyproject.toml support)
   bandit:

--- a/api/routers/system.py
+++ b/api/routers/system.py
@@ -26,7 +26,7 @@ async def get_version() -> dict:
     Returns:
         {
             "cli": {
-                "version": "0.17.3",
+                "version": "0.18.0",
                 "name": "phentrieve",
                 "type": "Python CLI/Library"
             },

--- a/phentrieve/benchmark/extraction_benchmark.py
+++ b/phentrieve/benchmark/extraction_benchmark.py
@@ -34,12 +34,14 @@ from phentrieve.evaluation.extraction_metrics import (
     CorpusExtractionMetrics,
     CorpusMetrics,
     ExtractionResult,
+    OntologyAwareCorpusMetrics,
     serialize_ontology_metrics,
 )
 
 if TYPE_CHECKING:
     from sentence_transformers import SentenceTransformer
 
+    from phentrieve.evaluation.ontology_credit import OntologyCreditConfig
     from phentrieve.retrieval.dense_retriever import DenseRetriever
     from phentrieve.text_processing.pipeline import TextProcessingPipeline
 
@@ -68,41 +70,22 @@ class ExtractionConfig:
     ontology_similarity_formula: str = "hybrid"
 
 
-def _build_ontology_credit_config(config: ExtractionConfig) -> Any:
+def _build_ontology_credit_config(config: ExtractionConfig) -> OntologyCreditConfig:
     """Build ontology-aware metric config from extraction benchmark settings."""
-    from phentrieve.evaluation.metrics import SimilarityFormula
-    from phentrieve.evaluation.ontology_credit import OntologyCreditConfig
+    from phentrieve.evaluation.ontology_credit import build_ontology_credit_config
 
-    if not 0.0 <= config.ontology_semantic_floor <= 1.0:
-        raise ValueError(
-            "ontology_semantic_floor must be between 0.0 and 1.0 inclusive; "
-            f"got {config.ontology_semantic_floor!r}."
-        )
-
-    formula = config.ontology_similarity_formula.strip().lower()
-    formula_map = {
-        "hybrid": SimilarityFormula.HYBRID,
-        "simple_resnik_like": SimilarityFormula.SIMPLE_RESNIK_LIKE,
-    }
-    if formula not in formula_map:
-        raise ValueError(
-            "Invalid ontology similarity formula: "
-            f"{config.ontology_similarity_formula!r}. "
-            "Expected 'hybrid' or 'simple_resnik_like'."
-        )
-
-    return OntologyCreditConfig(
+    return build_ontology_credit_config(
         semantic_floor=config.ontology_semantic_floor,
-        similarity_formula=formula_map[formula],
+        similarity_formula=config.ontology_similarity_formula,
     )
 
 
-def _attach_ontology_metrics(
-    metrics: CorpusMetrics,
-    ontology_metrics: Any,
-) -> None:
-    metrics_with_extension: Any = metrics
-    metrics_with_extension.ontology_metrics = ontology_metrics
+def validate_hpo_graph_available() -> None:
+    from phentrieve.evaluation.ontology_credit import (
+        validate_hpo_graph_available as validate,
+    )
+
+    validate()
 
 
 class HPOExtractor:
@@ -262,6 +245,7 @@ class ExtractionBenchmark:
         ontology_config = None
         if config.ontology_aware_metrics:
             ontology_config = _build_ontology_credit_config(config)
+            validate_hpo_graph_available()
 
         # Update extractor with new config for this run
         self.extractor.config = config
@@ -318,7 +302,7 @@ class ExtractionBenchmark:
                 results,
                 config=ontology_config,
             )
-            _attach_ontology_metrics(metrics, ontology_metrics)
+            metrics.ontology_metrics = ontology_metrics
             if config.detailed_output:
                 self._attach_ontology_detailed_results(
                     detailed_results,
@@ -335,9 +319,8 @@ class ExtractionBenchmark:
                 macro=metrics.macro,
                 weighted=metrics.weighted,
                 confidence_intervals=ci,
+                ontology_metrics=ontology_metrics,
             )
-            if ontology_metrics is not None:
-                _attach_ontology_metrics(metrics, ontology_metrics)
 
         # Save results (pass detailed_results only if enabled)
         self._save_results(
@@ -665,7 +648,7 @@ class ExtractionBenchmark:
         output_dir: Path,
         dataset_metadata: dict,
         config: ExtractionConfig,
-        ontology_metrics: Any | None = None,
+        ontology_metrics: OntologyAwareCorpusMetrics | None = None,
         detailed_results: list[dict[str, Any]] | None = None,
     ):
         """Save benchmark results to files."""

--- a/phentrieve/benchmark/extraction_benchmark.py
+++ b/phentrieve/benchmark/extraction_benchmark.py
@@ -34,6 +34,7 @@ from phentrieve.evaluation.extraction_metrics import (
     CorpusExtractionMetrics,
     CorpusMetrics,
     ExtractionResult,
+    serialize_ontology_metrics,
 )
 
 if TYPE_CHECKING:
@@ -62,6 +63,46 @@ class ExtractionConfig:
     bootstrap_samples: int = 1000
     dataset: str = "all"
     detailed_output: bool = False
+    ontology_aware_metrics: bool = False
+    ontology_semantic_floor: float = 0.30
+    ontology_similarity_formula: str = "hybrid"
+
+
+def _build_ontology_credit_config(config: ExtractionConfig) -> Any:
+    """Build ontology-aware metric config from extraction benchmark settings."""
+    from phentrieve.evaluation.metrics import SimilarityFormula
+    from phentrieve.evaluation.ontology_credit import OntologyCreditConfig
+
+    if not 0.0 <= config.ontology_semantic_floor <= 1.0:
+        raise ValueError(
+            "ontology_semantic_floor must be between 0.0 and 1.0 inclusive; "
+            f"got {config.ontology_semantic_floor!r}."
+        )
+
+    formula = config.ontology_similarity_formula.strip().lower()
+    formula_map = {
+        "hybrid": SimilarityFormula.HYBRID,
+        "simple_resnik_like": SimilarityFormula.SIMPLE_RESNIK_LIKE,
+    }
+    if formula not in formula_map:
+        raise ValueError(
+            "Invalid ontology similarity formula: "
+            f"{config.ontology_similarity_formula!r}. "
+            "Expected 'hybrid' or 'simple_resnik_like'."
+        )
+
+    return OntologyCreditConfig(
+        semantic_floor=config.ontology_semantic_floor,
+        similarity_formula=formula_map[formula],
+    )
+
+
+def _attach_ontology_metrics(
+    metrics: CorpusMetrics,
+    ontology_metrics: Any,
+) -> None:
+    metrics_with_extension: Any = metrics
+    metrics_with_extension.ontology_metrics = ontology_metrics
 
 
 class HPOExtractor:
@@ -218,6 +259,10 @@ class ExtractionBenchmark:
                 if hasattr(config, key):
                     setattr(config, key, value)
 
+        ontology_config = None
+        if config.ontology_aware_metrics:
+            ontology_config = _build_ontology_credit_config(config)
+
         # Update extractor with new config for this run
         self.extractor.config = config
 
@@ -267,6 +312,13 @@ class ExtractionBenchmark:
         # Calculate metrics
         evaluator = CorpusExtractionMetrics(averaging=config.averaging)
         metrics = evaluator.calculate_all_metrics(results)
+        ontology_metrics = None
+        if ontology_config is not None:
+            ontology_metrics = evaluator.calculate_ontology_aware_metrics(
+                results,
+                config=ontology_config,
+            )
+            _attach_ontology_metrics(metrics, ontology_metrics)
 
         # Calculate bootstrap CI if requested
         if config.bootstrap_ci:
@@ -279,6 +331,8 @@ class ExtractionBenchmark:
                 weighted=metrics.weighted,
                 confidence_intervals=ci,
             )
+            if ontology_metrics is not None:
+                _attach_ontology_metrics(metrics, ontology_metrics)
 
         # Save results (pass detailed_results only if enabled)
         self._save_results(
@@ -287,6 +341,7 @@ class ExtractionBenchmark:
             output_dir,
             test_data.get("metadata", {}),
             config,
+            ontology_metrics,
             detailed_results if config.detailed_output else None,
         )
 
@@ -500,6 +555,7 @@ class ExtractionBenchmark:
         output_dir: Path,
         dataset_metadata: dict,
         config: ExtractionConfig,
+        ontology_metrics: Any | None = None,
         detailed_results: list[dict[str, Any]] | None = None,
     ):
         """Save benchmark results to files."""
@@ -531,6 +587,9 @@ class ExtractionBenchmark:
                             "relaxed_matching": config.relaxed_matching,
                             "chunk_retrieval_threshold": config.chunk_retrieval_threshold,
                             "min_confidence_for_aggregated": config.min_confidence_for_aggregated,
+                            "ontology_aware_metrics": config.ontology_aware_metrics,
+                            "ontology_semantic_floor": config.ontology_semantic_floor,
+                            "ontology_similarity_formula": config.ontology_similarity_formula,
                         },
                         "dataset": dataset_metadata,
                     },
@@ -540,6 +599,15 @@ class ExtractionBenchmark:
                         "macro": metrics.macro,
                         "weighted": metrics.weighted,
                         "confidence_intervals": metrics.confidence_intervals,
+                        **(
+                            {
+                                "ontology_metrics": serialize_ontology_metrics(
+                                    ontology_metrics
+                                )
+                            }
+                            if ontology_metrics is not None
+                            else {}
+                        ),
                     },
                 },
                 f,
@@ -547,24 +615,39 @@ class ExtractionBenchmark:
             )
 
         # Save summary metrics
+        summary = {
+            "model": self.model_name,
+            "micro_f1": metrics.micro.get("f1", 0),
+            "micro_precision": metrics.micro.get("precision", 0),
+            "micro_recall": metrics.micro.get("recall", 0),
+            "macro_f1": metrics.macro.get("f1", 0),
+            "macro_precision": metrics.macro.get("precision", 0),
+            "macro_recall": metrics.macro.get("recall", 0),
+            "weighted_f1": metrics.weighted.get("f1", 0),
+            "weighted_precision": metrics.weighted.get("precision", 0),
+            "weighted_recall": metrics.weighted.get("recall", 0),
+        }
+        if ontology_metrics is not None:
+            summary.update(
+                {
+                    "soft_micro_f1": ontology_metrics.soft.micro.get("f1", 0),
+                    "soft_micro_precision": ontology_metrics.soft.micro.get(
+                        "precision", 0
+                    ),
+                    "soft_micro_recall": ontology_metrics.soft.micro.get("recall", 0),
+                    "partial_micro_f1": ontology_metrics.partial.micro.get("f1", 0),
+                    "partial_micro_precision": ontology_metrics.partial.micro.get(
+                        "precision", 0
+                    ),
+                    "partial_micro_recall": ontology_metrics.partial.micro.get(
+                        "recall", 0
+                    ),
+                }
+            )
+
         summary_file = output_dir / "extraction_summary.json"
         with open(summary_file, "w") as f:
-            json.dump(
-                {
-                    "model": self.model_name,
-                    "micro_f1": metrics.micro.get("f1", 0),
-                    "micro_precision": metrics.micro.get("precision", 0),
-                    "micro_recall": metrics.micro.get("recall", 0),
-                    "macro_f1": metrics.macro.get("f1", 0),
-                    "macro_precision": metrics.macro.get("precision", 0),
-                    "macro_recall": metrics.macro.get("recall", 0),
-                    "weighted_f1": metrics.weighted.get("f1", 0),
-                    "weighted_precision": metrics.weighted.get("precision", 0),
-                    "weighted_recall": metrics.weighted.get("recall", 0),
-                },
-                f,
-                indent=2,
-            )
+            json.dump(summary, f, indent=2)
 
         # Save detailed analysis with chunks (NEW!)
         if detailed_results:

--- a/phentrieve/benchmark/extraction_benchmark.py
+++ b/phentrieve/benchmark/extraction_benchmark.py
@@ -319,6 +319,11 @@ class ExtractionBenchmark:
                 config=ontology_config,
             )
             _attach_ontology_metrics(metrics, ontology_metrics)
+            if config.detailed_output:
+                self._attach_ontology_detailed_results(
+                    detailed_results,
+                    ontology_metrics.document_metrics,
+                )
 
         # Calculate bootstrap CI if requested
         if config.bootstrap_ci:
@@ -546,6 +551,111 @@ class ExtractionBenchmark:
                 "false_negatives": false_negatives,
             },
             "all_chunks": all_chunks,
+        }
+
+    def _attach_ontology_detailed_results(
+        self,
+        detailed_results: list[dict[str, Any]],
+        document_metrics: list[Any],
+    ) -> None:
+        metrics_by_doc_id = {metric.doc_id: metric for metric in document_metrics}
+        for detailed_result in detailed_results:
+            ontology_metric = metrics_by_doc_id.get(detailed_result["doc_id"])
+            if ontology_metric is None:
+                continue
+            detailed_result["ontology_metrics"] = (
+                self._serialize_document_ontology_metrics(
+                    ontology_metric,
+                    detailed_result,
+                )
+            )
+
+    def _serialize_document_ontology_metrics(
+        self,
+        ontology_metric: Any,
+        detailed_result: dict[str, Any],
+    ) -> dict[str, Any]:
+        predicted_labels, gold_labels = self._ontology_label_lookups(detailed_result)
+
+        return {
+            "counts": {
+                "predictions": ontology_metric.prediction_count,
+                "gold": ontology_metric.gold_count,
+                "strict_tp": ontology_metric.strict_tp,
+            },
+            "soft": {
+                "tp": ontology_metric.soft_tp,
+                "fp": ontology_metric.soft_fp,
+                "fn": ontology_metric.soft_fn,
+                "precision": ontology_metric.soft_precision,
+                "recall": ontology_metric.soft_recall,
+                "f1": ontology_metric.soft_f1,
+            },
+            "partial": {
+                "precision": ontology_metric.partial_precision,
+                "recall": ontology_metric.partial_recall,
+                "f1": ontology_metric.partial_f1,
+            },
+            "matches": [
+                {
+                    "predicted": self._serialize_ontology_annotation(
+                        match.predicted,
+                        predicted_labels,
+                    ),
+                    "gold": self._serialize_ontology_annotation(
+                        match.gold,
+                        gold_labels,
+                    ),
+                    "assertion": match.predicted[1],
+                    "match_kind": match.credit.match_kind.value,
+                    "credit": match.credit.credit,
+                    "semantic_similarity": match.credit.semantic_similarity,
+                    "distance": match.credit.distance,
+                }
+                for match in ontology_metric.matches
+            ],
+            "unmatched_predictions": [
+                self._serialize_ontology_annotation(annotation, predicted_labels)
+                for annotation in ontology_metric.unmatched_predictions
+            ],
+            "unmatched_gold": [
+                self._serialize_ontology_annotation(annotation, gold_labels)
+                for annotation in ontology_metric.unmatched_gold
+            ],
+        }
+
+    def _ontology_label_lookups(
+        self,
+        detailed_result: dict[str, Any],
+    ) -> tuple[dict[str, str], dict[str, str]]:
+        predicted_labels: dict[str, str] = {}
+        gold_labels: dict[str, str] = {}
+        analysis = detailed_result.get("analysis", {})
+
+        for item in analysis.get("true_positives", []):
+            hpo_id = item["hpo_id"]
+            label = item.get("label", "")
+            predicted_labels[hpo_id] = label
+            gold_labels[hpo_id] = label
+
+        for item in analysis.get("false_positives", []):
+            predicted_labels[item["hpo_id"]] = item.get("label", "")
+
+        for item in analysis.get("false_negatives", []):
+            gold_labels[item["hpo_id"]] = item.get("label", "")
+
+        return predicted_labels, gold_labels
+
+    def _serialize_ontology_annotation(
+        self,
+        annotation: tuple[str, str],
+        labels_by_id: dict[str, str],
+    ) -> dict[str, Any]:
+        hpo_id, assertion = annotation
+        return {
+            "hpo_id": hpo_id,
+            "label": labels_by_id.get(hpo_id, ""),
+            "assertion": assertion,
         }
 
     def _save_results(

--- a/phentrieve/benchmark/extraction_cli.py
+++ b/phentrieve/benchmark/extraction_cli.py
@@ -272,7 +272,7 @@ def _display_results(metrics):
 
     console.print(table)
 
-    ontology_metrics = getattr(metrics, "ontology_metrics", None)
+    ontology_metrics = metrics.ontology_metrics
     if ontology_metrics is not None:
         ontology_table = Table(title="Ontology-Aware Benchmark Results")
         ontology_table.add_column("Metric", style="cyan")

--- a/phentrieve/benchmark/extraction_cli.py
+++ b/phentrieve/benchmark/extraction_cli.py
@@ -66,6 +66,21 @@ def run(
         "--detailed-output",
         help="Generate detailed chunk-level analysis JSON (extraction_detailed_analysis.json)",
     ),
+    ontology_aware_metrics: bool = typer.Option(
+        False,
+        "--ontology-aware-metrics/--no-ontology-aware-metrics",
+        help="Calculate ontology-aware soft and partial benchmark metrics.",
+    ),
+    ontology_semantic_floor: float = typer.Option(
+        0.30,
+        "--ontology-semantic-floor",
+        help="Minimum fallback semantic similarity for ontology-aware credit.",
+    ),
+    ontology_similarity_formula: str = typer.Option(
+        "hybrid",
+        "--ontology-similarity-formula",
+        help="Ontology fallback similarity formula: hybrid or simple_resnik_like.",
+    ),
     verbose: bool = typer.Option(
         False, "-v", "--verbose", help="Enable verbose output"
     ),
@@ -112,6 +127,9 @@ def run(
         top_term_per_chunk=top_term_only,
         dataset=dataset,
         detailed_output=detailed_output,
+        ontology_aware_metrics=ontology_aware_metrics,
+        ontology_semantic_floor=ontology_semantic_floor,
+        ontology_similarity_formula=ontology_similarity_formula,
     )
 
     # Initialize benchmark
@@ -253,6 +271,24 @@ def _display_results(metrics):
         )
 
     console.print(table)
+
+    ontology_metrics = getattr(metrics, "ontology_metrics", None)
+    if ontology_metrics is not None:
+        ontology_table = Table(title="Ontology-Aware Benchmark Results")
+        ontology_table.add_column("Metric", style="cyan")
+        ontology_table.add_column("Micro F1", style="magenta")
+
+        ontology_table.add_row(
+            "Strict", f"{ontology_metrics.strict.micro.get('f1', 0):.3f}"
+        )
+        ontology_table.add_row(
+            "Soft", f"{ontology_metrics.soft.micro.get('f1', 0):.3f}"
+        )
+        ontology_table.add_row(
+            "Partial", f"{ontology_metrics.partial.micro.get('f1', 0):.3f}"
+        )
+
+        console.print(ontology_table)
 
     # Display confidence intervals if available
     if metrics.confidence_intervals:

--- a/phentrieve/benchmark/extraction_reporter.py
+++ b/phentrieve/benchmark/extraction_reporter.py
@@ -29,19 +29,43 @@ class ExtractionReporter:
 
         # Summary table
         lines.append("## Summary\n")
-        lines.append("| Model | Micro F1 | Macro F1 | Precision | Recall |")
-        lines.append("|-------|----------|----------|-----------|--------|")
+        has_ontology_metrics = any(
+            result.get("corpus_metrics", {}).get("ontology_metrics")
+            for result in results
+        )
+        if has_ontology_metrics:
+            lines.append(
+                "| Model | Micro F1 | Macro F1 | Precision | Recall | "
+                "Soft Micro F1 | Partial Micro F1 |"
+            )
+            lines.append(
+                "|-------|----------|----------|-----------|--------|"
+                "---------------|------------------|"
+            )
+        else:
+            lines.append("| Model | Micro F1 | Macro F1 | Precision | Recall |")
+            lines.append("|-------|----------|----------|-----------|--------|")
 
         for result in results:
             model = result.get("metadata", {}).get("model", "Unknown")
-            micro = result.get("corpus_metrics", {}).get("micro", {})
-            macro = result.get("corpus_metrics", {}).get("macro", {})
+            corpus_metrics = result.get("corpus_metrics", {})
+            micro = corpus_metrics.get("micro", {})
+            macro = corpus_metrics.get("macro", {})
 
-            lines.append(
+            row = (
                 f"| {model} | {micro.get('f1', 0):.3f} | "
                 f"{macro.get('f1', 0):.3f} | {micro.get('precision', 0):.3f} | "
-                f"{micro.get('recall', 0):.3f} |"
+                f"{micro.get('recall', 0):.3f}"
             )
+            if has_ontology_metrics:
+                ontology_metrics = corpus_metrics.get("ontology_metrics") or {}
+                soft_micro = ontology_metrics.get("soft", {}).get("micro", {})
+                partial_micro = ontology_metrics.get("partial", {}).get("micro", {})
+                row += (
+                    f" | {soft_micro.get('f1', 0):.3f} | "
+                    f"{partial_micro.get('f1', 0):.3f}"
+                )
+            lines.append(f"{row} |")
 
         lines.append("\n## Details\n")
         # Add more detailed sections as needed

--- a/phentrieve/benchmark/llm_benchmark.py
+++ b/phentrieve/benchmark/llm_benchmark.py
@@ -82,32 +82,22 @@ def build_ontology_credit_config(
     semantic_floor: float,
     similarity_formula: str,
 ) -> Any:
-    """Build ontology-aware metric config from benchmark option values."""
-    from phentrieve.evaluation.metrics import SimilarityFormula
-    from phentrieve.evaluation.ontology_credit import OntologyCreditConfig
-
-    if not 0.0 <= semantic_floor <= 1.0:
-        raise ValueError(
-            "ontology_semantic_floor must be between 0.0 and 1.0 inclusive; "
-            f"got {semantic_floor!r}."
-        )
-
-    formula = similarity_formula.strip().lower()
-    formula_map = {
-        "hybrid": SimilarityFormula.HYBRID,
-        "simple_resnik_like": SimilarityFormula.SIMPLE_RESNIK_LIKE,
-    }
-    if formula not in formula_map:
-        raise ValueError(
-            "Invalid ontology similarity formula: "
-            f"{similarity_formula!r}. "
-            "Expected 'hybrid' or 'simple_resnik_like'."
-        )
-
-    return OntologyCreditConfig(
-        semantic_floor=semantic_floor,
-        similarity_formula=formula_map[formula],
+    from phentrieve.evaluation.ontology_credit import (
+        build_ontology_credit_config as build,
     )
+
+    return build(
+        semantic_floor=semantic_floor,
+        similarity_formula=similarity_formula,
+    )
+
+
+def validate_hpo_graph_available() -> None:
+    from phentrieve.evaluation.ontology_credit import (
+        validate_hpo_graph_available as validate,
+    )
+
+    validate()
 
 
 class TokenPricingConfig(BaseModel):
@@ -300,6 +290,7 @@ def run_llm_benchmark(
             semantic_floor=ontology_semantic_floor,
             similarity_formula=ontology_similarity_formula,
         )
+        validate_hpo_graph_available()
 
     test_path = Path(test_file)
     logger.info(

--- a/phentrieve/benchmark/llm_benchmark.py
+++ b/phentrieve/benchmark/llm_benchmark.py
@@ -22,6 +22,7 @@ from phentrieve.benchmark.data_loader import (
 from phentrieve.evaluation.extraction_metrics import (
     CorpusExtractionMetrics,
     ExtractionResult,
+    serialize_ontology_metrics,
 )
 from phentrieve.llm.config import DEFAULT_LLM_LANGUAGE, DEFAULT_PROVIDER_NAME
 from phentrieve.llm.pipeline import (
@@ -74,6 +75,39 @@ DATASET_ASSERTION_PROJECTION: dict[str, dict[str, str | None]] = {
         "other": None,
     },
 }
+
+
+def build_ontology_credit_config(
+    *,
+    semantic_floor: float,
+    similarity_formula: str,
+) -> Any:
+    """Build ontology-aware metric config from benchmark option values."""
+    from phentrieve.evaluation.metrics import SimilarityFormula
+    from phentrieve.evaluation.ontology_credit import OntologyCreditConfig
+
+    if not 0.0 <= semantic_floor <= 1.0:
+        raise ValueError(
+            "ontology_semantic_floor must be between 0.0 and 1.0 inclusive; "
+            f"got {semantic_floor!r}."
+        )
+
+    formula = similarity_formula.strip().lower()
+    formula_map = {
+        "hybrid": SimilarityFormula.HYBRID,
+        "simple_resnik_like": SimilarityFormula.SIMPLE_RESNIK_LIKE,
+    }
+    if formula not in formula_map:
+        raise ValueError(
+            "Invalid ontology similarity formula: "
+            f"{similarity_formula!r}. "
+            "Expected 'hybrid' or 'simple_resnik_like'."
+        )
+
+    return OntologyCreditConfig(
+        semantic_floor=semantic_floor,
+        similarity_formula=formula_map[formula],
+    )
 
 
 class TokenPricingConfig(BaseModel):
@@ -238,6 +272,9 @@ def run_llm_benchmark(
     output_cost_per_1m_tokens: float | None = None,
     cached_input_cost_per_1m_tokens: float | None = None,
     capture_phase1_debug: bool = False,
+    ontology_aware_metrics: bool = False,
+    ontology_semantic_floor: float = 0.30,
+    ontology_similarity_formula: str = "hybrid",
     accounting_config: BenchmarkAccountingConfig | None = None,
     checkpoint_state: dict[str, Any] | None = None,
     progress_callback: Callable[[dict[str, Any]], None] | None = None,
@@ -255,6 +292,13 @@ def run_llm_benchmark(
             "Unsupported llm_internal_mode: "
             f"{llm_internal_mode!r}. Expected 'whole_document_legacy' or "
             "'whole_document_grounded'."
+        )
+
+    ontology_config = None
+    if ontology_aware_metrics:
+        ontology_config = build_ontology_credit_config(
+            semantic_floor=ontology_semantic_floor,
+            similarity_formula=ontology_similarity_formula,
         )
 
     test_path = Path(test_file)
@@ -635,6 +679,9 @@ def run_llm_benchmark(
                         llm_internal_mode=llm_internal_mode,
                         language=language,
                         prompt_templates_dir=prompt_templates_dir,
+                        ontology_aware_metrics=ontology_aware_metrics,
+                        ontology_semantic_floor=ontology_semantic_floor,
+                        ontology_similarity_formula=ontology_similarity_formula,
                         dataset_metadata=test_data.get("metadata", {}),
                         total_prompt_tokens=total_prompt_tokens,
                         total_completion_tokens=total_completion_tokens,
@@ -656,6 +703,23 @@ def run_llm_benchmark(
 
     assertion_metrics = evaluator.calculate_all_metrics(assertion_results)
     id_only_metrics = evaluator.calculate_all_metrics(id_only_results)
+    assertion_metrics_payload = _serialize_corpus_metrics(assertion_metrics)
+    id_only_metrics_payload = _serialize_corpus_metrics(id_only_metrics)
+    if ontology_config is not None:
+        assertion_ontology_metrics = evaluator.calculate_ontology_aware_metrics(
+            assertion_results,
+            config=ontology_config,
+        )
+        id_only_ontology_metrics = evaluator.calculate_ontology_aware_metrics(
+            id_only_results,
+            config=ontology_config,
+        )
+        assertion_metrics_payload["ontology_metrics"] = serialize_ontology_metrics(
+            assertion_ontology_metrics
+        )
+        id_only_metrics_payload["ontology_metrics"] = serialize_ontology_metrics(
+            id_only_ontology_metrics
+        )
     logger.info("Calculated benchmark metrics for %d documents", len(results))
     wall_clock_seconds = prior_wall_clock_seconds + (
         time.perf_counter() - benchmark_start_time
@@ -678,6 +742,9 @@ def run_llm_benchmark(
         llm_internal_mode=llm_internal_mode,
         language=language,
         prompt_templates_dir=prompt_templates_dir,
+        ontology_aware_metrics=ontology_aware_metrics,
+        ontology_semantic_floor=ontology_semantic_floor,
+        ontology_similarity_formula=ontology_similarity_formula,
         dataset_metadata=test_data.get("metadata", {}),
         total_prompt_tokens=total_prompt_tokens,
         total_completion_tokens=total_completion_tokens,
@@ -692,8 +759,8 @@ def run_llm_benchmark(
         results=results,
         prediction_records=prediction_records,
         metrics={
-            "assertion_aware": _serialize_corpus_metrics(assertion_metrics),
-            "id_only": _serialize_corpus_metrics(id_only_metrics),
+            "assertion_aware": assertion_metrics_payload,
+            "id_only": id_only_metrics_payload,
         },
         status="completed",
     )
@@ -846,6 +913,9 @@ def _build_benchmark_payload(
     llm_internal_mode: str,
     language: str,
     prompt_templates_dir: str | None,
+    ontology_aware_metrics: bool,
+    ontology_semantic_floor: float,
+    ontology_similarity_formula: str,
     dataset_metadata: dict[str, Any],
     total_prompt_tokens: int,
     total_completion_tokens: int,
@@ -873,6 +943,9 @@ def _build_benchmark_payload(
         "llm_internal_mode": llm_internal_mode,
         "language": language,
         "prompt_templates_dir": prompt_templates_dir,
+        "ontology_aware_metrics": ontology_aware_metrics,
+        "ontology_semantic_floor": ontology_semantic_floor,
+        "ontology_similarity_formula": ontology_similarity_formula,
         "requested_doc_ids": list(requested_doc_ids) if requested_doc_ids else None,
         "dataset_metadata": dataset_metadata,
         "token_usage": {

--- a/phentrieve/benchmark/llm_cli.py
+++ b/phentrieve/benchmark/llm_cli.py
@@ -26,6 +26,11 @@ app = typer.Typer(help="Benchmark LLM full-text extraction.")
 console = Console()
 logger = logging.getLogger(__name__)
 DEFAULT_LLM_BENCHMARK_OUTPUT_DIR = Path("results") / "llm"
+CHECKPOINT_DEFAULTS: dict[str, Any] = {
+    "ontology_aware_metrics": False,
+    "ontology_semantic_floor": 0.30,
+    "ontology_similarity_formula": "hybrid",
+}
 
 
 def _default_output_path() -> Path:
@@ -70,6 +75,9 @@ def run_llm_benchmark_cli(
     output_cost_per_1m_tokens: float | None = None,
     cached_input_cost_per_1m_tokens: float | None = None,
     capture_phase1_debug: bool = False,
+    ontology_aware_metrics: bool = False,
+    ontology_semantic_floor: float = 0.30,
+    ontology_similarity_formula: str = "hybrid",
     measure_energy: bool = False,
     per_document_energy: bool = False,
     electricity_cost_per_kwh: float | None = None,
@@ -138,6 +146,9 @@ def run_llm_benchmark_cli(
                 "llm_internal_mode": llm_internal_mode,
                 "language": language,
                 "capture_phase1_debug": capture_phase1_debug,
+                "ontology_aware_metrics": ontology_aware_metrics,
+                "ontology_semantic_floor": ontology_semantic_floor,
+                "ontology_similarity_formula": ontology_similarity_formula,
                 "prompt_templates_dir": prompt_templates_dir,
                 "requested_doc_ids": list(doc_ids) if doc_ids else None,
             },
@@ -175,6 +186,9 @@ def run_llm_benchmark_cli(
         output_cost_per_1m_tokens=output_cost_per_1m_tokens,
         cached_input_cost_per_1m_tokens=cached_input_cost_per_1m_tokens,
         capture_phase1_debug=capture_phase1_debug,
+        ontology_aware_metrics=ontology_aware_metrics,
+        ontology_semantic_floor=ontology_semantic_floor,
+        ontology_similarity_formula=ontology_similarity_formula,
         accounting_config=accounting_config,
         checkpoint_state=existing_checkpoint,
         progress_callback=_persist_checkpoint,
@@ -292,7 +306,10 @@ def _checkpoint_matches_run(
     payload: dict[str, Any],
     current_run: dict[str, Any],
 ) -> bool:
-    return all(payload.get(key) == value for key, value in current_run.items())
+    return all(
+        payload.get(key, CHECKPOINT_DEFAULTS.get(key)) == value
+        for key, value in current_run.items()
+    )
 
 
 def _write_benchmark_artifacts(
@@ -493,6 +510,27 @@ def benchmark_llm(
             help="Capture phase 1 source text, prompt, and raw structured outputs in per-case traces.",
         ),
     ] = False,
+    ontology_aware_metrics: Annotated[
+        bool,
+        typer.Option(
+            "--ontology-aware-metrics/--no-ontology-aware-metrics",
+            help="Calculate ontology-aware soft and partial benchmark metrics.",
+        ),
+    ] = False,
+    ontology_semantic_floor: Annotated[
+        float,
+        typer.Option(
+            "--ontology-semantic-floor",
+            help="Minimum fallback semantic similarity for ontology-aware credit.",
+        ),
+    ] = 0.30,
+    ontology_similarity_formula: Annotated[
+        str,
+        typer.Option(
+            "--ontology-similarity-formula",
+            help="Ontology fallback similarity formula: hybrid or simple_resnik_like.",
+        ),
+    ] = "hybrid",
     measure_energy: Annotated[
         bool,
         typer.Option(
@@ -556,6 +594,9 @@ def benchmark_llm(
             output_cost_per_1m_tokens=output_cost_per_1m_tokens,
             cached_input_cost_per_1m_tokens=cached_input_cost_per_1m_tokens,
             capture_phase1_debug=capture_phase1_debug,
+            ontology_aware_metrics=ontology_aware_metrics,
+            ontology_semantic_floor=ontology_semantic_floor,
+            ontology_similarity_formula=ontology_similarity_formula,
             measure_energy=measure_energy,
             per_document_energy=per_document_energy,
             electricity_cost_per_kwh=electricity_cost_per_kwh,

--- a/phentrieve/evaluation/_extraction_types.py
+++ b/phentrieve/evaluation/_extraction_types.py
@@ -1,0 +1,12 @@
+"""Shared extraction evaluation types."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ExtractionResult:
+    """Single document extraction result."""
+
+    doc_id: str
+    predicted: list[tuple[str, str]]  # (hpo_id, assertion)
+    gold: list[tuple[str, str]]  # (hpo_id, assertion)

--- a/phentrieve/evaluation/extraction_metrics.py
+++ b/phentrieve/evaluation/extraction_metrics.py
@@ -1,21 +1,16 @@
 """Extraction metrics for document-level HPO extraction evaluation."""
 
+from __future__ import annotations
+
 import random
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypedDict
 
+from phentrieve.evaluation._extraction_types import ExtractionResult
+
 if TYPE_CHECKING:
     from phentrieve.evaluation.ontology_credit import OntologyCreditConfig
     from phentrieve.evaluation.ontology_matching import DocumentOntologyMetrics
-
-
-@dataclass
-class ExtractionResult:
-    """Single document extraction result."""
-
-    doc_id: str
-    predicted: list[tuple[str, str]]  # (hpo_id, assertion)
-    gold: list[tuple[str, str]]  # (hpo_id, assertion)
 
 
 @dataclass
@@ -26,6 +21,7 @@ class CorpusMetrics:
     macro: dict[str, float]  # precision, recall, f1
     weighted: dict[str, float]  # weighted by doc size
     confidence_intervals: dict[str, tuple[float, float]]
+    ontology_metrics: OntologyAwareCorpusMetrics | None = None
 
 
 class MatchBreakdownEntry(TypedDict):
@@ -52,7 +48,7 @@ class OntologyAwareCorpusMetrics:
     soft: OntologyMetricBlock
     partial: OntologyMetricBlock
     match_breakdown: dict[str, MatchBreakdownEntry]
-    document_metrics: list["DocumentOntologyMetrics"]
+    document_metrics: list[DocumentOntologyMetrics]
 
 
 def _calculate_prf(tp: int, fp: int, fn: int) -> tuple[float, float, float]:
@@ -157,8 +153,8 @@ def serialize_ontology_metrics(
 
 def calculate_document_ontology_metrics(
     result: ExtractionResult,
-    config: "OntologyCreditConfig | None" = None,
-) -> "DocumentOntologyMetrics":
+    config: OntologyCreditConfig | None = None,
+) -> DocumentOntologyMetrics:
     from phentrieve.evaluation.ontology_matching import (
         calculate_document_ontology_metrics as calculate,
     )
@@ -205,7 +201,7 @@ class CorpusExtractionMetrics:
     def calculate_ontology_aware_metrics(
         self,
         results: list[ExtractionResult],
-        config: "OntologyCreditConfig | None" = None,
+        config: OntologyCreditConfig | None = None,
     ) -> OntologyAwareCorpusMetrics:
         """Calculate strict and ontology-aware corpus extraction metrics."""
         if not results:

--- a/phentrieve/evaluation/extraction_metrics.py
+++ b/phentrieve/evaluation/extraction_metrics.py
@@ -2,10 +2,11 @@
 
 import random
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
 if TYPE_CHECKING:
     from phentrieve.evaluation.ontology_credit import OntologyCreditConfig
+    from phentrieve.evaluation.ontology_matching import DocumentOntologyMetrics
 
 
 @dataclass
@@ -27,6 +28,13 @@ class CorpusMetrics:
     confidence_intervals: dict[str, tuple[float, float]]
 
 
+class MatchBreakdownEntry(TypedDict):
+    """Corpus-level count and credit total for one ontology match kind."""
+
+    count: int
+    credit: float
+
+
 @dataclass
 class OntologyMetricBlock:
     """Ontology-aware corpus metrics for one matching mode."""
@@ -43,8 +51,8 @@ class OntologyAwareCorpusMetrics:
     strict: OntologyMetricBlock
     soft: OntologyMetricBlock
     partial: OntologyMetricBlock
-    match_breakdown: dict[str, dict[str, float]]
-    document_metrics: list[Any]
+    match_breakdown: dict[str, MatchBreakdownEntry]
+    document_metrics: list["DocumentOntologyMetrics"]
 
 
 def _calculate_prf(tp: int, fp: int, fn: int) -> tuple[float, float, float]:
@@ -147,6 +155,17 @@ def serialize_ontology_metrics(
     }
 
 
+def calculate_document_ontology_metrics(
+    result: ExtractionResult,
+    config: "OntologyCreditConfig | None" = None,
+) -> "DocumentOntologyMetrics":
+    from phentrieve.evaluation.ontology_matching import (
+        calculate_document_ontology_metrics as calculate,
+    )
+
+    return calculate(result, config)
+
+
 class CorpusExtractionMetrics:
     """Document-level HPO extraction evaluation."""
 
@@ -197,10 +216,6 @@ class CorpusExtractionMetrics:
                 match_breakdown={},
                 document_metrics=[],
             )
-
-        from phentrieve.evaluation.ontology_matching import (
-            calculate_document_ontology_metrics,
-        )
 
         document_metrics = [
             calculate_document_ontology_metrics(result, config) for result in results
@@ -286,7 +301,7 @@ class CorpusExtractionMetrics:
             weighted=_average_metric_dicts(partial_document_metrics, weights),
         )
 
-        match_breakdown: dict[str, dict[str, float]] = {}
+        match_breakdown: dict[str, MatchBreakdownEntry] = {}
         for metric in document_metrics:
             for match in metric.matches:
                 kind = match.credit.match_kind.value

--- a/phentrieve/evaluation/extraction_metrics.py
+++ b/phentrieve/evaluation/extraction_metrics.py
@@ -2,6 +2,10 @@
 
 import random
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from phentrieve.evaluation.ontology_credit import OntologyCreditConfig
 
 
 @dataclass
@@ -21,6 +25,26 @@ class CorpusMetrics:
     macro: dict[str, float]  # precision, recall, f1
     weighted: dict[str, float]  # weighted by doc size
     confidence_intervals: dict[str, tuple[float, float]]
+
+
+@dataclass
+class OntologyMetricBlock:
+    """Ontology-aware corpus metrics for one matching mode."""
+
+    micro: dict[str, float]
+    macro: dict[str, float]
+    weighted: dict[str, float]
+
+
+@dataclass
+class OntologyAwareCorpusMetrics:
+    """Corpus-level ontology-aware extraction metrics."""
+
+    strict: OntologyMetricBlock
+    soft: OntologyMetricBlock
+    partial: OntologyMetricBlock
+    match_breakdown: dict[str, dict[str, float]]
+    document_metrics: list[Any]
 
 
 def _calculate_prf(tp: int, fp: int, fn: int) -> tuple[float, float, float]:
@@ -49,6 +73,78 @@ def _doc_metrics(result: ExtractionResult) -> tuple[float, float, float, int]:
 
     precision, recall, f1 = _calculate_prf(tp, fp, fn)
     return precision, recall, f1, len(gold_set)
+
+
+def _zero_metrics() -> dict[str, float]:
+    return {"precision": 0.0, "recall": 0.0, "f1": 0.0}
+
+
+def _zero_ontology_block() -> OntologyMetricBlock:
+    return OntologyMetricBlock(
+        micro=_zero_metrics(),
+        macro=_zero_metrics(),
+        weighted=_zero_metrics(),
+    )
+
+
+def _ontology_block_from_corpus_metrics(metrics: CorpusMetrics) -> OntologyMetricBlock:
+    return OntologyMetricBlock(
+        micro=dict(metrics.micro),
+        macro=dict(metrics.macro),
+        weighted=dict(metrics.weighted),
+    )
+
+
+def _harmonic_mean(precision: float, recall: float) -> float:
+    if precision + recall == 0:
+        return 0.0
+    return 2 * precision * recall / (precision + recall)
+
+
+def _average_metric_dicts(
+    metrics: list[dict[str, float]],
+    weights: list[int] | None = None,
+) -> dict[str, float]:
+    if not metrics:
+        return _zero_metrics()
+
+    if weights is None:
+        weights = [1] * len(metrics)
+
+    total_weight = sum(weights)
+    if total_weight == 0:
+        return _zero_metrics()
+
+    def weighted_sum(metric_name: str) -> float:
+        return sum(
+            metric[metric_name] * weight
+            for metric, weight in zip(metrics, weights, strict=True)
+        )
+
+    return {
+        "precision": weighted_sum("precision") / total_weight,
+        "recall": weighted_sum("recall") / total_weight,
+        "f1": weighted_sum("f1") / total_weight,
+    }
+
+
+def _block(metrics: OntologyMetricBlock) -> dict[str, dict[str, float]]:
+    return {
+        "micro": dict(metrics.micro),
+        "macro": dict(metrics.macro),
+        "weighted": dict(metrics.weighted),
+    }
+
+
+def serialize_ontology_metrics(
+    metrics: OntologyAwareCorpusMetrics,
+) -> dict[str, Any]:
+    return {
+        "strict": _block(metrics.strict),
+        "soft": _block(metrics.soft),
+        "partial": _block(metrics.partial),
+        "match_breakdown": metrics.match_breakdown,
+    }
 
 
 class CorpusExtractionMetrics:
@@ -85,6 +181,126 @@ class CorpusExtractionMetrics:
             macro=macro,
             weighted=weighted,
             confidence_intervals={},
+        )
+
+    def calculate_ontology_aware_metrics(
+        self,
+        results: list[ExtractionResult],
+        config: "OntologyCreditConfig | None" = None,
+    ) -> OntologyAwareCorpusMetrics:
+        """Calculate strict and ontology-aware corpus extraction metrics."""
+        if not results:
+            return OntologyAwareCorpusMetrics(
+                strict=_zero_ontology_block(),
+                soft=_zero_ontology_block(),
+                partial=_zero_ontology_block(),
+                match_breakdown={},
+                document_metrics=[],
+            )
+
+        from phentrieve.evaluation.ontology_matching import (
+            calculate_document_ontology_metrics,
+        )
+
+        document_metrics = [
+            calculate_document_ontology_metrics(result, config) for result in results
+        ]
+        strict = _ontology_block_from_corpus_metrics(
+            self.calculate_all_metrics(results)
+        )
+
+        total_soft_tp = sum(metric.soft_tp for metric in document_metrics)
+        total_soft_fp = sum(metric.soft_fp for metric in document_metrics)
+        total_soft_fn = sum(metric.soft_fn for metric in document_metrics)
+        soft_precision = (
+            total_soft_tp / (total_soft_tp + total_soft_fp)
+            if total_soft_tp + total_soft_fp > 0
+            else 0.0
+        )
+        soft_recall = (
+            total_soft_tp / (total_soft_tp + total_soft_fn)
+            if total_soft_tp + total_soft_fn > 0
+            else 0.0
+        )
+        soft_micro = {
+            "precision": soft_precision,
+            "recall": soft_recall,
+            "f1": _harmonic_mean(soft_precision, soft_recall),
+        }
+
+        partial_precision_denominator = sum(
+            metric.prediction_count for metric in document_metrics
+        )
+        partial_recall_denominator = sum(
+            metric.gold_count for metric in document_metrics
+        )
+        partial_precision = (
+            sum(
+                metric.partial_precision * metric.prediction_count
+                for metric in document_metrics
+            )
+            / partial_precision_denominator
+            if partial_precision_denominator > 0
+            else 0.0
+        )
+        partial_recall = (
+            sum(
+                metric.partial_recall * metric.gold_count for metric in document_metrics
+            )
+            / partial_recall_denominator
+            if partial_recall_denominator > 0
+            else 0.0
+        )
+        partial_micro = {
+            "precision": partial_precision,
+            "recall": partial_recall,
+            "f1": _harmonic_mean(partial_precision, partial_recall),
+        }
+
+        soft_document_metrics = [
+            {
+                "precision": metric.soft_precision,
+                "recall": metric.soft_recall,
+                "f1": metric.soft_f1,
+            }
+            for metric in document_metrics
+        ]
+        partial_document_metrics = [
+            {
+                "precision": metric.partial_precision,
+                "recall": metric.partial_recall,
+                "f1": metric.partial_f1,
+            }
+            for metric in document_metrics
+        ]
+        weights = [max(metric.gold_count, 1) for metric in document_metrics]
+
+        soft = OntologyMetricBlock(
+            micro=soft_micro,
+            macro=_average_metric_dicts(soft_document_metrics),
+            weighted=_average_metric_dicts(soft_document_metrics, weights),
+        )
+        partial = OntologyMetricBlock(
+            micro=partial_micro,
+            macro=_average_metric_dicts(partial_document_metrics),
+            weighted=_average_metric_dicts(partial_document_metrics, weights),
+        )
+
+        match_breakdown: dict[str, dict[str, float]] = {}
+        for metric in document_metrics:
+            for match in metric.matches:
+                kind = match.credit.match_kind.value
+                if kind not in match_breakdown:
+                    match_breakdown[kind] = {"count": 0, "credit": 0.0}
+                match_breakdown[kind]["count"] += 1
+                match_breakdown[kind]["credit"] += match.credit.credit
+
+        return OntologyAwareCorpusMetrics(
+            strict=strict,
+            soft=soft,
+            partial=partial,
+            match_breakdown=match_breakdown,
+            document_metrics=document_metrics,
         )
 
     def _compute_micro(self, results: list[ExtractionResult]) -> dict[str, float]:

--- a/phentrieve/evaluation/ontology_credit.py
+++ b/phentrieve/evaluation/ontology_credit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import math
 from collections import deque
 from dataclasses import dataclass
@@ -10,6 +11,9 @@ from phentrieve.evaluation.metrics import (
     calculate_semantic_similarity,
     load_hpo_graph_data,
 )
+
+logger = logging.getLogger(__name__)
+_PARENTS_CACHE: dict[tuple[int, str], set[str]] = {}
 
 
 class MatchKind(str, Enum):  # noqa: UP042 - Python 3.10 compatible enum.
@@ -46,6 +50,45 @@ class PairCredit:
     distance: int | None
 
 
+def build_ontology_credit_config(
+    *,
+    semantic_floor: float,
+    similarity_formula: str,
+) -> OntologyCreditConfig:
+    """Build ontology-aware metric config from benchmark option values."""
+    if not 0.0 <= semantic_floor <= 1.0:
+        raise ValueError(
+            "ontology_semantic_floor must be between 0.0 and 1.0 inclusive; "
+            f"got {semantic_floor!r}."
+        )
+
+    formula = similarity_formula.strip().lower()
+    formula_map = {
+        "hybrid": SimilarityFormula.HYBRID,
+        "simple_resnik_like": SimilarityFormula.SIMPLE_RESNIK_LIKE,
+    }
+    if formula not in formula_map:
+        raise ValueError(
+            "Invalid ontology similarity formula: "
+            f"{similarity_formula!r}. Expected 'hybrid' or 'simple_resnik_like'."
+        )
+
+    return OntologyCreditConfig(
+        semantic_floor=semantic_floor,
+        similarity_formula=formula_map[formula],
+    )
+
+
+def validate_hpo_graph_available() -> None:
+    """Fail fast when opt-in ontology metrics cannot load HPO graph data."""
+    ancestors, depths = load_hpo_graph_data()
+    if not ancestors or not depths:
+        raise RuntimeError(
+            "HPO graph data is required for ontology-aware metrics. "
+            "Run 'phentrieve data prepare' to generate the HPO database."
+        )
+
+
 def calculate_pair_credit(
     predicted_id: str,
     gold_id: str,
@@ -58,21 +101,23 @@ def calculate_pair_credit(
 
     distance = _ontology_distance(predicted_id, gold_id, ancestors, depths)
     if _is_descendant(predicted_id, gold_id, ancestors):
+        similarity = _safe_similarity(predicted_id, gold_id, config)
         credit = max(
             config.descendant_min,
             config.descendant_base
             - config.descendant_step_penalty * ((distance or 1) - 1),
         )
         return PairCredit(
-            predicted_id, gold_id, credit, MatchKind.DESCENDANT, 0.0, distance
+            predicted_id, gold_id, credit, MatchKind.DESCENDANT, similarity, distance
         )
     if _is_descendant(gold_id, predicted_id, ancestors):
+        similarity = _safe_similarity(predicted_id, gold_id, config)
         credit = max(
             config.ancestor_min,
             config.ancestor_base - config.ancestor_step_penalty * ((distance or 1) - 1),
         )
         return PairCredit(
-            predicted_id, gold_id, credit, MatchKind.ANCESTOR, 0.0, distance
+            predicted_id, gold_id, credit, MatchKind.ANCESTOR, similarity, distance
         )
 
     similarity = _safe_similarity(predicted_id, gold_id, config)
@@ -144,7 +189,7 @@ def _ancestor_distances(
     queue = deque([term_id])
     while queue:
         current = queue.popleft()
-        for parent in _parents_of(current, ancestors, depths):
+        for parent in _parents_of(current, ancestors):
             if parent in distances:
                 continue
             distances[parent] = distances[current] + 1
@@ -153,16 +198,17 @@ def _ancestor_distances(
     return distances
 
 
-def _parents_of(
-    term_id: str,
-    ancestors: dict[str, set[str]],
-    depths: dict[str, int],
-) -> set[str]:
+def _parents_of(term_id: str, ancestors: dict[str, set[str]]) -> set[str]:
+    cache_key = (id(ancestors), term_id)
+    if cache_key in _PARENTS_CACHE:
+        return _PARENTS_CACHE[cache_key]
+
     proper_ancestors = ancestors.get(term_id, set()) - {term_id}
     if not proper_ancestors:
-        return set()
+        _PARENTS_CACHE[cache_key] = set()
+        return _PARENTS_CACHE[cache_key]
 
-    return {
+    parents = {
         ancestor
         for ancestor in proper_ancestors
         if not any(
@@ -171,6 +217,8 @@ def _parents_of(
             if other_ancestor != ancestor
         )
     }
+    _PARENTS_CACHE[cache_key] = parents
+    return parents
 
 
 def _sibling_or_cousin(
@@ -179,8 +227,8 @@ def _sibling_or_cousin(
     ancestors: dict[str, set[str]],
     depths: dict[str, int],
 ) -> MatchKind | None:
-    parents_a = _parents_of(term_a, ancestors, depths)
-    parents_b = _parents_of(term_b, ancestors, depths)
+    parents_a = _parents_of(term_a, ancestors)
+    parents_b = _parents_of(term_b, ancestors)
     if not parents_a or not parents_b:
         return None
 
@@ -188,11 +236,11 @@ def _sibling_or_cousin(
         return MatchKind.SIBLING
 
     for parent_a in parents_a:
-        grand_parents_a = _parents_of(parent_a, ancestors, depths)
+        grand_parents_a = _parents_of(parent_a, ancestors)
         if not grand_parents_a:
             continue
         for parent_b in parents_b:
-            if grand_parents_a.intersection(_parents_of(parent_b, ancestors, depths)):
+            if grand_parents_a.intersection(_parents_of(parent_b, ancestors)):
                 return MatchKind.COUSIN
 
     return None
@@ -210,6 +258,12 @@ def _safe_similarity(
             config.similarity_formula,
         )
     except Exception:
+        logger.warning(
+            "Failed to calculate semantic similarity for %s vs %s",
+            predicted_id,
+            gold_id,
+            exc_info=True,
+        )
         return 0.0
 
     if not math.isfinite(similarity):

--- a/phentrieve/evaluation/ontology_credit.py
+++ b/phentrieve/evaluation/ontology_credit.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import math
+from collections import deque
+from dataclasses import dataclass
+from enum import Enum
+
+from phentrieve.evaluation.metrics import (
+    SimilarityFormula,
+    calculate_semantic_similarity,
+    load_hpo_graph_data,
+)
+
+
+class MatchKind(str, Enum):  # noqa: UP042 - Python 3.10 compatible enum.
+    EXACT = "exact"
+    DESCENDANT = "descendant"
+    ANCESTOR = "ancestor"
+    SIBLING = "sibling"
+    COUSIN = "cousin"
+    SEMANTIC = "semantic"
+    UNRELATED = "unrelated"
+
+
+@dataclass(frozen=True)
+class OntologyCreditConfig:
+    semantic_floor: float = 0.30
+    descendant_base: float = 0.95
+    descendant_step_penalty: float = 0.05
+    descendant_min: float = 0.75
+    ancestor_base: float = 0.85
+    ancestor_step_penalty: float = 0.08
+    ancestor_min: float = 0.50
+    sibling_min: float = 0.65
+    cousin_min: float = 0.45
+    similarity_formula: SimilarityFormula = SimilarityFormula.HYBRID
+
+
+@dataclass(frozen=True)
+class PairCredit:
+    predicted_id: str
+    gold_id: str
+    credit: float
+    match_kind: MatchKind
+    semantic_similarity: float
+    distance: int | None
+
+
+def calculate_pair_credit(
+    predicted_id: str,
+    gold_id: str,
+    config: OntologyCreditConfig | None = None,
+) -> PairCredit:
+    config = config or OntologyCreditConfig()
+    ancestors, depths = load_hpo_graph_data()
+    if predicted_id == gold_id:
+        return PairCredit(predicted_id, gold_id, 1.0, MatchKind.EXACT, 1.0, 0)
+
+    distance = _ontology_distance(predicted_id, gold_id, ancestors, depths)
+    if _is_descendant(predicted_id, gold_id, ancestors):
+        credit = max(
+            config.descendant_min,
+            config.descendant_base
+            - config.descendant_step_penalty * ((distance or 1) - 1),
+        )
+        return PairCredit(
+            predicted_id, gold_id, credit, MatchKind.DESCENDANT, 0.0, distance
+        )
+    if _is_descendant(gold_id, predicted_id, ancestors):
+        credit = max(
+            config.ancestor_min,
+            config.ancestor_base - config.ancestor_step_penalty * ((distance or 1) - 1),
+        )
+        return PairCredit(
+            predicted_id, gold_id, credit, MatchKind.ANCESTOR, 0.0, distance
+        )
+
+    similarity = _safe_similarity(predicted_id, gold_id, config)
+    relationship = _sibling_or_cousin(predicted_id, gold_id, ancestors, depths)
+    if relationship == MatchKind.SIBLING:
+        return PairCredit(
+            predicted_id,
+            gold_id,
+            max(similarity, config.sibling_min),
+            MatchKind.SIBLING,
+            similarity,
+            distance,
+        )
+    if relationship == MatchKind.COUSIN:
+        return PairCredit(
+            predicted_id,
+            gold_id,
+            max(similarity, config.cousin_min),
+            MatchKind.COUSIN,
+            similarity,
+            distance,
+        )
+    if similarity >= config.semantic_floor:
+        return PairCredit(
+            predicted_id, gold_id, similarity, MatchKind.SEMANTIC, similarity, distance
+        )
+    return PairCredit(
+        predicted_id, gold_id, 0.0, MatchKind.UNRELATED, similarity, distance
+    )
+
+
+def _is_descendant(
+    child: str,
+    parent: str,
+    ancestors: dict[str, set[str]],
+) -> bool:
+    return child != parent and parent in ancestors.get(child, set())
+
+
+def _ontology_distance(
+    term_a: str,
+    term_b: str,
+    ancestors: dict[str, set[str]],
+    depths: dict[str, int],
+) -> int | None:
+    distances_a = _ancestor_distances(term_a, ancestors, depths)
+    distances_b = _ancestor_distances(term_b, ancestors, depths)
+    if not distances_a or not distances_b:
+        return None
+
+    common_ancestors = set(distances_a).intersection(distances_b)
+    if not common_ancestors:
+        return None
+
+    return min(
+        distances_a[ancestor] + distances_b[ancestor] for ancestor in common_ancestors
+    )
+
+
+def _ancestor_distances(
+    term_id: str,
+    ancestors: dict[str, set[str]],
+    depths: dict[str, int],
+) -> dict[str, int]:
+    if term_id not in ancestors:
+        return {}
+
+    distances = {term_id: 0}
+    queue = deque([term_id])
+    while queue:
+        current = queue.popleft()
+        for parent in _parents_of(current, ancestors, depths):
+            if parent in distances:
+                continue
+            distances[parent] = distances[current] + 1
+            queue.append(parent)
+
+    return distances
+
+
+def _parents_of(
+    term_id: str,
+    ancestors: dict[str, set[str]],
+    depths: dict[str, int],
+) -> set[str]:
+    proper_ancestors = ancestors.get(term_id, set()) - {term_id}
+    if not proper_ancestors:
+        return set()
+
+    return {
+        ancestor
+        for ancestor in proper_ancestors
+        if not any(
+            ancestor in ancestors.get(other_ancestor, set())
+            for other_ancestor in proper_ancestors
+            if other_ancestor != ancestor
+        )
+    }
+
+
+def _sibling_or_cousin(
+    term_a: str,
+    term_b: str,
+    ancestors: dict[str, set[str]],
+    depths: dict[str, int],
+) -> MatchKind | None:
+    parents_a = _parents_of(term_a, ancestors, depths)
+    parents_b = _parents_of(term_b, ancestors, depths)
+    if not parents_a or not parents_b:
+        return None
+
+    if parents_a.intersection(parents_b):
+        return MatchKind.SIBLING
+
+    for parent_a in parents_a:
+        grand_parents_a = _parents_of(parent_a, ancestors, depths)
+        if not grand_parents_a:
+            continue
+        for parent_b in parents_b:
+            if grand_parents_a.intersection(_parents_of(parent_b, ancestors, depths)):
+                return MatchKind.COUSIN
+
+    return None
+
+
+def _safe_similarity(
+    predicted_id: str,
+    gold_id: str,
+    config: OntologyCreditConfig,
+) -> float:
+    try:
+        similarity = calculate_semantic_similarity(
+            predicted_id,
+            gold_id,
+            config.similarity_formula,
+        )
+    except Exception:
+        return 0.0
+
+    if not math.isfinite(similarity):
+        return 0.0
+    return max(0.0, min(1.0, similarity))

--- a/phentrieve/evaluation/ontology_matching.py
+++ b/phentrieve/evaluation/ontology_matching.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+
+import networkx as nx
+from networkx.algorithms.matching import max_weight_matching
+
+from phentrieve.evaluation.extraction_metrics import ExtractionResult
+from phentrieve.evaluation.ontology_credit import (
+    OntologyCreditConfig,
+    PairCredit,
+    calculate_pair_credit,
+)
+
+Annotation = tuple[str, str]
+
+
+@dataclass(frozen=True)
+class MatchedPair:
+    predicted: Annotation
+    gold: Annotation
+    credit: PairCredit
+
+
+@dataclass(frozen=True)
+class DocumentOntologyMetrics:
+    doc_id: str
+    prediction_count: int
+    gold_count: int
+    strict_tp: int
+    soft_tp: float
+    soft_fp: float
+    soft_fn: float
+    soft_precision: float
+    soft_recall: float
+    soft_f1: float
+    partial_precision: float
+    partial_recall: float
+    partial_f1: float
+    matches: list[MatchedPair]
+    unmatched_predictions: list[Annotation]
+    unmatched_gold: list[Annotation]
+
+
+def calculate_document_ontology_metrics(
+    result: ExtractionResult,
+    config: OntologyCreditConfig | None = None,
+) -> DocumentOntologyMetrics:
+    predictions = _unique_annotations(result.predicted)
+    gold = _unique_annotations(result.gold)
+
+    exact_matches = set(predictions).intersection(gold)
+    matches = [
+        MatchedPair(
+            predicted=annotation,
+            gold=annotation,
+            credit=calculate_pair_credit(annotation[0], annotation[0], config),
+        )
+        for annotation in predictions
+        if annotation in exact_matches
+    ]
+
+    unmatched_predictions = [
+        annotation for annotation in predictions if annotation not in exact_matches
+    ]
+    unmatched_gold = [
+        annotation for annotation in gold if annotation not in exact_matches
+    ]
+
+    matches.extend(
+        _match_remaining_by_assertion(unmatched_predictions, unmatched_gold, config)
+    )
+
+    matched_predictions = {match.predicted for match in matches}
+    matched_gold = {match.gold for match in matches}
+    final_unmatched_predictions = [
+        annotation
+        for annotation in predictions
+        if annotation not in matched_predictions
+    ]
+    final_unmatched_gold = [
+        annotation for annotation in gold if annotation not in matched_gold
+    ]
+
+    prediction_count = len(predictions)
+    gold_count = len(gold)
+    soft_tp = _clean_float(sum(match.credit.credit for match in matches))
+    soft_fp = _clean_float(prediction_count - soft_tp)
+    soft_fn = _clean_float(gold_count - soft_tp)
+    soft_precision, soft_recall, soft_f1 = _prf(soft_tp, soft_fp, soft_fn)
+    partial_precision, partial_recall, partial_f1 = _partial_diagnostics(
+        predictions,
+        gold,
+        config,
+    )
+
+    return DocumentOntologyMetrics(
+        doc_id=result.doc_id,
+        prediction_count=prediction_count,
+        gold_count=gold_count,
+        strict_tp=len(exact_matches),
+        soft_tp=soft_tp,
+        soft_fp=soft_fp,
+        soft_fn=soft_fn,
+        soft_precision=soft_precision,
+        soft_recall=soft_recall,
+        soft_f1=soft_f1,
+        partial_precision=partial_precision,
+        partial_recall=partial_recall,
+        partial_f1=partial_f1,
+        matches=matches,
+        unmatched_predictions=final_unmatched_predictions,
+        unmatched_gold=final_unmatched_gold,
+    )
+
+
+def _unique_annotations(annotations: list[Annotation]) -> list[Annotation]:
+    return list(dict.fromkeys(annotations))
+
+
+def _match_remaining_by_assertion(
+    predictions: list[Annotation],
+    gold: list[Annotation],
+    config: OntologyCreditConfig | None,
+) -> list[MatchedPair]:
+    predictions_by_assertion = _group_by_assertion(predictions)
+    gold_by_assertion = _group_by_assertion(gold)
+    matches: list[MatchedPair] = []
+
+    for assertion in predictions_by_assertion.keys() & gold_by_assertion.keys():
+        matches.extend(
+            _maximum_weight_matches(
+                predictions_by_assertion[assertion],
+                gold_by_assertion[assertion],
+                config,
+            )
+        )
+
+    return matches
+
+
+def _maximum_weight_matches(
+    predictions: list[Annotation],
+    gold: list[Annotation],
+    config: OntologyCreditConfig | None,
+) -> list[MatchedPair]:
+    graph = nx.Graph()
+    for pred_index, prediction in enumerate(predictions):
+        pred_node = ("pred", pred_index)
+        graph.add_node(pred_node, bipartite=0)
+        for gold_index, gold_annotation in enumerate(gold):
+            gold_node = ("gold", gold_index)
+            graph.add_node(gold_node, bipartite=1)
+            credit = calculate_pair_credit(prediction[0], gold_annotation[0], config)
+            if credit.credit <= 0.0:
+                continue
+            graph.add_edge(
+                pred_node,
+                gold_node,
+                weight=credit.credit,
+                predicted=prediction,
+                gold=gold_annotation,
+                credit=credit,
+            )
+
+    matched_pairs: list[MatchedPair] = []
+    for node_a, node_b in max_weight_matching(graph, weight="weight"):
+        edge_data = graph[node_a][node_b]
+        matched_pairs.append(
+            MatchedPair(
+                predicted=edge_data["predicted"],
+                gold=edge_data["gold"],
+                credit=edge_data["credit"],
+            )
+        )
+
+    return matched_pairs
+
+
+def _group_by_assertion(annotations: list[Annotation]) -> dict[str, list[Annotation]]:
+    grouped: dict[str, list[Annotation]] = defaultdict(list)
+    for annotation in annotations:
+        grouped[annotation[1]].append(annotation)
+    return dict(grouped)
+
+
+def _partial_diagnostics(
+    predictions: list[Annotation],
+    gold: list[Annotation],
+    config: OntologyCreditConfig | None,
+) -> tuple[float, float, float]:
+    gold_by_assertion = _group_by_assertion(gold)
+    predictions_by_assertion = _group_by_assertion(predictions)
+
+    prediction_scores = [
+        _best_credit(prediction, gold_by_assertion.get(prediction[1], []), config)
+        for prediction in predictions
+    ]
+    gold_scores = [
+        _best_recall_credit(
+            predictions_by_assertion.get(gold_annotation[1], []),
+            gold_annotation,
+            config,
+        )
+        for gold_annotation in gold
+    ]
+
+    partial_precision = _mean(prediction_scores)
+    partial_recall = _mean(gold_scores)
+    partial_f1 = _harmonic_mean(partial_precision, partial_recall)
+    return partial_precision, partial_recall, partial_f1
+
+
+def _best_credit(
+    source: Annotation,
+    candidates: list[Annotation],
+    config: OntologyCreditConfig | None,
+) -> float:
+    if not candidates:
+        return 0.0
+    return _clean_float(
+        max(
+            calculate_pair_credit(source[0], candidate[0], config).credit
+            for candidate in candidates
+        )
+    )
+
+
+def _best_recall_credit(
+    prediction_candidates: list[Annotation],
+    gold: Annotation,
+    config: OntologyCreditConfig | None,
+) -> float:
+    if not prediction_candidates:
+        return 0.0
+    return _clean_float(
+        max(
+            calculate_pair_credit(prediction[0], gold[0], config).credit
+            for prediction in prediction_candidates
+        )
+    )
+
+
+def _mean(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    return _clean_float(sum(values) / len(values))
+
+
+def _prf(tp: float, fp: float, fn: float) -> tuple[float, float, float]:
+    precision = tp / (tp + fp) if tp + fp > 0 else 0.0
+    recall = tp / (tp + fn) if tp + fn > 0 else 0.0
+    return (
+        _clean_float(precision),
+        _clean_float(recall),
+        _harmonic_mean(precision, recall),
+    )
+
+
+def _harmonic_mean(value_a: float, value_b: float) -> float:
+    if value_a + value_b == 0:
+        return 0.0
+    return _clean_float(2 * value_a * value_b / (value_a + value_b))
+
+
+def _clean_float(value: float) -> float:
+    return round(value, 12)

--- a/phentrieve/evaluation/ontology_matching.py
+++ b/phentrieve/evaluation/ontology_matching.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import networkx as nx
 from networkx.algorithms.matching import max_weight_matching
 
-from phentrieve.evaluation.extraction_metrics import ExtractionResult
+from phentrieve.evaluation._extraction_types import ExtractionResult
 from phentrieve.evaluation.ontology_credit import (
     MatchKind,
     OntologyCreditConfig,
@@ -50,6 +50,7 @@ def calculate_document_ontology_metrics(
 ) -> DocumentOntologyMetrics:
     predictions = _unique_annotations(result.predicted)
     gold = _unique_annotations(result.gold)
+    credit_cache: dict[tuple[str, str], PairCredit] = {}
 
     exact_matches = set(predictions).intersection(gold)
     matches = [
@@ -70,7 +71,12 @@ def calculate_document_ontology_metrics(
     ]
 
     matches.extend(
-        _match_remaining_by_assertion(unmatched_predictions, unmatched_gold, config)
+        _match_remaining_by_assertion(
+            unmatched_predictions,
+            unmatched_gold,
+            config,
+            credit_cache,
+        )
     )
     matches = sorted(matches, key=_matched_pair_sort_key)
 
@@ -95,6 +101,7 @@ def calculate_document_ontology_metrics(
         predictions,
         gold,
         config,
+        credit_cache,
     )
 
     return DocumentOntologyMetrics(
@@ -136,6 +143,7 @@ def _match_remaining_by_assertion(
     predictions: list[Annotation],
     gold: list[Annotation],
     config: OntologyCreditConfig | None,
+    credit_cache: dict[tuple[str, str], PairCredit],
 ) -> list[MatchedPair]:
     predictions_by_assertion = _group_by_assertion(predictions)
     gold_by_assertion = _group_by_assertion(gold)
@@ -147,6 +155,7 @@ def _match_remaining_by_assertion(
                 predictions_by_assertion[assertion],
                 gold_by_assertion[assertion],
                 config,
+                credit_cache,
             )
         )
 
@@ -157,6 +166,7 @@ def _maximum_weight_matches(
     predictions: list[Annotation],
     gold: list[Annotation],
     config: OntologyCreditConfig | None,
+    credit_cache: dict[tuple[str, str], PairCredit],
 ) -> list[MatchedPair]:
     graph = nx.Graph()
     for pred_index, prediction in enumerate(predictions):
@@ -165,7 +175,12 @@ def _maximum_weight_matches(
         for gold_index, gold_annotation in enumerate(gold):
             gold_node = ("gold", gold_index)
             graph.add_node(gold_node, bipartite=1)
-            credit = _pair_credit(prediction[0], gold_annotation[0], config)
+            credit = _pair_credit(
+                prediction[0],
+                gold_annotation[0],
+                config,
+                credit_cache,
+            )
             if credit.credit <= 0.0:
                 continue
             graph.add_edge(
@@ -206,12 +221,18 @@ def _partial_diagnostics(
     predictions: list[Annotation],
     gold: list[Annotation],
     config: OntologyCreditConfig | None,
+    credit_cache: dict[tuple[str, str], PairCredit],
 ) -> tuple[float, float, float]:
     gold_by_assertion = _group_by_assertion(gold)
     predictions_by_assertion = _group_by_assertion(predictions)
 
     prediction_scores = [
-        _best_credit(prediction, gold_by_assertion.get(prediction[1], []), config)
+        _best_credit(
+            prediction,
+            gold_by_assertion.get(prediction[1], []),
+            config,
+            credit_cache,
+        )
         for prediction in predictions
     ]
     gold_scores = [
@@ -219,6 +240,7 @@ def _partial_diagnostics(
             predictions_by_assertion.get(gold_annotation[1], []),
             gold_annotation,
             config,
+            credit_cache,
         )
         for gold_annotation in gold
     ]
@@ -233,12 +255,13 @@ def _best_credit(
     source: Annotation,
     candidates: list[Annotation],
     config: OntologyCreditConfig | None,
+    credit_cache: dict[tuple[str, str], PairCredit],
 ) -> float:
     if not candidates:
         return 0.0
     return _clean_float(
         max(
-            _pair_credit(source[0], candidate[0], config).credit
+            _pair_credit(source[0], candidate[0], config, credit_cache).credit
             for candidate in candidates
         )
     )
@@ -248,12 +271,13 @@ def _best_recall_credit(
     prediction_candidates: list[Annotation],
     gold: Annotation,
     config: OntologyCreditConfig | None,
+    credit_cache: dict[tuple[str, str], PairCredit],
 ) -> float:
     if not prediction_candidates:
         return 0.0
     return _clean_float(
         max(
-            _pair_credit(prediction[0], gold[0], config).credit
+            _pair_credit(prediction[0], gold[0], config, credit_cache).credit
             for prediction in prediction_candidates
         )
     )
@@ -263,10 +287,14 @@ def _pair_credit(
     predicted_id: str,
     gold_id: str,
     config: OntologyCreditConfig | None,
+    credit_cache: dict[tuple[str, str], PairCredit],
 ) -> PairCredit:
     if predicted_id == gold_id:
         return _exact_pair_credit(predicted_id)
-    return calculate_pair_credit(predicted_id, gold_id, config)
+    cache_key = (predicted_id, gold_id)
+    if cache_key not in credit_cache:
+        credit_cache[cache_key] = calculate_pair_credit(predicted_id, gold_id, config)
+    return credit_cache[cache_key]
 
 
 def _mean(values: list[float]) -> float:

--- a/phentrieve/evaluation/ontology_matching.py
+++ b/phentrieve/evaluation/ontology_matching.py
@@ -8,6 +8,7 @@ from networkx.algorithms.matching import max_weight_matching
 
 from phentrieve.evaluation.extraction_metrics import ExtractionResult
 from phentrieve.evaluation.ontology_credit import (
+    MatchKind,
     OntologyCreditConfig,
     PairCredit,
     calculate_pair_credit,
@@ -55,7 +56,7 @@ def calculate_document_ontology_metrics(
         MatchedPair(
             predicted=annotation,
             gold=annotation,
-            credit=calculate_pair_credit(annotation[0], annotation[0], config),
+            credit=_exact_pair_credit(annotation[0]),
         )
         for annotation in predictions
         if annotation in exact_matches
@@ -71,17 +72,18 @@ def calculate_document_ontology_metrics(
     matches.extend(
         _match_remaining_by_assertion(unmatched_predictions, unmatched_gold, config)
     )
+    matches = sorted(matches, key=_matched_pair_sort_key)
 
     matched_predictions = {match.predicted for match in matches}
     matched_gold = {match.gold for match in matches}
-    final_unmatched_predictions = [
+    final_unmatched_predictions = sorted(
         annotation
         for annotation in predictions
         if annotation not in matched_predictions
-    ]
-    final_unmatched_gold = [
+    )
+    final_unmatched_gold = sorted(
         annotation for annotation in gold if annotation not in matched_gold
-    ]
+    )
 
     prediction_count = len(predictions)
     gold_count = len(gold)
@@ -116,7 +118,18 @@ def calculate_document_ontology_metrics(
 
 
 def _unique_annotations(annotations: list[Annotation]) -> list[Annotation]:
-    return list(dict.fromkeys(annotations))
+    return sorted(dict.fromkeys(annotations))
+
+
+def _exact_pair_credit(hpo_id: str) -> PairCredit:
+    return PairCredit(
+        predicted_id=hpo_id,
+        gold_id=hpo_id,
+        credit=1.0,
+        match_kind=MatchKind.EXACT,
+        semantic_similarity=1.0,
+        distance=0,
+    )
 
 
 def _match_remaining_by_assertion(
@@ -128,7 +141,7 @@ def _match_remaining_by_assertion(
     gold_by_assertion = _group_by_assertion(gold)
     matches: list[MatchedPair] = []
 
-    for assertion in predictions_by_assertion.keys() & gold_by_assertion.keys():
+    for assertion in sorted(predictions_by_assertion.keys() & gold_by_assertion.keys()):
         matches.extend(
             _maximum_weight_matches(
                 predictions_by_assertion[assertion],
@@ -152,7 +165,7 @@ def _maximum_weight_matches(
         for gold_index, gold_annotation in enumerate(gold):
             gold_node = ("gold", gold_index)
             graph.add_node(gold_node, bipartite=1)
-            credit = calculate_pair_credit(prediction[0], gold_annotation[0], config)
+            credit = _pair_credit(prediction[0], gold_annotation[0], config)
             if credit.credit <= 0.0:
                 continue
             graph.add_edge(
@@ -175,7 +188,11 @@ def _maximum_weight_matches(
             )
         )
 
-    return matched_pairs
+    return sorted(matched_pairs, key=_matched_pair_sort_key)
+
+
+def _matched_pair_sort_key(match: MatchedPair) -> tuple[Annotation, Annotation]:
+    return match.predicted, match.gold
 
 
 def _group_by_assertion(annotations: list[Annotation]) -> dict[str, list[Annotation]]:
@@ -221,7 +238,7 @@ def _best_credit(
         return 0.0
     return _clean_float(
         max(
-            calculate_pair_credit(source[0], candidate[0], config).credit
+            _pair_credit(source[0], candidate[0], config).credit
             for candidate in candidates
         )
     )
@@ -236,10 +253,20 @@ def _best_recall_credit(
         return 0.0
     return _clean_float(
         max(
-            calculate_pair_credit(prediction[0], gold[0], config).credit
+            _pair_credit(prediction[0], gold[0], config).credit
             for prediction in prediction_candidates
         )
     )
+
+
+def _pair_credit(
+    predicted_id: str,
+    gold_id: str,
+    config: OntologyCreditConfig | None,
+) -> PairCredit:
+    if predicted_id == gold_id:
+        return _exact_pair_credit(predicted_id)
+    return calculate_pair_credit(predicted_id, gold_id, config)
 
 
 def _mean(values: list[float]) -> float:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "phentrieve"
-version = "0.17.3"
+version = "0.18.0"
 description = "A CLI tool for retrieving Human Phenotype Ontology (HPO) terms from clinical text using multilingual embeddings."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/integration/test_benchmark_workflow.py
+++ b/tests/integration/test_benchmark_workflow.py
@@ -1391,6 +1391,120 @@ def test_extraction_benchmark_saves_ontology_metrics_when_enabled(
     assert summary["partial_micro_f1"] == 0.5
 
 
+def test_extraction_benchmark_detailed_output_includes_ontology_pairs_when_enabled(
+    tmp_path, monkeypatch
+):
+    benchmark = ExtractionBenchmark(
+        model_name="sentence-transformers/LaBSE",
+        config=ExtractionConfig(
+            model_name="sentence-transformers/LaBSE",
+            dataset="all",
+            averaging="micro",
+            bootstrap_ci=False,
+            detailed_output=True,
+            ontology_aware_metrics=True,
+        ),
+    )
+
+    def _fake_load_benchmark_data(test_path, dataset):
+        return {
+            "metadata": {
+                "dataset_name": f"phenobert_{dataset}",
+                "source": "phenobert",
+                "total_documents": 1,
+                "total_annotations": 1,
+            },
+            "documents": [
+                {
+                    "id": "doc-1",
+                    "text": "Patient has seizures.",
+                    "gold_hpo_terms": [
+                        {
+                            "id": "HP:0001250",
+                            "label": "Seizure",
+                            "assertion": "PRESENT",
+                            "evidence_spans": [],
+                        }
+                    ],
+                    "source_dataset": dataset,
+                }
+            ],
+        }
+
+    def _fake_extract_with_details(text):
+        return [("HP:0001250", "PRESENT")], {
+            "chunk_results": [
+                {
+                    "chunk_idx": 0,
+                    "chunk_text": text,
+                    "matches": [
+                        {
+                            "id": "HP:0001250",
+                            "score": 0.91,
+                        }
+                    ],
+                }
+            ],
+            "aggregated_results": [
+                {
+                    "id": "HP:0001250",
+                    "name": "Seizure",
+                    "score": 0.91,
+                    "avg_score": 0.91,
+                }
+            ],
+            "processed_chunks": [
+                {
+                    "chunk_idx": 0,
+                    "text": text,
+                    "assertion_status": "affirmed",
+                    "start_char": 0,
+                    "end_char": len(text),
+                }
+            ],
+        }
+
+    monkeypatch.setattr(
+        "phentrieve.benchmark.extraction_benchmark.load_benchmark_data",
+        _fake_load_benchmark_data,
+    )
+    monkeypatch.setattr(
+        benchmark.extractor,
+        "extract_with_details",
+        _fake_extract_with_details,
+    )
+
+    output_dir = tmp_path / "results"
+    benchmark.run_benchmark(test_file=tmp_path, output_dir=output_dir)
+
+    detailed = json.loads(
+        (output_dir / "extraction_detailed_analysis.json").read_text(encoding="utf-8")
+    )
+    ontology_details = detailed["documents"][0]["ontology_metrics"]
+
+    assert ontology_details["soft"]["tp"] == 1.0
+    assert ontology_details["partial"]["f1"] == 1.0
+    assert ontology_details["matches"] == [
+        {
+            "predicted": {
+                "hpo_id": "HP:0001250",
+                "label": "Seizure",
+                "assertion": "PRESENT",
+            },
+            "gold": {
+                "hpo_id": "HP:0001250",
+                "label": "Seizure",
+                "assertion": "PRESENT",
+            },
+            "assertion": "PRESENT",
+            "match_kind": "exact",
+            "credit": 1.0,
+            "semantic_similarity": 1.0,
+            "distance": 0,
+        }
+    ]
+
+
 def test_extraction_benchmark_rejects_invalid_ontology_formula_before_extraction(
     tmp_path, monkeypatch
 ):

--- a/tests/integration/test_benchmark_workflow.py
+++ b/tests/integration/test_benchmark_workflow.py
@@ -1370,6 +1370,10 @@ def test_extraction_benchmark_saves_ontology_metrics_when_enabled(
         "calculate_ontology_aware_metrics",
         _fake_calculate_ontology_aware_metrics,
     )
+    monkeypatch.setattr(
+        "phentrieve.benchmark.extraction_benchmark.validate_hpo_graph_available",
+        lambda: None,
+    )
 
     output_dir = tmp_path / "results"
     benchmark.run_benchmark(test_file=tmp_path, output_dir=output_dir)
@@ -1473,6 +1477,10 @@ def test_extraction_benchmark_detailed_output_includes_ontology_pairs_when_enabl
         "extract_with_details",
         _fake_extract_with_details,
     )
+    monkeypatch.setattr(
+        "phentrieve.benchmark.extraction_benchmark.validate_hpo_graph_available",
+        lambda: None,
+    )
 
     output_dir = tmp_path / "results"
     benchmark.run_benchmark(test_file=tmp_path, output_dir=output_dir)
@@ -1503,6 +1511,35 @@ def test_extraction_benchmark_detailed_output_includes_ontology_pairs_when_enabl
             "distance": 0,
         }
     ]
+
+
+def test_extraction_benchmark_requires_hpo_graph_for_ontology_metrics(
+    tmp_path,
+    monkeypatch,
+):
+    benchmark = ExtractionBenchmark(
+        model_name="sentence-transformers/LaBSE",
+        config=ExtractionConfig(
+            model_name="sentence-transformers/LaBSE",
+            bootstrap_ci=False,
+            ontology_aware_metrics=True,
+        ),
+    )
+
+    def _fail_load_benchmark_data(test_path, dataset):
+        raise AssertionError("benchmark data should not be loaded")
+
+    monkeypatch.setattr(
+        "phentrieve.benchmark.extraction_benchmark.load_benchmark_data",
+        _fail_load_benchmark_data,
+    )
+    monkeypatch.setattr(
+        "phentrieve.evaluation.ontology_credit.load_hpo_graph_data",
+        lambda: ({}, {}),
+    )
+
+    with pytest.raises(RuntimeError, match="HPO graph data is required"):
+        benchmark.run_benchmark(test_file=tmp_path, output_dir=tmp_path / "results")
 
 
 def test_extraction_benchmark_rejects_invalid_ontology_formula_before_extraction(

--- a/tests/integration/test_benchmark_workflow.py
+++ b/tests/integration/test_benchmark_workflow.py
@@ -24,6 +24,10 @@ from phentrieve.benchmark.extraction_benchmark import (
     ExtractionConfig,
 )
 from phentrieve.benchmark.llm_cli import run_llm_benchmark_cli
+from phentrieve.evaluation.extraction_metrics import (
+    OntologyAwareCorpusMetrics,
+    OntologyMetricBlock,
+)
 from phentrieve.evaluation.runner import compare_models, run_evaluation
 from phentrieve.evaluation.statistics import (
     compare_models_with_significance,
@@ -1305,3 +1309,146 @@ def test_extraction_benchmark_uses_effective_config_overrides(tmp_path, monkeypa
     assert saved_payload["metadata"]["dataset"]["dataset_name"] == (
         "phenobert_GeneReviews"
     )
+
+
+def test_extraction_benchmark_saves_ontology_metrics_when_enabled(
+    tmp_path, monkeypatch
+):
+    benchmark = ExtractionBenchmark(
+        model_name="sentence-transformers/LaBSE",
+        config=ExtractionConfig(
+            model_name="sentence-transformers/LaBSE",
+            dataset="all",
+            averaging="micro",
+            bootstrap_ci=False,
+            ontology_aware_metrics=True,
+        ),
+    )
+
+    def _fake_load_benchmark_data(test_path, dataset):
+        return {
+            "metadata": {
+                "dataset_name": f"phenobert_{dataset}",
+                "source": "phenobert",
+                "total_documents": 1,
+                "total_annotations": 1,
+            },
+            "documents": [
+                {
+                    "id": "doc-1",
+                    "text": "Clinical text",
+                    "gold_hpo_terms": [{"id": "HP:0001250", "assertion": "PRESENT"}],
+                    "source_dataset": dataset,
+                }
+            ],
+        }
+
+    def _metric_block(value):
+        metric = {"precision": value, "recall": value, "f1": value}
+        return OntologyMetricBlock(
+            micro=dict(metric),
+            macro=dict(metric),
+            weighted=dict(metric),
+        )
+
+    def _fake_calculate_ontology_aware_metrics(self, results, config=None):
+        return OntologyAwareCorpusMetrics(
+            strict=_metric_block(0.0),
+            soft=_metric_block(0.75),
+            partial=_metric_block(0.5),
+            match_breakdown={},
+            document_metrics=[],
+        )
+
+    monkeypatch.setattr(
+        "phentrieve.benchmark.extraction_benchmark.load_benchmark_data",
+        _fake_load_benchmark_data,
+    )
+    monkeypatch.setattr(benchmark.extractor, "extract", lambda text: [])
+    monkeypatch.setattr(
+        "phentrieve.evaluation.extraction_metrics.CorpusExtractionMetrics."
+        "calculate_ontology_aware_metrics",
+        _fake_calculate_ontology_aware_metrics,
+    )
+
+    output_dir = tmp_path / "results"
+    benchmark.run_benchmark(test_file=tmp_path, output_dir=output_dir)
+
+    saved_payload = json.loads(
+        (output_dir / "extraction_results.json").read_text(encoding="utf-8")
+    )
+    summary = json.loads(
+        (output_dir / "extraction_summary.json").read_text(encoding="utf-8")
+    )
+
+    assert saved_payload["metadata"]["config"]["ontology_aware_metrics"] is True
+    assert "ontology_metrics" in saved_payload["corpus_metrics"]
+    assert (
+        saved_payload["corpus_metrics"]["ontology_metrics"]["soft"]["micro"]["f1"]
+        == 0.75
+    )
+    assert summary["soft_micro_f1"] == 0.75
+    assert summary["partial_micro_f1"] == 0.5
+
+
+def test_extraction_benchmark_rejects_invalid_ontology_formula_before_extraction(
+    tmp_path, monkeypatch
+):
+    benchmark = ExtractionBenchmark(
+        model_name="sentence-transformers/LaBSE",
+        config=ExtractionConfig(
+            model_name="sentence-transformers/LaBSE",
+            dataset="all",
+            averaging="micro",
+            bootstrap_ci=False,
+            ontology_aware_metrics=True,
+            ontology_similarity_formula="invalid_formula",
+        ),
+    )
+
+    def _fail_load_benchmark_data(test_path, dataset):
+        raise AssertionError("benchmark data should not be loaded")
+
+    def _fail_extract(text):
+        raise AssertionError("extractor should not be called")
+
+    monkeypatch.setattr(
+        "phentrieve.benchmark.extraction_benchmark.load_benchmark_data",
+        _fail_load_benchmark_data,
+    )
+    monkeypatch.setattr(benchmark.extractor, "extract", _fail_extract)
+
+    with pytest.raises(ValueError, match="Invalid ontology similarity formula"):
+        benchmark.run_benchmark(test_file=tmp_path, output_dir=tmp_path / "results")
+
+
+@pytest.mark.parametrize("semantic_floor", [-0.1, 1.1])
+def test_extraction_benchmark_rejects_invalid_ontology_floor_before_extraction(
+    tmp_path, monkeypatch, semantic_floor
+):
+    benchmark = ExtractionBenchmark(
+        model_name="sentence-transformers/LaBSE",
+        config=ExtractionConfig(
+            model_name="sentence-transformers/LaBSE",
+            dataset="all",
+            averaging="micro",
+            bootstrap_ci=False,
+            ontology_aware_metrics=True,
+            ontology_semantic_floor=semantic_floor,
+        ),
+    )
+
+    def _fail_load_benchmark_data(test_path, dataset):
+        raise AssertionError("benchmark data should not be loaded")
+
+    def _fail_extract(text):
+        raise AssertionError("extractor should not be called")
+
+    monkeypatch.setattr(
+        "phentrieve.benchmark.extraction_benchmark.load_benchmark_data",
+        _fail_load_benchmark_data,
+    )
+    monkeypatch.setattr(benchmark.extractor, "extract", _fail_extract)
+
+    with pytest.raises(ValueError, match="ontology_semantic_floor"):
+        benchmark.run_benchmark(test_file=tmp_path, output_dir=tmp_path / "results")

--- a/tests/unit/benchmark/test_extraction_reporter.py
+++ b/tests/unit/benchmark/test_extraction_reporter.py
@@ -1,0 +1,29 @@
+import pytest
+
+from phentrieve.benchmark.extraction_reporter import ExtractionReporter
+
+pytestmark = pytest.mark.unit
+
+
+def test_markdown_report_includes_ontology_metric_columns():
+    reporter = ExtractionReporter(output_format="markdown")
+
+    report = reporter.generate_report(
+        [
+            {
+                "metadata": {"model": "demo-model"},
+                "corpus_metrics": {
+                    "micro": {"precision": 0.5, "recall": 0.6, "f1": 0.55},
+                    "macro": {"f1": 0.45},
+                    "ontology_metrics": {
+                        "soft": {"micro": {"f1": 0.75}},
+                        "partial": {"micro": {"f1": 0.80}},
+                    },
+                },
+            }
+        ]
+    )
+
+    assert "Soft Micro F1" in report
+    assert "Partial Micro F1" in report
+    assert "| demo-model | 0.550 | 0.450 | 0.500 | 0.600 | 0.750 | 0.800 |" in report

--- a/tests/unit/cli/test_benchmark_commands.py
+++ b/tests/unit/cli/test_benchmark_commands.py
@@ -524,6 +524,50 @@ def test_benchmark_llm_command_passes_timeout_override(tmp_path, monkeypatch):
     assert captured["llm_timeout_seconds"] == 900
 
 
+def test_benchmark_llm_command_passes_ontology_metric_options(tmp_path, monkeypatch):
+    runner = CliRunner()
+    test_file = tmp_path / "cases.json"
+    test_file.write_text("[]", encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    def fake_run_llm_benchmark_cli(**kwargs):
+        captured.update(kwargs)
+        return {
+            "cases": 0,
+            "llm_model": kwargs["llm_model"],
+            "llm_mode": kwargs["llm_mode"],
+            "dataset": kwargs["dataset"],
+            "output_path": str(tmp_path / "result.json"),
+        }
+
+    monkeypatch.setattr(
+        "phentrieve.benchmark.llm_cli.run_llm_benchmark_cli",
+        fake_run_llm_benchmark_cli,
+    )
+
+    result = runner.invoke(
+        cli_app,
+        [
+            "benchmark",
+            "llm",
+            "--test-file",
+            str(test_file),
+            "--llm-model",
+            "gemini-3.1-flash-lite-preview",
+            "--ontology-aware-metrics",
+            "--ontology-semantic-floor",
+            "0.25",
+            "--ontology-similarity-formula",
+            "simple_resnik_like",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["ontology_aware_metrics"] is True
+    assert captured["ontology_semantic_floor"] == 0.25
+    assert captured["ontology_similarity_formula"] == "simple_resnik_like"
+
+
 # =============================================================================
 # Tests for compare_benchmarks()
 # =============================================================================

--- a/tests/unit/cli/test_benchmark_commands.py
+++ b/tests/unit/cli/test_benchmark_commands.py
@@ -257,6 +257,7 @@ def test_benchmark_extraction_run_help_exposes_ontology_metric_options():
         cli_app,
         ["benchmark", "extraction", "run", "--help"],
         env={"COLUMNS": "200"},
+        color=False,
     )
 
     assert result.exit_code == 0

--- a/tests/unit/cli/test_benchmark_commands.py
+++ b/tests/unit/cli/test_benchmark_commands.py
@@ -250,6 +250,21 @@ def test_benchmark_group_exposes_llm_subcommand():
     assert "llm" in result.stdout
 
 
+def test_benchmark_extraction_run_help_exposes_ontology_metric_options():
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli_app,
+        ["benchmark", "extraction", "run", "--help"],
+        env={"COLUMNS": "200"},
+    )
+
+    assert result.exit_code == 0
+    assert "--ontology-aware-metrics" in result.stdout
+    assert "--ontology-semantic-floor" in result.stdout
+    assert "--ontology-similarity-formula" in result.stdout
+
+
 def test_benchmark_llm_command_shows_friendly_error_for_missing_file(tmp_path):
     runner = CliRunner()
     missing_file = tmp_path / "does-not-exist.json"

--- a/tests/unit/cli/test_benchmark_commands.py
+++ b/tests/unit/cli/test_benchmark_commands.py
@@ -14,6 +14,7 @@ Following best practices:
 
 import pytest
 import typer
+from click.utils import strip_ansi
 from typer.testing import CliRunner
 
 from phentrieve.cli import app as cli_app
@@ -260,10 +261,12 @@ def test_benchmark_extraction_run_help_exposes_ontology_metric_options():
         color=False,
     )
 
+    help_text = strip_ansi(result.stdout)
+
     assert result.exit_code == 0
-    assert "--ontology-aware-metrics" in result.stdout
-    assert "--ontology-semantic-floor" in result.stdout
-    assert "--ontology-similarity-formula" in result.stdout
+    assert "--ontology-aware-metrics" in help_text
+    assert "--ontology-semantic-floor" in help_text
+    assert "--ontology-similarity-formula" in help_text
 
 
 def test_benchmark_llm_command_shows_friendly_error_for_missing_file(tmp_path):

--- a/tests/unit/evaluation/test_ontology_credit.py
+++ b/tests/unit/evaluation/test_ontology_credit.py
@@ -1,0 +1,172 @@
+import pytest
+
+from phentrieve.evaluation.ontology_credit import (
+    MatchKind,
+    OntologyCreditConfig,
+    calculate_pair_credit,
+    load_hpo_graph_data,
+)
+
+
+def test_exact_pair_receives_full_credit(monkeypatch):
+    monkeypatch.setattr(
+        "phentrieve.evaluation.ontology_credit.load_hpo_graph_data",
+        lambda: ({"HP:1": {"HP:1"}}, {"HP:1": 1}),
+    )
+
+    credit = calculate_pair_credit("HP:1", "HP:1")
+
+    assert credit.credit == 1.0
+    assert credit.match_kind == MatchKind.EXACT
+
+
+def test_direct_descendant_receives_high_credit(monkeypatch):
+    monkeypatch.setattr(
+        "phentrieve.evaluation.ontology_credit.load_hpo_graph_data",
+        lambda: (
+            {
+                "HP:parent": {"HP:root", "HP:parent"},
+                "HP:child": {"HP:root", "HP:parent", "HP:child"},
+            },
+            {"HP:root": 0, "HP:parent": 1, "HP:child": 2},
+        ),
+    )
+
+    credit = calculate_pair_credit("HP:child", "HP:parent")
+
+    assert credit.credit == 0.95
+    assert credit.match_kind == MatchKind.DESCENDANT
+    assert credit.distance == 1
+
+
+def test_direct_ancestor_receives_lower_credit(monkeypatch):
+    monkeypatch.setattr(
+        "phentrieve.evaluation.ontology_credit.load_hpo_graph_data",
+        lambda: (
+            {
+                "HP:parent": {"HP:root", "HP:parent"},
+                "HP:child": {"HP:root", "HP:parent", "HP:child"},
+            },
+            {"HP:root": 0, "HP:parent": 1, "HP:child": 2},
+        ),
+    )
+
+    credit = calculate_pair_credit("HP:parent", "HP:child")
+
+    assert credit.credit == 0.85
+    assert credit.match_kind == MatchKind.ANCESTOR
+    assert credit.distance == 1
+
+
+def test_dag_descendant_distance_uses_parent_edges_not_global_depth(monkeypatch):
+    monkeypatch.setattr(
+        "phentrieve.evaluation.ontology_credit.load_hpo_graph_data",
+        lambda: (
+            {
+                "HP:parent": {"HP:root", "HP:parent"},
+                "HP:mid": {"HP:root", "HP:parent", "HP:mid"},
+                "HP:child": {"HP:root", "HP:parent", "HP:mid", "HP:child"},
+            },
+            {"HP:root": 0, "HP:parent": 1, "HP:mid": 2, "HP:child": 2},
+        ),
+    )
+
+    credit = calculate_pair_credit("HP:child", "HP:parent")
+
+    assert credit.credit == pytest.approx(0.90)
+    assert credit.match_kind == MatchKind.DESCENDANT
+    assert credit.distance == 2
+
+
+def test_assertion_independent_sibling_credit_uses_minimum(monkeypatch):
+    monkeypatch.setattr(
+        "phentrieve.evaluation.ontology_credit.load_hpo_graph_data",
+        lambda: (
+            {
+                "HP:a": {"HP:root", "HP:parent", "HP:a"},
+                "HP:b": {"HP:root", "HP:parent", "HP:b"},
+                "HP:parent": {"HP:root", "HP:parent"},
+            },
+            {"HP:root": 0, "HP:parent": 1, "HP:a": 2, "HP:b": 2},
+        ),
+    )
+    monkeypatch.setattr(
+        "phentrieve.evaluation.ontology_credit.calculate_semantic_similarity",
+        lambda *_args, **_kwargs: 0.2,
+    )
+
+    credit = calculate_pair_credit("HP:a", "HP:b")
+
+    assert credit.credit == 0.65
+    assert credit.match_kind == MatchKind.SIBLING
+
+
+def test_dag_terms_sharing_non_parent_ancestor_are_not_siblings(monkeypatch):
+    monkeypatch.setattr(
+        "phentrieve.evaluation.ontology_credit.load_hpo_graph_data",
+        lambda: (
+            {
+                "HP:p": {"HP:root", "HP:p"},
+                "HP:q": {"HP:root", "HP:p", "HP:q"},
+                "HP:r": {"HP:root", "HP:p", "HP:r"},
+                "HP:a": {"HP:root", "HP:p", "HP:q", "HP:a"},
+                "HP:b": {"HP:root", "HP:p", "HP:r", "HP:b"},
+            },
+            {
+                "HP:root": 0,
+                "HP:p": 1,
+                "HP:q": 2,
+                "HP:r": 2,
+                "HP:a": 2,
+                "HP:b": 2,
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        "phentrieve.evaluation.ontology_credit.calculate_semantic_similarity",
+        lambda *_args, **_kwargs: 0.2,
+    )
+
+    credit = calculate_pair_credit("HP:a", "HP:b")
+
+    assert credit.credit == 0.45
+    assert credit.match_kind == MatchKind.COUSIN
+
+
+def test_unrelated_below_floor_receives_zero(monkeypatch):
+    monkeypatch.setattr(
+        "phentrieve.evaluation.ontology_credit.load_hpo_graph_data",
+        lambda: (
+            {
+                "HP:a": {"HP:root", "HP:a"},
+                "HP:b": {"HP:other", "HP:b"},
+            },
+            {"HP:root": 0, "HP:other": 0, "HP:a": 1, "HP:b": 1},
+        ),
+    )
+    monkeypatch.setattr(
+        "phentrieve.evaluation.ontology_credit.calculate_semantic_similarity",
+        lambda *_args, **_kwargs: 0.29,
+    )
+
+    credit = calculate_pair_credit("HP:a", "HP:b")
+
+    assert credit.credit == 0.0
+    assert credit.match_kind == MatchKind.UNRELATED
+
+
+def test_real_hpo_intellectual_disability_child_credit():
+    ancestors, _ = load_hpo_graph_data()
+    if not ancestors:
+        pytest.skip("HPO graph data is not available")
+    if "HP:0001256" not in ancestors or "HP:0001249" not in ancestors:
+        pytest.skip("Real HPO graph data lacks required test terms")
+
+    credit = calculate_pair_credit(
+        "HP:0001256",
+        "HP:0001249",
+        OntologyCreditConfig(semantic_floor=0.30),
+    )
+
+    assert credit.match_kind == MatchKind.DESCENDANT
+    assert credit.credit >= 0.90

--- a/tests/unit/evaluation/test_ontology_credit.py
+++ b/tests/unit/evaluation/test_ontology_credit.py
@@ -1,8 +1,10 @@
 import pytest
 
+from phentrieve.evaluation.metrics import SimilarityFormula
 from phentrieve.evaluation.ontology_credit import (
     MatchKind,
     OntologyCreditConfig,
+    build_ontology_credit_config,
     calculate_pair_credit,
     load_hpo_graph_data,
 )
@@ -37,6 +39,28 @@ def test_direct_descendant_receives_high_credit(monkeypatch):
     assert credit.credit == 0.95
     assert credit.match_kind == MatchKind.DESCENDANT
     assert credit.distance == 1
+
+
+def test_descendant_credit_records_semantic_similarity(monkeypatch):
+    monkeypatch.setattr(
+        "phentrieve.evaluation.ontology_credit.load_hpo_graph_data",
+        lambda: (
+            {
+                "HP:parent": {"HP:root", "HP:parent"},
+                "HP:child": {"HP:root", "HP:parent", "HP:child"},
+            },
+            {"HP:root": 0, "HP:parent": 1, "HP:child": 2},
+        ),
+    )
+    monkeypatch.setattr(
+        "phentrieve.evaluation.ontology_credit.calculate_semantic_similarity",
+        lambda *_args, **_kwargs: 0.42,
+    )
+
+    credit = calculate_pair_credit("HP:child", "HP:parent")
+
+    assert credit.match_kind == MatchKind.DESCENDANT
+    assert credit.semantic_similarity == pytest.approx(0.42)
 
 
 def test_direct_ancestor_receives_lower_credit(monkeypatch):
@@ -153,6 +177,60 @@ def test_unrelated_below_floor_receives_zero(monkeypatch):
 
     assert credit.credit == 0.0
     assert credit.match_kind == MatchKind.UNRELATED
+
+
+def test_semantic_similarity_failures_are_logged(monkeypatch, caplog):
+    monkeypatch.setattr(
+        "phentrieve.evaluation.ontology_credit.load_hpo_graph_data",
+        lambda: (
+            {
+                "HP:a": {"HP:root", "HP:a"},
+                "HP:b": {"HP:other", "HP:b"},
+            },
+            {"HP:root": 0, "HP:other": 0, "HP:a": 1, "HP:b": 1},
+        ),
+    )
+
+    def fail_similarity(*_args, **_kwargs):
+        raise RuntimeError("similarity backend failed")
+
+    monkeypatch.setattr(
+        "phentrieve.evaluation.ontology_credit.calculate_semantic_similarity",
+        fail_similarity,
+    )
+
+    with caplog.at_level("WARNING"):
+        credit = calculate_pair_credit("HP:a", "HP:b")
+
+    assert credit.match_kind == MatchKind.UNRELATED
+    assert "Failed to calculate semantic similarity" in caplog.text
+
+
+def test_build_ontology_credit_config_validates_options():
+    config = build_ontology_credit_config(
+        semantic_floor=0.25,
+        similarity_formula="simple_resnik_like",
+    )
+
+    assert config.semantic_floor == 0.25
+    assert config.similarity_formula == SimilarityFormula.SIMPLE_RESNIK_LIKE
+
+
+@pytest.mark.parametrize("semantic_floor", [-0.1, 1.1])
+def test_build_ontology_credit_config_rejects_invalid_floor(semantic_floor):
+    with pytest.raises(ValueError, match="ontology_semantic_floor"):
+        build_ontology_credit_config(
+            semantic_floor=semantic_floor,
+            similarity_formula="hybrid",
+        )
+
+
+def test_build_ontology_credit_config_rejects_invalid_formula():
+    with pytest.raises(ValueError, match="Invalid ontology similarity formula"):
+        build_ontology_credit_config(
+            semantic_floor=0.25,
+            similarity_formula="simple",
+        )
 
 
 def test_real_hpo_intellectual_disability_child_credit():

--- a/tests/unit/evaluation/test_ontology_matching.py
+++ b/tests/unit/evaluation/test_ontology_matching.py
@@ -1,0 +1,108 @@
+from phentrieve.evaluation.extraction_metrics import ExtractionResult
+from phentrieve.evaluation.ontology_credit import MatchKind, PairCredit
+from phentrieve.evaluation.ontology_matching import (
+    calculate_document_ontology_metrics,
+)
+
+
+def _fake_credit(
+    predicted_id: str,
+    gold_id: str,
+    credit: float,
+    match_kind: str,
+) -> PairCredit:
+    return PairCredit(
+        predicted_id=predicted_id,
+        gold_id=gold_id,
+        credit=credit,
+        match_kind=MatchKind(match_kind),
+        semantic_similarity=credit,
+        distance=None,
+    )
+
+
+def test_exact_document_match_scores_one(monkeypatch):
+    result = ExtractionResult(
+        doc_id="doc",
+        predicted=[("HP:1", "PRESENT")],
+        gold=[("HP:1", "PRESENT")],
+    )
+
+    metrics = calculate_document_ontology_metrics(result)
+
+    assert metrics.soft_precision == 1.0
+    assert metrics.soft_recall == 1.0
+    assert metrics.soft_f1 == 1.0
+    assert metrics.soft_tp == 1.0
+
+
+def test_partial_child_match_scores_fraction(monkeypatch):
+    monkeypatch.setattr(
+        "phentrieve.evaluation.ontology_matching.calculate_pair_credit",
+        lambda pred, gold, config=None: _fake_credit(pred, gold, 0.95, "descendant"),
+    )
+    result = ExtractionResult(
+        doc_id="doc",
+        predicted=[("HP:child", "PRESENT")],
+        gold=[("HP:parent", "PRESENT")],
+    )
+
+    metrics = calculate_document_ontology_metrics(result)
+
+    assert metrics.soft_tp == 0.95
+    assert metrics.soft_fp == 0.05
+    assert metrics.soft_fn == 0.05
+    assert metrics.soft_f1 == 0.95
+
+
+def test_assertion_mismatch_gets_no_credit(monkeypatch):
+    result = ExtractionResult(
+        doc_id="doc",
+        predicted=[("HP:1", "ABSENT")],
+        gold=[("HP:1", "PRESENT")],
+    )
+
+    metrics = calculate_document_ontology_metrics(result)
+
+    assert metrics.soft_tp == 0.0
+    assert metrics.soft_precision == 0.0
+    assert metrics.soft_recall == 0.0
+
+
+def test_one_prediction_cannot_satisfy_two_gold_terms(monkeypatch):
+    monkeypatch.setattr(
+        "phentrieve.evaluation.ontology_matching.calculate_pair_credit",
+        lambda pred, gold, config=None: _fake_credit(pred, gold, 0.9, "semantic"),
+    )
+    result = ExtractionResult(
+        doc_id="doc",
+        predicted=[("HP:p", "PRESENT")],
+        gold=[("HP:g1", "PRESENT"), ("HP:g2", "PRESENT")],
+    )
+
+    metrics = calculate_document_ontology_metrics(result)
+
+    assert metrics.soft_tp == 0.9
+    assert metrics.soft_recall == 0.45
+    assert metrics.partial_recall == 0.9
+
+
+def test_partial_recall_uses_prediction_to_gold_credit_direction(monkeypatch):
+    def directional_credit(pred, gold, config=None):
+        if pred == "HP:child" and gold == "HP:parent":
+            return _fake_credit(pred, gold, 0.95, "descendant")
+        return _fake_credit(pred, gold, 0.50, "ancestor")
+
+    monkeypatch.setattr(
+        "phentrieve.evaluation.ontology_matching.calculate_pair_credit",
+        directional_credit,
+    )
+    result = ExtractionResult(
+        doc_id="doc",
+        predicted=[("HP:child", "PRESENT")],
+        gold=[("HP:parent", "PRESENT")],
+    )
+
+    metrics = calculate_document_ontology_metrics(result)
+
+    assert metrics.partial_recall == 0.95

--- a/tests/unit/evaluation/test_ontology_matching.py
+++ b/tests/unit/evaluation/test_ontology_matching.py
@@ -36,6 +36,83 @@ def test_exact_document_match_scores_one(monkeypatch):
     assert metrics.soft_tp == 1.0
 
 
+def test_exact_document_match_does_not_calculate_pair_credit(monkeypatch):
+    def fail_pair_credit(pred, gold, config=None):
+        raise AssertionError("exact match should not calculate pair credit")
+
+    monkeypatch.setattr(
+        "phentrieve.evaluation.ontology_matching.calculate_pair_credit",
+        fail_pair_credit,
+    )
+    result = ExtractionResult(
+        doc_id="doc",
+        predicted=[("HP:1", "PRESENT")],
+        gold=[("HP:1", "PRESENT")],
+    )
+
+    metrics = calculate_document_ontology_metrics(result)
+
+    assert metrics.soft_tp == 1.0
+    assert metrics.matches[0].credit.match_kind == MatchKind.EXACT
+    assert metrics.matches[0].credit.semantic_similarity == 1.0
+    assert metrics.matches[0].credit.distance == 0
+
+
+def test_empty_document_scores_zero():
+    result = ExtractionResult(doc_id="doc", predicted=[], gold=[])
+
+    metrics = calculate_document_ontology_metrics(result)
+
+    assert metrics.prediction_count == 0
+    assert metrics.gold_count == 0
+    assert metrics.strict_tp == 0
+    assert metrics.soft_tp == 0.0
+    assert metrics.soft_fp == 0.0
+    assert metrics.soft_fn == 0.0
+    assert metrics.soft_precision == 0.0
+    assert metrics.soft_recall == 0.0
+    assert metrics.soft_f1 == 0.0
+    assert metrics.partial_precision == 0.0
+    assert metrics.partial_recall == 0.0
+    assert metrics.partial_f1 == 0.0
+    assert metrics.matches == []
+    assert metrics.unmatched_predictions == []
+    assert metrics.unmatched_gold == []
+
+
+def test_duplicate_annotations_are_deduplicated_consistently(monkeypatch):
+    monkeypatch.setattr(
+        "phentrieve.evaluation.ontology_matching.calculate_pair_credit",
+        lambda pred, gold, config=None: _fake_credit(pred, gold, 0.0, "unrelated"),
+    )
+    result = ExtractionResult(
+        doc_id="doc",
+        predicted=[
+            ("HP:2", "PRESENT"),
+            ("HP:1", "PRESENT"),
+            ("HP:1", "PRESENT"),
+        ],
+        gold=[
+            ("HP:3", "PRESENT"),
+            ("HP:1", "PRESENT"),
+            ("HP:1", "PRESENT"),
+        ],
+    )
+
+    metrics = calculate_document_ontology_metrics(result)
+
+    assert metrics.prediction_count == 2
+    assert metrics.gold_count == 2
+    assert metrics.strict_tp == 1
+    assert metrics.soft_tp == 1.0
+    assert metrics.soft_fp == 1.0
+    assert metrics.soft_fn == 1.0
+    assert len(metrics.matches) == 1
+    assert metrics.matches[0].predicted == ("HP:1", "PRESENT")
+    assert metrics.unmatched_predictions == [("HP:2", "PRESENT")]
+    assert metrics.unmatched_gold == [("HP:3", "PRESENT")]
+
+
 def test_partial_child_match_scores_fraction(monkeypatch):
     monkeypatch.setattr(
         "phentrieve.evaluation.ontology_matching.calculate_pair_credit",

--- a/tests/unit/evaluation/test_ontology_matching.py
+++ b/tests/unit/evaluation/test_ontology_matching.py
@@ -183,3 +183,30 @@ def test_partial_recall_uses_prediction_to_gold_credit_direction(monkeypatch):
     metrics = calculate_document_ontology_metrics(result)
 
     assert metrics.partial_recall == 0.95
+
+
+def test_document_matching_memoizes_pair_credit(monkeypatch):
+    calls = []
+
+    def counting_credit(pred, gold, config=None):
+        calls.append((pred, gold))
+        return _fake_credit(pred, gold, 0.5, "semantic")
+
+    monkeypatch.setattr(
+        "phentrieve.evaluation.ontology_matching.calculate_pair_credit",
+        counting_credit,
+    )
+    result = ExtractionResult(
+        doc_id="doc",
+        predicted=[("HP:p1", "PRESENT"), ("HP:p2", "PRESENT")],
+        gold=[("HP:g1", "PRESENT"), ("HP:g2", "PRESENT")],
+    )
+
+    calculate_document_ontology_metrics(result)
+
+    assert sorted(calls) == [
+        ("HP:p1", "HP:g1"),
+        ("HP:p1", "HP:g2"),
+        ("HP:p2", "HP:g1"),
+        ("HP:p2", "HP:g2"),
+    ]

--- a/tests/unit/test_extraction_metrics.py
+++ b/tests/unit/test_extraction_metrics.py
@@ -1,6 +1,7 @@
 """Tests for extraction metrics module."""
 
 import json
+from dataclasses import replace as dataclass_replace
 
 import pytest
 
@@ -212,6 +213,27 @@ class TestCorpusExtractionMetrics:
         assert metrics.micro["f1"] == 1.0
         assert metrics.macro["f1"] == 1.0
         assert metrics.weighted["f1"] == 1.0
+        assert metrics.ontology_metrics is None
+
+    def test_corpus_metrics_explicitly_preserves_ontology_metrics_on_replace(
+        self,
+    ):
+        """Ontology metrics are part of the dataclass schema, not a dynamic attr."""
+        evaluator = CorpusExtractionMetrics()
+        strict_metrics = evaluator.calculate_all_metrics(
+            [ExtractionResult("doc1", [("HP:1", "PRESENT")], [("HP:1", "PRESENT")])]
+        )
+        ontology_metrics = evaluator.calculate_ontology_aware_metrics(
+            [ExtractionResult("doc1", [("HP:1", "PRESENT")], [("HP:1", "PRESENT")])]
+        )
+
+        strict_metrics.ontology_metrics = ontology_metrics
+        replaced = dataclass_replace(
+            strict_metrics,
+            confidence_intervals={"f1": (0.9, 1.0)},
+        )
+
+        assert replaced.ontology_metrics is ontology_metrics
 
     def test_empty_results(self):
         """Test with empty results."""

--- a/tests/unit/test_extraction_metrics.py
+++ b/tests/unit/test_extraction_metrics.py
@@ -11,6 +11,7 @@ from phentrieve.evaluation.extraction_metrics import (
     _doc_metrics,
 )
 from phentrieve.evaluation.ontology_credit import MatchKind, PairCredit
+from phentrieve.evaluation.ontology_matching import DocumentOntologyMetrics
 
 pytestmark = pytest.mark.unit
 
@@ -28,6 +29,40 @@ def _fake_credit(
         match_kind=MatchKind(match_kind),
         semantic_similarity=credit,
         distance=None,
+    )
+
+
+def _document_metrics(
+    doc_id: str,
+    prediction_count: int,
+    gold_count: int,
+    soft_tp: float,
+    soft_fp: float,
+    soft_fn: float,
+    soft_precision: float,
+    soft_recall: float,
+    soft_f1: float,
+    partial_precision: float,
+    partial_recall: float,
+    partial_f1: float,
+) -> DocumentOntologyMetrics:
+    return DocumentOntologyMetrics(
+        doc_id=doc_id,
+        prediction_count=prediction_count,
+        gold_count=gold_count,
+        strict_tp=0,
+        soft_tp=soft_tp,
+        soft_fp=soft_fp,
+        soft_fn=soft_fn,
+        soft_precision=soft_precision,
+        soft_recall=soft_recall,
+        soft_f1=soft_f1,
+        partial_precision=partial_precision,
+        partial_recall=partial_recall,
+        partial_f1=partial_f1,
+        matches=[],
+        unmatched_predictions=[],
+        unmatched_gold=[],
     )
 
 
@@ -294,6 +329,83 @@ class TestCorpusExtractionMetrics:
         for breakdown in metrics.match_breakdown.values():
             assert isinstance(breakdown["count"], int)
             assert isinstance(breakdown["credit"], float)
+
+    def test_calculate_ontology_aware_metrics_numeric_aggregation(self, monkeypatch):
+        """Ontology-aware corpus metrics use the documented aggregation rules."""
+        document_metrics = {
+            "doc1": _document_metrics(
+                doc_id="doc1",
+                prediction_count=2,
+                gold_count=4,
+                soft_tp=1.5,
+                soft_fp=0.5,
+                soft_fn=2.5,
+                soft_precision=0.75,
+                soft_recall=0.375,
+                soft_f1=0.5,
+                partial_precision=0.5,
+                partial_recall=0.25,
+                partial_f1=1 / 3,
+            ),
+            "doc2": _document_metrics(
+                doc_id="doc2",
+                prediction_count=1,
+                gold_count=0,
+                soft_tp=0.0,
+                soft_fp=1.0,
+                soft_fn=0.0,
+                soft_precision=0.0,
+                soft_recall=0.0,
+                soft_f1=0.0,
+                partial_precision=1.0,
+                partial_recall=0.0,
+                partial_f1=0.0,
+            ),
+        }
+
+        monkeypatch.setattr(
+            "phentrieve.evaluation.extraction_metrics."
+            "calculate_document_ontology_metrics",
+            lambda result, config=None: document_metrics[result.doc_id],
+        )
+        evaluator = CorpusExtractionMetrics()
+        results = [
+            ExtractionResult("doc1", [("HP:1", "PRESENT")], [("HP:1", "PRESENT")]),
+            ExtractionResult("doc2", [("HP:2", "PRESENT")], []),
+        ]
+
+        metrics = evaluator.calculate_ontology_aware_metrics(results)
+
+        assert metrics.soft.micro == {
+            "precision": pytest.approx(0.5),
+            "recall": pytest.approx(0.375),
+            "f1": pytest.approx(3 / 7),
+        }
+        assert metrics.partial.micro == {
+            "precision": pytest.approx(2 / 3),
+            "recall": pytest.approx(0.25),
+            "f1": pytest.approx(4 / 11),
+        }
+        assert metrics.soft.macro == {
+            "precision": pytest.approx(0.375),
+            "recall": pytest.approx(0.1875),
+            "f1": pytest.approx(0.25),
+        }
+        assert metrics.partial.macro == {
+            "precision": pytest.approx(0.75),
+            "recall": pytest.approx(0.125),
+            "f1": pytest.approx(1 / 6),
+        }
+        assert metrics.soft.weighted == {
+            "precision": pytest.approx(0.6),
+            "recall": pytest.approx(0.3),
+            "f1": pytest.approx(0.4),
+        }
+        assert metrics.partial.weighted == {
+            "precision": pytest.approx(0.6),
+            "recall": pytest.approx(0.2),
+            "f1": pytest.approx(4 / 15),
+        }
 
     def test_serialize_ontology_metrics_returns_json_primitives(self):
         """Compact ontology metric serialization can be encoded as JSON."""

--- a/tests/unit/test_extraction_metrics.py
+++ b/tests/unit/test_extraction_metrics.py
@@ -1,5 +1,7 @@
 """Tests for extraction metrics module."""
 
+import json
+
 import pytest
 
 from phentrieve.evaluation.extraction_metrics import (
@@ -8,8 +10,25 @@ from phentrieve.evaluation.extraction_metrics import (
     _calculate_prf,
     _doc_metrics,
 )
+from phentrieve.evaluation.ontology_credit import MatchKind, PairCredit
 
 pytestmark = pytest.mark.unit
+
+
+def _fake_credit(
+    predicted_id: str,
+    gold_id: str,
+    credit: float,
+    match_kind: str,
+) -> PairCredit:
+    return PairCredit(
+        predicted_id=predicted_id,
+        gold_id=gold_id,
+        credit=credit,
+        match_kind=MatchKind(match_kind),
+        semantic_similarity=credit,
+        distance=None,
+    )
 
 
 class TestHelperFunctions:
@@ -212,6 +231,91 @@ class TestCorpusExtractionMetrics:
 
         with pytest.raises(ValueError, match="Unknown averaging strategy"):
             evaluator.calculate_metrics(results)
+
+    def test_calculate_ontology_aware_metrics_aggregates_micro(self, monkeypatch):
+        """Ontology-aware corpus metrics include strict, soft, and partial blocks."""
+        monkeypatch.setattr(
+            "phentrieve.evaluation.ontology_matching.calculate_pair_credit",
+            lambda pred, gold, config=None: _fake_credit(pred, gold, 0.0, "unrelated"),
+        )
+        evaluator = CorpusExtractionMetrics()
+        results = [
+            ExtractionResult("doc1", [("HP:1", "PRESENT")], [("HP:1", "PRESENT")]),
+            ExtractionResult("doc2", [("HP:2", "PRESENT")], [("HP:3", "PRESENT")]),
+        ]
+
+        metrics = evaluator.calculate_ontology_aware_metrics(results)
+
+        assert (
+            metrics.strict.micro["f1"]
+            == evaluator.calculate_all_metrics(results).micro["f1"]
+        )
+        assert "f1" in metrics.soft.micro
+        assert "f1" in metrics.partial.micro
+
+    def test_calculate_ontology_aware_metrics_empty_results(self):
+        """Empty corpora return zero metric blocks and no document details."""
+        evaluator = CorpusExtractionMetrics()
+
+        metrics = evaluator.calculate_ontology_aware_metrics([])
+
+        zero_metrics = {"precision": 0.0, "recall": 0.0, "f1": 0.0}
+        for block in (metrics.strict, metrics.soft, metrics.partial):
+            assert block.micro == zero_metrics
+            assert block.macro == zero_metrics
+            assert block.weighted == zero_metrics
+        assert metrics.match_breakdown == {}
+        assert metrics.document_metrics == []
+
+    def test_calculate_ontology_aware_metrics_match_breakdown_shape(self, monkeypatch):
+        """Match breakdown counts matched pairs and sums credit by match kind."""
+        monkeypatch.setattr(
+            "phentrieve.evaluation.ontology_matching.calculate_pair_credit",
+            lambda pred, gold, config=None: _fake_credit(
+                pred, gold, 0.95, "descendant"
+            ),
+        )
+        evaluator = CorpusExtractionMetrics()
+        results = [
+            ExtractionResult("doc1", [("HP:1", "PRESENT")], [("HP:1", "PRESENT")]),
+            ExtractionResult(
+                "doc2",
+                [("HP:child", "PRESENT")],
+                [("HP:parent", "PRESENT")],
+            ),
+        ]
+
+        metrics = evaluator.calculate_ontology_aware_metrics(results)
+
+        assert metrics.match_breakdown == {
+            "descendant": {"count": 1, "credit": pytest.approx(0.95)},
+            "exact": {"count": 1, "credit": pytest.approx(1.0)},
+        }
+        for breakdown in metrics.match_breakdown.values():
+            assert isinstance(breakdown["count"], int)
+            assert isinstance(breakdown["credit"], float)
+
+    def test_serialize_ontology_metrics_returns_json_primitives(self):
+        """Compact ontology metric serialization can be encoded as JSON."""
+        from phentrieve.evaluation.extraction_metrics import (
+            serialize_ontology_metrics,
+        )
+
+        evaluator = CorpusExtractionMetrics()
+        metrics = evaluator.calculate_ontology_aware_metrics(
+            [
+                ExtractionResult(
+                    "doc1",
+                    [("HP:1", "PRESENT")],
+                    [("HP:1", "PRESENT")],
+                )
+            ]
+        )
+
+        serialized = serialize_ontology_metrics(metrics)
+
+        assert set(serialized) == {"strict", "soft", "partial", "match_breakdown"}
+        json.dumps(serialized)
 
 
 class TestAssertionAwareMatching:

--- a/tests/unit/test_llm_benchmark.py
+++ b/tests/unit/test_llm_benchmark.py
@@ -99,6 +99,7 @@ def test_run_llm_benchmark_includes_ontology_metrics_when_enabled(monkeypatch):
     monkeypatch.setattr(llm_benchmark, "load_benchmark_data", fake_load_benchmark_data)
     monkeypatch.setattr(llm_benchmark, "get_llm_provider", lambda llm_model: object())
     monkeypatch.setattr(llm_benchmark, "TwoPhaseLLMPipeline", _FakePipeline)
+    monkeypatch.setattr(llm_benchmark, "validate_hpo_graph_available", lambda: None)
 
     result = llm_benchmark.run_llm_benchmark(
         test_file="tests/data/en/phenobert",
@@ -111,6 +112,24 @@ def test_run_llm_benchmark_includes_ontology_metrics_when_enabled(monkeypatch):
     assert result["ontology_aware_metrics"] is True
     assert result["ontology_semantic_floor"] == 0.30
     assert result["ontology_similarity_formula"] == "hybrid"
+
+
+def test_run_llm_benchmark_requires_hpo_graph_for_ontology_metrics(monkeypatch):
+    def fail_load_benchmark_data(*_args, **_kwargs):
+        raise AssertionError("benchmark data should not load without ontology graph")
+
+    monkeypatch.setattr(llm_benchmark, "load_benchmark_data", fail_load_benchmark_data)
+    monkeypatch.setattr(
+        "phentrieve.evaluation.ontology_credit.load_hpo_graph_data",
+        lambda: ({}, {}),
+    )
+
+    with pytest.raises(RuntimeError, match="HPO graph data is required"):
+        llm_benchmark.run_llm_benchmark(
+            test_file="tests/data/en/phenobert",
+            llm_model="gemini-2.5-flash",
+            ontology_aware_metrics=True,
+        )
 
 
 def test_run_llm_benchmark_filters_to_requested_doc_ids(monkeypatch):

--- a/tests/unit/test_llm_benchmark.py
+++ b/tests/unit/test_llm_benchmark.py
@@ -70,6 +70,49 @@ def test_run_llm_benchmark_defaults_to_genereviews_dataset(monkeypatch):
     assert result["dataset_metadata"]["dataset_name"] == "phenobert_GeneReviews"
 
 
+def test_run_llm_benchmark_includes_ontology_metrics_when_enabled(monkeypatch):
+    def fake_load_benchmark_data(test_path: Path, dataset: str):
+        return {
+            "metadata": {"dataset_name": f"phenobert_{dataset}"},
+            "documents": [
+                {
+                    "id": "doc-1",
+                    "text": "Clinical text",
+                    "gold_hpo_terms": [],
+                    "source_dataset": "GeneReviews",
+                }
+            ],
+        }
+
+    class _FakePipeline:
+        def __init__(self, provider):
+            self.provider = provider
+
+        def run(self, *, text, grounded_chunks, config):
+            from phentrieve.llm.types import LLMExtractionResult, LLMMeta
+
+            return LLMExtractionResult(
+                terms=[],
+                meta=LLMMeta(llm_model=config.model, llm_mode=config.mode),
+            )
+
+    monkeypatch.setattr(llm_benchmark, "load_benchmark_data", fake_load_benchmark_data)
+    monkeypatch.setattr(llm_benchmark, "get_llm_provider", lambda llm_model: object())
+    monkeypatch.setattr(llm_benchmark, "TwoPhaseLLMPipeline", _FakePipeline)
+
+    result = llm_benchmark.run_llm_benchmark(
+        test_file="tests/data/en/phenobert",
+        llm_model="gemini-2.5-flash",
+        ontology_aware_metrics=True,
+    )
+
+    assert "ontology_metrics" in result["metrics"]["assertion_aware"]
+    assert "ontology_metrics" in result["metrics"]["id_only"]
+    assert result["ontology_aware_metrics"] is True
+    assert result["ontology_semantic_floor"] == 0.30
+    assert result["ontology_similarity_formula"] == "hybrid"
+
+
 def test_run_llm_benchmark_filters_to_requested_doc_ids(monkeypatch):
     def fake_load_benchmark_data(test_path: Path, dataset: str):
         return {
@@ -247,6 +290,48 @@ def test_run_llm_benchmark_passes_provider_to_factory(monkeypatch) -> None:
 
     assert captured["llm_provider"] == "ollama"
     assert captured["timeout_seconds"] == 900
+
+
+def test_run_llm_benchmark_rejects_invalid_ontology_formula_before_loading(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        llm_benchmark,
+        "load_benchmark_data",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("benchmark data should not be loaded")
+        ),
+    )
+
+    with pytest.raises(ValueError, match="Invalid ontology similarity formula"):
+        llm_benchmark.run_llm_benchmark(
+            test_file="tests/data/en/phenobert",
+            llm_model="gemini-2.5-flash",
+            ontology_aware_metrics=True,
+            ontology_similarity_formula="invalid_formula",
+        )
+
+
+@pytest.mark.parametrize("semantic_floor", [-0.1, 1.1])
+def test_run_llm_benchmark_rejects_invalid_ontology_floor_before_loading(
+    monkeypatch,
+    semantic_floor,
+) -> None:
+    monkeypatch.setattr(
+        llm_benchmark,
+        "load_benchmark_data",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("benchmark data should not be loaded")
+        ),
+    )
+
+    with pytest.raises(ValueError, match="ontology_semantic_floor"):
+        llm_benchmark.run_llm_benchmark(
+            test_file="tests/data/en/phenobert",
+            llm_model="gemini-2.5-flash",
+            ontology_aware_metrics=True,
+            ontology_semantic_floor=semantic_floor,
+        )
 
 
 def test_run_llm_benchmark_records_resolved_provider_base_url(monkeypatch) -> None:
@@ -2090,6 +2175,54 @@ def test_run_llm_benchmark_cli_writes_prediction_and_metrics_artifacts(
     assert (artifacts_dir / "metrics" / "benchmark_two_phase.json").exists()
 
 
+def test_run_llm_benchmark_cli_writes_ontology_metrics_artifact(tmp_path, monkeypatch):
+    test_file = tmp_path / "cases.json"
+    test_file.write_text("[]", encoding="utf-8")
+    output_path = tmp_path / "summary.json"
+    artifacts_dir = tmp_path / "artifacts"
+
+    monkeypatch.setattr(
+        llm_cli.llm_benchmark,
+        "run_llm_benchmark",
+        lambda **kwargs: {
+            "cases": 1,
+            "llm_model": kwargs["llm_model"],
+            "llm_mode": kwargs["llm_mode"],
+            "dataset": kwargs["dataset"],
+            "dataset_metadata": {"dataset_name": "phenobert_GeneReviews"},
+            "metrics": {
+                "assertion_aware": {
+                    "micro": {"f1": 1.0},
+                    "ontology_metrics": {
+                        "soft": {"micro": {"f1": 0.75}},
+                        "partial": {"micro": {"f1": 0.5}},
+                    },
+                },
+                "id_only": {"micro": {"f1": 1.0}},
+            },
+            "prediction_records": [],
+            "results": [{"doc_id": "doc-1"}],
+        },
+    )
+
+    result = llm_cli.run_llm_benchmark_cli(
+        test_file=str(test_file),
+        llm_model="gemini-2.5-flash",
+        output_path=str(output_path),
+        artifacts_dir=str(artifacts_dir),
+    )
+
+    metrics_path = Path(result["metrics_path"])
+    metrics_payload = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert "ontology_metrics" in metrics_payload["assertion_aware_metrics"]
+    assert (
+        metrics_payload["assertion_aware_metrics"]["ontology_metrics"]["soft"]["micro"][
+            "f1"
+        ]
+        == 0.75
+    )
+
+
 def test_run_llm_benchmark_cli_sanitizes_artifact_filenames(tmp_path, monkeypatch):
     test_file = tmp_path / "cases.json"
     test_file.write_text("[]", encoding="utf-8")
@@ -2241,6 +2374,72 @@ def test_run_llm_benchmark_cli_rejects_mismatched_checkpoint(tmp_path):
             checkpoint_path=str(checkpoint_path),
             output_path=str(tmp_path / "summary.json"),
         )
+
+
+def test_run_llm_benchmark_cli_resumes_checkpoint_without_ontology_keys(
+    tmp_path, monkeypatch
+):
+    test_file = tmp_path / "cases.json"
+    test_file.write_text("[]", encoding="utf-8")
+    checkpoint_path = tmp_path / "checkpoint.json"
+    output_path = tmp_path / "summary.json"
+    artifacts_dir = tmp_path / "artifacts"
+    checkpoint_path.write_text(
+        json.dumps(
+            {
+                "test_file": str(test_file),
+                "dataset": "GeneReviews",
+                "llm_provider": None,
+                "llm_model": "gemini-2.5-flash",
+                "llm_base_url": None,
+                "llm_timeout_seconds": None,
+                "llm_seed": None,
+                "llm_mode": "two_phase",
+                "llm_internal_mode": "whole_document_grounded",
+                "language": "en",
+                "capture_phase1_debug": False,
+                "prompt_templates_dir": None,
+                "requested_doc_ids": None,
+                "status": "running",
+                "prediction_records": [],
+                "results": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    captured_checkpoint_state: dict[str, object] = {}
+
+    def fake_run_llm_benchmark(**kwargs):
+        captured_checkpoint_state.update(kwargs["checkpoint_state"])
+        return {
+            "status": "completed",
+            "cases": 0,
+            "llm_model": kwargs["llm_model"],
+            "llm_mode": kwargs["llm_mode"],
+            "dataset": kwargs["dataset"],
+            "dataset_metadata": {"dataset_name": "phenobert_GeneReviews"},
+            "metrics": {
+                "assertion_aware": {"micro": {"f1": 0.0}},
+                "id_only": {"micro": {"f1": 0.0}},
+            },
+            "prediction_records": [],
+            "results": [],
+        }
+
+    monkeypatch.setattr(
+        llm_cli.llm_benchmark, "run_llm_benchmark", fake_run_llm_benchmark
+    )
+
+    llm_cli.run_llm_benchmark_cli(
+        test_file=str(test_file),
+        llm_model="gemini-2.5-flash",
+        checkpoint_path=str(checkpoint_path),
+        output_path=str(output_path),
+        artifacts_dir=str(artifacts_dir),
+    )
+
+    assert captured_checkpoint_state["status"] == "running"
+    assert "ontology_aware_metrics" not in captured_checkpoint_state
 
 
 def test_run_llm_benchmark_cli_overwrites_existing_output_without_checkpoint(

--- a/uv.lock
+++ b/uv.lock
@@ -2848,7 +2848,7 @@ wheels = [
 
 [[package]]
 name = "phentrieve"
-version = "0.17.3"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Summary

Adds opt-in ontology-aware benchmark metrics for both benchmark command paths:

- `phentrieve benchmark extraction run ...`
- `phentrieve benchmark llm ...`

The new options are:

- `--ontology-aware-metrics`
- `--ontology-semantic-floor`
- `--ontology-similarity-formula`

Strict exact `micro`, `macro`, and `weighted` metrics remain the default behavior. Ontology-aware output is added only when explicitly enabled.

## Changes

- Adds deterministic HPO pair-credit and document-level one-to-one ontology matching.
- Adds corpus-level strict, soft, partial, and match-breakdown aggregation.
- Wires ontology-aware metrics into extraction and LLM benchmark payloads/artifacts.
- Adds detailed matched-pair records to `extraction_detailed_analysis.json` only when both detailed output and ontology-aware metrics are enabled.
- Preserves compatibility for older LLM benchmark checkpoints that do not contain the new ontology option keys.
- Includes the active plan and spec under `.planning/`.

## Validation

- `make check`
- `make typecheck-fast`
- `make test` (`1319 passed, 12 skipped`)
