### PR TITLE
feat: CLI profiles + adaptive re-chunking (#28, #171, #148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,43 @@ together:
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **`--profile NAME`** flag on `query`, `text process`, `text interactive` (issue #28).
+  Apply a named profile from `phentrieve.yaml` to preset CLI options. See
+  [Configuration Profiles](docs/user-guide/configuration-profiles.md). Both root
+  placement (`phentrieve --profile X cmd`) and per-command placement
+  (`phentrieve cmd --profile X`) work; subcommand-level wins on conflict.
+- **`phentrieve config`** subcommand group with `list-profiles`, `show`,
+  `validate`, `path` subcommands.
+- **`--show-resolved-config`** debug flag on every command. Prints resolved
+  option values with source labels (profile/yaml/const/commandline) to stderr
+  before running.
+- **`PHENTRIEVE_PROFILE`** environment variable, equivalent to `--profile`.
+- New `phentrieve.yaml` sections: `profiles:` and `extraction:`.
+- Built-in profiles: `default` (API-matching strict defaults) and `interactive`
+  (legacy `text interactive` defaults).
+
+### Fixed
+
+- **`phentrieve text interactive`** now uses config-driven defaults (issue #171).
+  Previously hardcoded `language="en"`, `chunk_retrieval_threshold=0.3`,
+  `aggregated_term_confidence=0.35`, `num_results=5` are now read from the new
+  built-in `interactive` profile (preserving prior behavior — no migration
+  needed). Pass `--profile default` to switch to API-matching strict defaults.
+- **Frontend `DEFAULT_SIMILARITY_THRESHOLD`** aligned with the API: `0.5` → `0.3`.
+  This is a behavior change for users who relied on the frontend's stricter
+  cutoff. To recover, pass an explicit threshold in the UI.
+
+### Changed
+
+- The previously-documented `--config-profile` flag (which was never
+  implemented) is replaced by the now-real `--profile`.
+  `docs/user-guide/configuration-profiles.md` is rewritten in place to reflect
+  the actual design.
+
 ## [0.18.2] — 2026-04-25
 
 **Component versions**: phentrieve `0.18.2`, phentrieve-api `0.9.3`, phentrieve-frontend `0.8.3`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,10 @@ together:
   per-chunk retrieval quality and, when poor, subdivides the chunk into
   sentence-bounded sub-chunks, re-queries them, and merges results. Enable
   on the CLI via `phentrieve text process FILE --adaptive-rechunking` with
-  three threshold flags (`--rechunk-quality-threshold`,
-  `--rechunk-margin-threshold`, `--rechunk-score-improvement-threshold`),
-  or in `phentrieve.yaml` under the new `extraction.adaptive_rechunking:`
+  three threshold flags (`--adaptive-rechunking-quality-threshold`,
+  `--adaptive-rechunking-margin-threshold`,
+  `--adaptive-rechunking-max-depth`), or in `phentrieve.yaml` under the new
+  `extraction.adaptive_rechunking:`
   block (also surfaced as `Profile.adaptive_rechunking` for per-profile
   overrides). The API `/text/process` request schema gains an
   `adaptive_rechunking` field (request-time override), and the response's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,20 @@ together:
 - New `phentrieve.yaml` sections: `profiles:` and `extraction:`.
 - Built-in profiles: `default` (API-matching strict defaults) and `interactive`
   (legacy `text interactive` defaults).
+- **Adaptive re-chunking** (issue #148): an opt-in mechanism that detects
+  per-chunk retrieval quality and, when poor, subdivides the chunk into
+  sentence-bounded sub-chunks, re-queries them, and merges results. Enable
+  on the CLI via `phentrieve text process FILE --adaptive-rechunking` with
+  three threshold flags (`--rechunk-quality-threshold`,
+  `--rechunk-margin-threshold`, `--rechunk-score-improvement-threshold`),
+  or in `phentrieve.yaml` under the new `extraction.adaptive_rechunking:`
+  block (also surfaced as `Profile.adaptive_rechunking` for per-profile
+  overrides). The API `/text/process` request schema gains an
+  `adaptive_rechunking` field (request-time override), and the response's
+  `meta` block gains an `adaptive_rechunking` summary
+  (`triggered_chunks`, `subdivided_chunks`, `recursion_depth`, etc.) when
+  the feature runs. See
+  [docs/user-guide/adaptive-rechunking.md](docs/user-guide/adaptive-rechunking.md).
 
 ### Fixed
 
@@ -52,6 +66,12 @@ together:
   implemented) is replaced by the now-real `--profile`.
   `docs/user-guide/configuration-profiles.md` is rewritten in place to reflect
   the actual design.
+- **`orchestrate_hpo_extraction` return type**: now returns an
+  `OrchestrationResult` dataclass instead of a plain tuple. Backward
+  compatible — legacy 2-tuple unpacking via `__iter__` continues to work
+  for all existing call sites. New attribute `raw_query_results` exposes
+  the unfiltered top-K from `query_batch` for callers (e.g. adaptive
+  re-chunking) that need scores below `chunk_retrieval_threshold`.
 
 ## [0.18.2] — 2026-04-25
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Phentrieve is an advanced AI-powered system for mapping clinical text to Human P
 
 * Multilingual HPO term mapping using state-of-the-art embedding models
 * Advanced text processing pipeline including semantic chunking and assertion detection
+* Optional adaptive re-chunking improves recall on multi-concept clinical sentences (`--adaptive-rechunking`). See [docs/user-guide/adaptive-rechunking.md](docs/user-guide/adaptive-rechunking.md).
 * Extensive benchmarking framework for model evaluation and comparison
 * User-friendly interfaces: CLI, FastAPI backend, and Vue.js frontend
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,24 @@ phentrieve text process "The patient exhibits microcephaly and frequent seizures
 
 Discover more commands and options in the [User Guide](https://berntpopp.github.io/phentrieve/user-guide/).
 
+## Configuration
+
+### Configuration profiles
+
+Define named profiles in `phentrieve.yaml` to preset CLI options:
+
+```yaml
+profiles:
+  fast_query:
+    command: query
+    num_results: 5
+    similarity_threshold: 0.5
+```
+
+Then `phentrieve query "TEXT" --profile fast_query`.
+
+See [docs/user-guide/configuration-profiles.md](docs/user-guide/configuration-profiles.md) for the full guide.
+
 ## Docker Deployment
 
 Deploy Phentrieve using Docker Compose for production environments:

--- a/api/routers/text_processing_router.py
+++ b/api/routers/text_processing_router.py
@@ -40,6 +40,9 @@ from phentrieve.config import (
     DEFAULT_STEP_SIZE_TOKENS,
     DEFAULT_WINDOW_SIZE_TOKENS,
 )
+from phentrieve.retrieval.adaptive_rechunker import (
+    adaptive_config_from_profile_block,
+)
 from phentrieve.text_processing.full_text_service import run_full_text_service
 from phentrieve.text_processing.pipeline import TextProcessingPipeline
 from phentrieve.utils import detect_language
@@ -674,6 +677,12 @@ async def _process_text_via_shared_service(request: TextProcessingRequest):
                 "include_positions": request.include_chunk_positions,
             }
         )
+        if request.adaptive_rechunking is not None:
+            service_kwargs["adaptive_rechunking"] = adaptive_config_from_profile_block(
+                block=request.adaptive_rechunking,
+                yaml_block=None,
+                cli_overrides=None,
+            )
     else:
         service_kwargs.update(
             {

--- a/api/schemas/text_processing_schemas.py
+++ b/api/schemas/text_processing_schemas.py
@@ -14,6 +14,7 @@ from phentrieve.config import (
     DEFAULT_STEP_SIZE_TOKENS,
     DEFAULT_WINDOW_SIZE_TOKENS,
 )
+from phentrieve.retrieval.adaptive_rechunker import AdaptiveRechunkingProfileBlock
 
 
 class TextProcessingRequest(BaseModel):
@@ -117,6 +118,17 @@ class TextProcessingRequest(BaseModel):
     include_chunk_positions: bool = Field(
         default=False,
         description="Include character positions (start_char, end_char) for each chunk.",
+    )
+
+    # Adaptive Re-chunking (Spec B)
+    adaptive_rechunking: AdaptiveRechunkingProfileBlock | None = Field(
+        default=None,
+        description=(
+            "Optional adaptive re-chunking configuration. When provided with "
+            "enabled=true, poor-quality chunks are re-chunked at finer "
+            "granularity. The response surfaces a meta.adaptive_rechunking "
+            "summary block when the feature triggers."
+        ),
     )
 
     @model_validator(mode="after")

--- a/docs/user-guide/adaptive-rechunking.md
+++ b/docs/user-guide/adaptive-rechunking.md
@@ -1,0 +1,260 @@
+# Adaptive Re-Chunking
+
+Optional retrieval-quality-driven sub-chunking. When a chunk's retrieval is
+poor (low top-1 similarity AND low margin between top-1 and top-2), Phentrieve
+subdivides the chunk into sentence-bounded sub-chunks, re-queries each, and
+merges the results. Improves recall on multi-concept clinical sentences
+without affecting users who don't enable it.
+
+The feature is opt-in. Default behavior is unchanged.
+
+## When to Enable
+
+Enable adaptive re-chunking when:
+
+- Inputs include long multi-finding paragraphs that combine several phenotypes
+  into one sentence.
+- You want to maximize recall and accept up to ~1.5x retrieval cost on average.
+- You're using a BioLORD-class biomedical encoder (default thresholds are
+  calibrated for this family).
+
+Skip it when:
+
+- Latency matters more than recall (e.g. interactive triage).
+- Inputs are typically short single-finding sentences. The trigger rarely
+  fires and the overhead is wasted.
+- You're using a non-biomedical encoder without retuning the thresholds.
+- You're running `phentrieve text interactive`. Adaptive rechunking is not
+  wired into interactive mode in v1.
+
+## Quick Start
+
+CLI:
+
+```bash
+phentrieve text process note.txt --adaptive-rechunking
+```
+
+YAML (`phentrieve.yaml`):
+
+```yaml
+extraction:
+  adaptive_rechunking:
+    enabled: true
+    quality_threshold: 0.55
+    max_depth: 2
+```
+
+Profile (combine with [Configuration Profiles](./configuration-profiles.md)):
+
+```yaml
+profiles:
+  high_recall:
+    command: text process
+    adaptive_rechunking:
+      enabled: true
+      quality_threshold: 0.55
+```
+
+```bash
+phentrieve text process note.txt --profile high_recall
+```
+
+## How It Works
+
+The orchestration loop runs after the standard extraction completes and
+before the response is adapted. It has four steps per recursion level:
+
+1. **Detect**: For each chunk, read the unfiltered top-K from `query_batch`
+   and compute `top_1`, `top_2`, and `margin = top_1 - top_2`. A chunk flags
+   as poor when:
+
+   ```
+   top_1 < quality_threshold
+       AND (margin < margin_threshold OR top_2 is None)
+   ```
+
+   Both conditions must hold. A confident top-1 (above the quality threshold)
+   trusts the result regardless of margin; a clear-but-weak match (low score
+   but large margin) is also trusted.
+
+2. **Subdivide**: Each flagged chunk is re-chunked at sentence boundaries via
+   `SentenceChunker`, grouped into sliding windows of
+   `max_sentences_per_subchunk` sentences with `overlap_sentences` overlap.
+   Sub-chunks shorter than `min_chunk_chars` are dropped. If only one
+   sub-chunk falls out, the parent is kept (no useful subdivision).
+
+3. **Query and gate**: All accepted child chunks are queried in a single
+   batched `query_batch` call. For each parent, the score-improvement gate
+   compares the parent's `top_1` to the best child's `top_1`. Subdivisions
+   that don't lift the top-1 by `score_improvement_gate` are reverted - the
+   parent stays in the flat list and its children are dropped.
+
+4. **Re-aggregate**: A combined raw-results dict is built (kept original
+   results for non-subdivided / reverted parents, plus accepted child
+   results) and `orchestrate_hpo_extraction` is called with
+   `precomputed_query_results=combined_raw_results`. This re-runs filtering
+   and aggregation only - no new `query_batch` call.
+
+Steps 1-4 then recurse on surviving children up to `max_depth` levels.
+
+## Configuration
+
+| Knob | Default | Notes |
+|---|---|---|
+| `enabled` | `false` | Opt-in switch. |
+| `quality_threshold` | `0.55` | top-1 similarity floor. Encoder-calibrated for BioLORD. |
+| `margin_threshold` | `0.03` | Minimum top-1 minus top-2 distance. |
+| `max_depth` | `2` | Recursion cap (depth-1 = subdivide once, depth-2 = subdivide children). |
+| `min_chunk_chars` | `30` | Sub-chunks shorter than this are dropped. |
+| `max_sentences_per_subchunk` | `3` | Sliding-window size in sentences. |
+| `overlap_sentences` | `1` | Sentence-level overlap between windows. |
+| `score_improvement_gate` | `0.05` | Children below this top-1 lift over the parent are reverted. |
+| `use_ontology_coherence` | `false` | Reserved, inert in v1. See Future Work in the spec. |
+
+The full YAML schema (under the `extraction:` section):
+
+```yaml
+extraction:
+  adaptive_rechunking:
+    enabled: false                  # opt-in
+    quality_threshold: 0.55         # encoder-calibrated for BioLORD
+    margin_threshold: 0.03
+    use_ontology_coherence: false   # reserved, inert in v1
+    max_depth: 2
+    min_chunk_chars: 30
+    max_sentences_per_subchunk: 3
+    overlap_sentences: 1
+    score_improvement_gate: 0.05
+```
+
+The CLI exposes the four most-tuned knobs:
+
+- `--adaptive-rechunking` / `--no-adaptive-rechunking`
+- `--adaptive-rechunking-quality-threshold FLOAT`
+- `--adaptive-rechunking-margin-threshold FLOAT`
+- `--adaptive-rechunking-max-depth INT`
+
+Other knobs are reachable only via YAML or a profile. Resolution order is
+CLI > profile > YAML > defaults; use `--show-resolved-config` to inspect the
+final values.
+
+## Encoder Calibration Warning
+
+The default `quality_threshold` (0.55) and `margin_threshold` (0.03) are
+calibrated for BioLORD-class biomedical encoders. If you switch to a
+different `retrieval_model`, the score distribution will differ - sentence-
+transformers/LaBSE, for example, produces markedly lower cosine similarities
+on the same input - and the trigger will mis-fire (either over-firing on
+every chunk or never firing). Retune both thresholds for your encoder before
+trusting the feature.
+
+A future `phentrieve config calibrate-thresholds` subcommand will help with
+this.
+
+## Cost Envelope
+
+Two costs scale differently and shouldn't be conflated:
+
+**`query_batch` RPC count - hard invariant:**
+
+- Adaptive disabled: 1 call.
+- Enabled, no chunks flag: 1 call.
+- Enabled, chunks flag at depth 1 only: 2 calls.
+- Enabled, chunks flag at depth 1 AND surviving children flag at depth 2: 3 calls.
+
+The general bound at depth `N` is `1 + N` calls.
+
+**Encoder work - loose bound:** each `query_batch` call encodes its full
+input list. A 10-chunk document where every chunk flags through depth 2
+with three sentence-window children per parent encodes roughly
+`10 + 30 + 90 = 130` strings - about 13x the original 10. So encoder
+workload can substantially exceed the query-call multiplier.
+
+In practice fan-out is bounded by `min_chunk_chars`, the score-improvement
+gate, and the rarity of chunks that genuinely benefit from depth-2
+recursion. Empirical typical wall-time multiplier: **1.2x to 1.5x**. Worst
+case is hard to bound tightly because it depends on encoder batch
+throughput and chunk-size distribution; we don't promise a specific
+multiplier.
+
+## Worked Examples
+
+### Aggressive recall
+
+Lower the quality threshold so more chunks flag, and keep depth at 2:
+
+```yaml
+extraction:
+  adaptive_rechunking:
+    enabled: true
+    quality_threshold: 0.6
+    margin_threshold: 0.05
+    max_depth: 2
+```
+
+### Conservative cost
+
+Cap recursion at 1 and require a larger improvement before keeping
+sub-chunks:
+
+```yaml
+extraction:
+  adaptive_rechunking:
+    enabled: true
+    max_depth: 1
+    score_improvement_gate: 0.1
+```
+
+### Cross-language (German) via profile
+
+```yaml
+profiles:
+  german_recall:
+    command: text process
+    language: de
+    adaptive_rechunking:
+      enabled: true
+      quality_threshold: 0.5
+```
+
+```bash
+phentrieve text process note.txt --profile german_recall
+```
+
+## Response Metadata
+
+When enabled and triggered, the response `meta` block carries a summary:
+
+```json
+{
+  "meta": {
+    "extraction_backend": "standard",
+    "adaptive_rechunking": {
+      "enabled": true,
+      "trigger_count": 3,
+      "subdivided_count": 2,
+      "reverted_count": 1,
+      "max_depth_reached": 1,
+      "extra_chunks_added": 4
+    }
+  }
+}
+```
+
+The block is omitted entirely when adaptive rechunking is disabled.
+
+## Related Notes
+
+- The interactive command (`phentrieve text interactive`) does not currently
+  accept the adaptive rechunking flags. The feature is wired into
+  `phentrieve text process` and the API only.
+- The CLI surface intentionally exposes only four knobs. The full set is
+  reachable via YAML / profiles for tuning experiments.
+- The aggregator (`hpo_extraction_orchestrator`) is unchanged by this
+  feature. Adaptive rechunking only changes the chunk list and the raw
+  query results that feed the existing aggregator.
+- See [Configuration Profiles](./configuration-profiles.md) for how to
+  bundle adaptive-rechunking knobs into named profiles.
+- See [CLI Usage](./cli-usage.md) for the `text process` command surface.
+- See [API Usage](./api-usage.md) for the request/response schema.

--- a/docs/user-guide/api-usage.md
+++ b/docs/user-guide/api-usage.md
@@ -75,3 +75,62 @@ The HTTP API does not accept the CLI's `--profile` flag - request fields
 are explicit. If you're moving a workflow from the CLI to the API, copy the
 relevant fields from your profile into the request body. See
 [Configuration Profiles](./configuration-profiles.md) for the profile schema.
+
+## Adaptive Re-Chunking
+
+`TextProcessingRequest` accepts an optional `adaptive_rechunking` field that
+mirrors the YAML `extraction.adaptive_rechunking` block. When provided with
+`enabled: true`, poor-quality chunks are subdivided at sentence boundaries
+and re-queried. The full schema and trigger semantics are described in
+[Adaptive Re-Chunking](./adaptive-rechunking.md).
+
+Request example:
+
+```bash
+curl -X POST "http://localhost:8734/api/v1/text/process" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "text": "Patient with intellectual disability, microcephaly, seizures, and short stature.",
+    "adaptive_rechunking": {
+      "enabled": true,
+      "quality_threshold": 0.55,
+      "margin_threshold": 0.03,
+      "max_depth": 2
+    }
+  }'
+```
+
+All `adaptive_rechunking` fields are optional; omitted fields fall through
+to server-side defaults. The full set of knobs is:
+
+- `enabled` (bool, default `false`)
+- `quality_threshold` (float, default `0.55`)
+- `margin_threshold` (float, default `0.03`)
+- `max_depth` (int, default `2`)
+- `min_chunk_chars` (int, default `30`)
+- `max_sentences_per_subchunk` (int, default `3`)
+- `overlap_sentences` (int, default `1`)
+- `score_improvement_gate` (float, default `0.05`)
+- `use_ontology_coherence` (bool, default `false`; reserved, inert in v1)
+
+When the feature is enabled and triggered, the response carries a
+`meta.adaptive_rechunking` block summarizing what happened:
+
+```json
+{
+  "meta": {
+    "extraction_backend": "standard",
+    "adaptive_rechunking": {
+      "enabled": true,
+      "trigger_count": 3,
+      "subdivided_count": 2,
+      "reverted_count": 1,
+      "max_depth_reached": 1,
+      "extra_chunks_added": 4
+    }
+  }
+}
+```
+
+The block is omitted when `adaptive_rechunking` is disabled or omitted from
+the request.

--- a/docs/user-guide/api-usage.md
+++ b/docs/user-guide/api-usage.md
@@ -68,3 +68,10 @@ When the API is running, the OpenAPI pages are available at:
 
 - Swagger UI: `http://localhost:8734/docs`
 - ReDoc: `http://localhost:8734/redoc`
+
+## Profiles vs API
+
+The HTTP API does not accept the CLI's `--profile` flag - request fields
+are explicit. If you're moving a workflow from the CLI to the API, copy the
+relevant fields from your profile into the request body. See
+[Configuration Profiles](./configuration-profiles.md) for the profile schema.

--- a/docs/user-guide/cli-usage.md
+++ b/docs/user-guide/cli-usage.md
@@ -136,6 +136,20 @@ Example JSON Lines output:
 - `--profile`, `-P`: Apply a named profile from `phentrieve.yaml`. See [Configuration Profiles](./configuration-profiles.md).
 - `--show-resolved-config`: Print resolved option values with source labels to stderr before running.
 
+**Adaptive Re-Chunking Flags** (opt-in; see [Adaptive Re-Chunking](./adaptive-rechunking.md)):
+
+- `--adaptive-rechunking` / `--no-adaptive-rechunking`: Enable adaptive re-chunking for poor-quality chunks (default: disabled).
+- `--adaptive-rechunking-quality-threshold FLOAT`: Override the top-1 quality floor (default: 0.55).
+- `--adaptive-rechunking-margin-threshold FLOAT`: Override the minimum top-1 minus top-2 margin (default: 0.03).
+- `--adaptive-rechunking-max-depth INT`: Override the recursion cap (default: 2).
+
+When enabled, chunks whose retrieval is poor (low top-1 AND low margin) are
+subdivided into sentence-bounded sub-chunks and re-queried. The full set of
+knobs (e.g. `min_chunk_chars`, `score_improvement_gate`) is reachable via
+`phentrieve.yaml` or a profile. See
+[Adaptive Re-Chunking](./adaptive-rechunking.md) for the trigger semantics,
+encoder-calibration warning, cost envelope, and worked examples.
+
 **Sliding Window Parameters** (override config for all strategies using sliding window):
 - `--window-size`: Window size in tokens (default: 7)
 - `--step-size`: Step size in tokens (default: 1)

--- a/docs/user-guide/cli-usage.md
+++ b/docs/user-guide/cli-usage.md
@@ -18,6 +18,12 @@ Available for all commands:
 *   `--version`: Show version information and exit
 *   `--help`: Show help message for any command
 
+## Profiles
+
+Most commands accept `--profile NAME` to apply a preset bundle of options
+defined in `phentrieve.yaml`. See [Configuration Profiles](./configuration-profiles.md)
+for the full guide.
+
 ## Available Commands
 
 ### Data Management
@@ -61,6 +67,13 @@ phentrieve query --text "The patient shows microcephaly and seizures"
 - `--similarity-threshold`: Minimum similarity score (0-1) to show results (default: 0.3)
 - `--num-results`: Maximum number of results to display (default: 5)
 - `--model-name`: Embedding model to use (default: "FremyCompany/BioLORD-2023-M")
+- `--profile`, `-P`: Apply a named profile from `phentrieve.yaml`. See [Configuration Profiles](./configuration-profiles.md).
+- `--show-resolved-config`: Print resolved option values with source labels to stderr before running.
+
+For interactive mode (`phentrieve query --interactive`), the same `--profile`
+and `--show-resolved-config` flags apply. The built-in `interactive` profile
+is auto-selected by `phentrieve text interactive` when no `--profile` is
+given; pass `--profile default` to swap to strict thresholds.
 
 ### Text Processing
 
@@ -120,6 +133,8 @@ Example JSON Lines output:
 - `--strategy`: Chunking strategy (see above)
 - `--language`: Text language for accurate processing (en, de, es, fr, nl)
 - `--output-format`: Output format (json_lines, rich_json_summary, csv_hpo_list)
+- `--profile`, `-P`: Apply a named profile from `phentrieve.yaml`. See [Configuration Profiles](./configuration-profiles.md).
+- `--show-resolved-config`: Print resolved option values with source labels to stderr before running.
 
 **Sliding Window Parameters** (override config for all strategies using sliding window):
 - `--window-size`: Window size in tokens (default: 7)

--- a/docs/user-guide/configuration-profiles.md
+++ b/docs/user-guide/configuration-profiles.md
@@ -1,75 +1,132 @@
 # Configuration Profiles
 
-This page explains how to use and customize configuration profiles in Phentrieve.
+Phentrieve supports named profiles in `phentrieve.yaml` to preset groups of
+CLI options for common workflows.
 
-## Introduction
+## Quick Start
 
-Phentrieve uses configuration profiles to manage different settings for various use cases. These profiles help you customize the behavior of the system without modifying the code.
-
-## Default Configuration
-
-The default configuration is defined in `phentrieve/config.py` and includes settings for:
-
-- Data directories
-- Default models
-- Processing parameters
-- Logging levels
-
-## Environment Variables
-
-You can override configuration settings using environment variables:
-
-```bash
-# Set data directory
-export PHENTRIEVE_DATA_DIR=/path/to/your/data
-
-# Set default model
-export PHENTRIEVE_DEFAULT_MODEL="FremyCompany/BioLORD-2023-M"
-```
-
-## Configuration Files
-
-For more permanent configuration, you can create configuration profiles:
-
-1. Create a `.phentrieve` directory in your home folder
-2. Add a `config.yaml` file with your custom settings
-
-Example `config.yaml`:
+Create or edit `phentrieve.yaml`:
 
 ```yaml
-data:
-  base_dir: /path/to/data
-  hpo_data_dir: ${data.base_dir}/hpo_core_data
-  index_dir: ${data.base_dir}/indexes
-  results_dir: ${data.base_dir}/results
+profiles:
+  high_recall_german:
+    description: "Recall-oriented German extraction"
+    command: text process
+    language: de
+    chunk_retrieval_threshold: 0.6
+    aggregated_term_confidence: 0.7
 
-models:
-  default: "FremyCompany/BioLORD-2023-M"
-
-processing:
-  chunking_strategy: "semantic"
-  min_confidence: 0.4
-  window_size: 128
-  step_size: 64
+  fast_query:
+    command: query
+    num_results: 5
+    similarity_threshold: 0.5
 ```
 
-## Profile Selection
-
-You can switch between different configuration profiles:
+Use it:
 
 ```bash
-# Use a specific configuration profile
-phentrieve --config-profile clinical query --interactive
-
-# Specify config file directly
-phentrieve --config-file /path/to/custom-config.yaml query --interactive
+phentrieve text process note.txt --profile high_recall_german
+phentrieve query "patient with seizures" --profile fast_query
 ```
 
-## Configuration Hierarchy
+## Precedence
 
-Phentrieve uses the following hierarchy for configuration (later sources override earlier ones):
+Phentrieve resolves option values in this order (highest priority first):
 
-1. Default configuration in code
-2. Configuration files
-3. Environment variables
-4. Command-line arguments
+1. **Explicit CLI flag** - `--language fr` always wins.
+2. **Active profile** - `--profile X` or auto-selected built-in.
+3. **Top-level `phentrieve.yaml`** - entries like `default_language: de`.
+4. **Fallback constants** - defaults baked into `phentrieve/config.py`.
+
+To see the resolved values for any invocation, add `--show-resolved-config`:
+
+```bash
+phentrieve text process note.txt --profile high_recall_german --show-resolved-config
+```
+
+## Built-in Profiles
+
+Two profiles ship in code and need no configuration:
+
+- **`default`** - strict defaults matching API behavior. Used by `phentrieve query`,
+  `phentrieve text process`, and most other commands when no `--profile` is given.
+- **`interactive`** - loose discovery defaults preserving the prior `text interactive`
+  behavior. Auto-selected by `phentrieve text interactive` when no `--profile` is given.
+
+You can shadow either by name in your `phentrieve.yaml`. Pass `--profile default`
+to `phentrieve text interactive` to swap to strict thresholds.
+
+## Schema
+
+Each profile supports these keys (all optional):
+
+| Key | Type | Notes |
+|---|---|---|
+| `description` | string | Free-form description, shown by `phentrieve config list-profiles`. |
+| `command` | string | Bind the profile to a command (e.g. `"query"`, `"text process"`). |
+| `language` | string | ISO 639-1 code (e.g. `"de"`). |
+| `model_name` | string | Embedding model. |
+| `chunk_retrieval_threshold` | float | Per-chunk similarity threshold. |
+| `aggregated_term_confidence` | float | Min confidence for aggregated terms. |
+| `num_results` | int | Number of results to return. |
+| `similarity_threshold` | float | Query-mode similarity threshold. |
+| `chunking_strategy` | string | E.g. `"semantic"`, `"sliding_window_punct_conj_cleaned"`. |
+| `multi_vector` | bool | Use multi-vector retrieval. |
+
+Unknown keys cause a validation error at load time (the `extra="forbid"` rule).
+
+## Command Binding
+
+If a profile sets `command: text process`, it can only be used with that command.
+Using it with a different command produces an error. Profiles without a `command`
+field apply to any command, with keys filtered to those the active command accepts.
+
+```yaml
+profiles:
+  shared_german:
+    # No command: field - applies to any command.
+    language: de
+    semantic_chunker_model: jinaai/jina-embeddings-v2-base-de
+```
+
+## Config Inspection Commands
+
+```bash
+phentrieve config list-profiles    # show all profiles with their bindings
+phentrieve config show NAME        # print one profile as YAML
+phentrieve config validate         # validate phentrieve.yaml against the schema
+phentrieve config path             # print which phentrieve.yaml is being loaded
+```
+
+## YAML Search Path
+
+Phentrieve looks for `phentrieve.yaml` in this order:
+
+1. `./phentrieve.yaml` (current working directory) - highest priority
+2. `./phentrieve.yml`
+3. `~/.phentrieve/phentrieve.yaml` - legacy path, still supported
+4. `~/.phentrieve/config.yaml` - legacy path, still supported
+
+The first one found wins. `phentrieve config path` shows which one was loaded.
+
+## Environment Variable
+
+`PHENTRIEVE_PROFILE=NAME phentrieve <command>` is equivalent to
+`phentrieve --profile NAME <command>`. Per-option environment variables
+(e.g. `PHENTRIEVE_LANGUAGE`) are not supported in v1.
+
+## Surface Defaults Parity
+
+The frontend (`frontend/src/constants/defaults.js`) declares its own copy of
+each numeric default. These must match the Python constants in
+`phentrieve/config.py`. Drift is caught by
+`tests/unit/profiles/test_frontend_constant_parity.py`.
+
+The one intentional divergence: `DEFAULT_NUM_RESULTS_PER_CHUNK = 3` in the
+frontend (vs. backend `10`) - chosen for compact UI display.
+
+## What Replaced the Old `--config-profile` Flag
+
+The previous version of this page documented a `--config-profile` flag. That
+flag was never implemented in code. It has been replaced by the now-real
+`--profile` flag described above.

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -42,6 +42,7 @@ This User Guide section contains the following pages:
 
 - [CLI Usage](cli-usage.md): Detailed guide on using the Phentrieve command-line interface
 - [Text Processing Guide](text-processing-guide.md): How to process clinical text to extract HPO terms
+- [Adaptive Re-Chunking](adaptive-rechunking.md): Opt-in retrieval-quality-driven sub-chunking for multi-concept clinical sentences
 - [Benchmarking Guide](benchmarking-guide.md): Running and interpreting benchmarks
 - [Configuration Profiles](configuration-profiles.md): Configuring Phentrieve for different use cases
 - [API Usage](api-usage.md): Using the Phentrieve API

--- a/docs/user-guide/text-processing-guide.md
+++ b/docs/user-guide/text-processing-guide.md
@@ -57,6 +57,15 @@ phentrieve text process --strategy sliding_window --window-size 128 --step-size 
 !!! note "Command-line Parameters"
     The parameters `--window-size`, `--step-size`, `--threshold`, and `--min-segment` override the configuration for all strategies, not just "sliding_window".
 
+### Adaptive Re-Chunking (opt-in)
+
+When initial retrieval on a chunk is poor (low top-1 similarity AND low
+margin between top-1 and top-2), Phentrieve can optionally subdivide the
+chunk into sentence-window sub-chunks and re-query them. This is wired into
+`phentrieve text process` and the API only, not into `text interactive`.
+See [Adaptive Re-Chunking](./adaptive-rechunking.md) for the trigger
+semantics, configuration knobs, and cost envelope.
+
 ## Assertion Detection
 
 Phentrieve can detect the assertion status of each identified HPO term:

--- a/frontend/src/constants/defaults.js
+++ b/frontend/src/constants/defaults.js
@@ -1,11 +1,18 @@
 /**
  * Default values for query parameters and thresholds.
  * Single source of truth — used by QueryInterface and API calls.
+ *
+ * SURFACE PARITY: these constants must match the values in
+ * phentrieve/config.py. Cross-language drift is caught by
+ * tests/unit/profiles/test_frontend_constant_parity.py.
+ *
+ * Intentional UI-specific divergence: DEFAULT_NUM_RESULTS_PER_CHUNK = 3
+ * (backend default is 10; frontend uses a more compact display).
  */
 
 // Query defaults
 export const DEFAULT_NUM_RESULTS = 10;
-export const DEFAULT_SIMILARITY_THRESHOLD = 0.5;
+export const DEFAULT_SIMILARITY_THRESHOLD = 0.3;
 export const DEFAULT_SPLIT_THRESHOLD = 0.5;
 
 // Chunking defaults

--- a/frontend/src/services/PhentrieveService.js
+++ b/frontend/src/services/PhentrieveService.js
@@ -172,6 +172,8 @@ class PhentrieveService {
         textProcessingData.topTermPerChunkForAggregation ??
         null,
       include_details: textProcessingData.include_details ?? textProcessingData.includeDetails,
+      adaptive_rechunking:
+        textProcessingData.adaptive_rechunking ?? textProcessingData.adaptiveRechunking ?? null,
     };
 
     return Object.entries(payload).reduce((normalized, [key, value]) => {

--- a/frontend/src/test/components/QueryInterface.test.js
+++ b/frontend/src/test/components/QueryInterface.test.js
@@ -120,7 +120,7 @@ describe('QueryInterface (characterization)', () => {
 
   it('has default threshold values', async () => {
     const wrapper = await mountQueryInterface();
-    expect(wrapper.vm.similarityThreshold).toBe(0.5);
+    expect(wrapper.vm.similarityThreshold).toBe(0.3);
     expect(wrapper.vm.numResults).toBe(10);
     expect(wrapper.vm.chunkRetrievalThreshold).toBe(0.7);
     expect(wrapper.vm.aggregatedTermConfidence).toBe(0.75);

--- a/frontend/src/test/constants.test.js
+++ b/frontend/src/test/constants.test.js
@@ -21,7 +21,7 @@ import { HPO_TERM_URL, GITHUB_REPO_URL, PHENTRIEVE_PRODUCTION_URL } from '../con
 describe('constants/defaults', () => {
   it('exports numeric query defaults', () => {
     expect(DEFAULT_NUM_RESULTS).toBe(10);
-    expect(DEFAULT_SIMILARITY_THRESHOLD).toBe(0.5);
+    expect(DEFAULT_SIMILARITY_THRESHOLD).toBe(0.3);
     expect(DEFAULT_SPLIT_THRESHOLD).toBe(0.5);
   });
 

--- a/frontend/src/test/services/PhentrieveService.test.js
+++ b/frontend/src/test/services/PhentrieveService.test.js
@@ -226,6 +226,53 @@ describe('PhentrieveService', () => {
     expect(payload).not.toHaveProperty('retrieval_model_name');
   });
 
+  describe('adaptive_rechunking pass-through', () => {
+    it('forwards adaptive_rechunking when supplied', async () => {
+      axios.post.mockResolvedValue({
+        data: {
+          meta: { adaptive_rechunking: { enabled: true, trigger_count: 2 } },
+          processed_chunks: [],
+          aggregated_hpo_terms: [],
+        },
+      });
+
+      await PhentrieveService.processText({
+        text: 'Patient.',
+        adaptive_rechunking: { enabled: true, quality_threshold: 0.5 },
+      });
+
+      const payload = axios.post.mock.calls[0][1];
+      expect(payload.adaptive_rechunking).toEqual({
+        enabled: true,
+        quality_threshold: 0.5,
+      });
+    });
+
+    it('parses meta.adaptive_rechunking response without error', async () => {
+      axios.post.mockResolvedValue({
+        data: {
+          meta: { adaptive_rechunking: { enabled: true, trigger_count: 1 } },
+          processed_chunks: [],
+          aggregated_hpo_terms: [],
+        },
+      });
+
+      const result = await PhentrieveService.processText({ text: 'Patient.' });
+      expect(result.meta.adaptive_rechunking.enabled).toBe(true);
+    });
+
+    it('omits adaptive_rechunking from payload when not supplied', async () => {
+      axios.post.mockResolvedValue({
+        data: { meta: {}, processed_chunks: [], aggregated_hpo_terms: [] },
+      });
+
+      await PhentrieveService.processText({ text: 'Patient.' });
+
+      const payload = axios.post.mock.calls[0][1];
+      expect(payload).not.toHaveProperty('adaptive_rechunking');
+    });
+  });
+
   it('posts phenopacket export payloads to the backend endpoint', async () => {
     axios.post.mockResolvedValue({
       data: {

--- a/phentrieve.yaml
+++ b/phentrieve.yaml
@@ -119,3 +119,27 @@ multi_vector:
   # Options: label_only, label_synonyms_min, label_synonyms_max,
   #          all_weighted, all_max, all_min, custom
   aggregation_strategy: "label_synonyms_max"
+
+# =============================================================================
+# HPO EXTRACTION THRESHOLDS
+# =============================================================================
+# Read by phentrieve/config.py to populate DEFAULT_CHUNK_RETRIEVAL_THRESHOLD,
+# DEFAULT_MIN_CONFIDENCE_AGGREGATED, DEFAULT_CHUNK_CONFIDENCE, and
+# DEFAULT_ASSERTION_PREFERENCE. Key names match the existing config.py reads
+# exactly - DO NOT rename.
+
+extraction:
+  chunk_threshold: 0.7
+  min_confidence: 0.75
+  chunk_confidence: 0.2
+  assertion_preference: dependency
+
+# =============================================================================
+# OUTPUT FORMAT DEFAULTS
+# =============================================================================
+# Read by phentrieve/config.py to populate DEFAULT_OUTPUT_FORMAT_QUERY and
+# DEFAULT_OUTPUT_FORMAT_PROCESS.
+
+output:
+  format_query: text
+  format_process: json_lines

--- a/phentrieve.yaml.template
+++ b/phentrieve.yaml.template
@@ -127,6 +127,24 @@ multi_vector:
   # custom_formula: null
 
 # =============================================================================
+# CONFIGURATION PROFILES
+# =============================================================================
+# Named profiles for common CLI workflows. Pass --profile NAME to apply.
+# See docs/user-guide/configuration-profiles.md for the full schema.
+
+# profiles:
+#   high_recall_german:
+#     description: "Recall-oriented German extraction"
+#     command: text process              # bind to a specific command (optional)
+#     language: de
+#     chunk_retrieval_threshold: 0.6
+#
+#   fast_query:
+#     command: query
+#     num_results: 5
+#     similarity_threshold: 0.5
+
+# =============================================================================
 # HPO EXTRACTION THRESHOLDS
 # =============================================================================
 # Read by phentrieve/config.py to populate DEFAULT_CHUNK_RETRIEVAL_THRESHOLD,

--- a/phentrieve.yaml.template
+++ b/phentrieve.yaml.template
@@ -127,6 +127,30 @@ multi_vector:
   # custom_formula: null
 
 # =============================================================================
+# HPO EXTRACTION THRESHOLDS
+# =============================================================================
+# Read by phentrieve/config.py to populate DEFAULT_CHUNK_RETRIEVAL_THRESHOLD,
+# DEFAULT_MIN_CONFIDENCE_AGGREGATED, DEFAULT_CHUNK_CONFIDENCE, and
+# DEFAULT_ASSERTION_PREFERENCE. Key names match the existing config.py reads
+# exactly - DO NOT rename.
+
+# extraction:
+#   chunk_threshold: 0.7
+#   min_confidence: 0.75
+#   chunk_confidence: 0.2
+#   assertion_preference: dependency
+
+# =============================================================================
+# OUTPUT FORMAT DEFAULTS
+# =============================================================================
+# Read by phentrieve/config.py to populate DEFAULT_OUTPUT_FORMAT_QUERY and
+# DEFAULT_OUTPUT_FORMAT_PROCESS.
+
+# output:
+#   format_query: text
+#   format_process: json_lines
+
+# =============================================================================
 # EXTRACTION BENCHMARK CONFIGURATION
 # =============================================================================
 

--- a/phentrieve.yaml.template
+++ b/phentrieve.yaml.template
@@ -157,6 +157,20 @@ multi_vector:
 #   min_confidence: 0.75
 #   chunk_confidence: 0.2
 #   assertion_preference: dependency
+#
+#   # Adaptive re-chunking (opt-in). When a chunk's retrieval is poor,
+#   # subdivide it into sentence-bounded sub-chunks and re-query.
+#   # See docs/user-guide/adaptive-rechunking.md for full details.
+#   adaptive_rechunking:
+#     enabled: false                 # opt-in switch; default behavior unchanged
+#     quality_threshold: 0.55        # top-1 floor; encoder-calibrated for BioLORD
+#     margin_threshold: 0.03         # minimum top-1 minus top-2 distance
+#     use_ontology_coherence: false  # reserved, inert in v1
+#     max_depth: 2                   # recursion cap; 1 + max_depth query_batch calls worst case
+#     min_chunk_chars: 30            # drop sub-chunks shorter than this many chars
+#     max_sentences_per_subchunk: 3  # sliding-window size in sentences
+#     overlap_sentences: 1           # sentence-level overlap between sub-chunk windows
+#     score_improvement_gate: 0.05   # children below this top-1 lift over parent are reverted
 
 # =============================================================================
 # OUTPUT FORMAT DEFAULTS

--- a/phentrieve/cli/__init__.py
+++ b/phentrieve/cli/__init__.py
@@ -199,9 +199,22 @@ def main_callback(
             ),
         ),
     ] = None,
+    show_resolved_config: Annotated[
+        bool,
+        typer.Option(
+            "--show-resolved-config",
+            help=(
+                "Print the resolved option values (with source labels) to "
+                "stderr before running the command. Useful for diagnosing "
+                "why a profile or YAML default did not take effect."
+            ),
+        ),
+    ] = False,
 ):
     """Main callback for Phentrieve CLI - handles global options like --version."""
     ctx.ensure_object(dict)
+    if isinstance(ctx.obj, dict):
+        ctx.obj["show_resolved_config"] = show_resolved_config
 
 
 # Register command groups

--- a/phentrieve/cli/__init__.py
+++ b/phentrieve/cli/__init__.py
@@ -17,6 +17,7 @@ from typer.main import get_command
 # Import all command groups
 from phentrieve.cli import (
     benchmark_commands,
+    config_commands,
     index_commands,
     mcp_commands,
     query_commands,
@@ -219,6 +220,11 @@ app.add_typer(
     mcp_commands.app,
     name="mcp",
     help="Model Context Protocol (MCP) server commands.",
+)
+app.add_typer(
+    config_commands.config_app,
+    name="config",
+    help="Inspect and validate phentrieve.yaml configuration profiles.",
 )
 
 # Main command for query

--- a/phentrieve/cli/__init__.py
+++ b/phentrieve/cli/__init__.py
@@ -21,6 +21,7 @@ from phentrieve.cli import (
     mcp_commands,
     query_commands,
 )
+from phentrieve.cli._profile import apply_profile_callback
 
 # Read version from pyproject.toml
 __version__ = importlib.metadata.version("phentrieve")
@@ -172,6 +173,7 @@ def version_callback(value: bool):
 
 @app.callback()
 def main_callback(
+    ctx: typer.Context,
     version: Annotated[
         bool,
         typer.Option(
@@ -182,9 +184,23 @@ def main_callback(
             help="Show the application version and exit.",
         ),
     ] = False,
+    profile: Annotated[
+        str | None,
+        typer.Option(
+            "--profile",
+            "-P",
+            envvar="PHENTRIEVE_PROFILE",
+            callback=apply_profile_callback,
+            is_eager=True,
+            help=(
+                "Apply a named profile globally. A subcommand-level "
+                "--profile wins on conflict."
+            ),
+        ),
+    ] = None,
 ):
     """Main callback for Phentrieve CLI - handles global options like --version."""
-    pass
+    ctx.ensure_object(dict)
 
 
 # Register command groups

--- a/phentrieve/cli/_profile.py
+++ b/phentrieve/cli/_profile.py
@@ -197,6 +197,29 @@ def apply_profile_callback(
     # Idempotence guard: bail if already populated for this exact value.
     if ctx.obj.get("_profile_applied") == value:
         return value
+
+    # Placement precedence: when the root callback has already applied an
+    # explicit --profile (root --profile X), and this subcommand-level
+    # callback is firing with the option's built-in default (i.e. no
+    # subcommand-level --profile and no PHENTRIEVA_PROFILE env), do not
+    # overwrite the root's resolved defaults. The subcommand value only
+    # wins when the user (or env) supplied it explicitly.
+    parent_obj = ctx.parent.obj if ctx.parent is not None else None
+    parent_applied = (
+        parent_obj.get("_profile_applied") if isinstance(parent_obj, dict) else None
+    )
+    if parent_applied not in (None, ""):
+        try:
+            from click.core import ParameterSource
+
+            source = ctx.get_parameter_source(param.name) if param.name else None
+        except Exception:  # noqa: BLE001 - defensive: older click variants
+            source = None
+        if source is not None and source == ParameterSource.DEFAULT:
+            # Inherit the parent's resolved sources/defaults; bail.
+            ctx.obj["_profile_applied"] = parent_applied
+            return value
+
     ctx.obj["_profile_applied"] = value
 
     # Reconstruct command path. For the root-callback case where the
@@ -218,11 +241,17 @@ def apply_profile_callback(
     accepted_keys = set() if is_root else raw_accepted_keys
 
     profiles = merged_profiles()
+    # At the root callback Click has not yet selected the subcommand, so the
+    # command-binding check in resolve_profile_for_command would always reject
+    # bound profiles like `command: query`. Skip the binding check for the
+    # root case; the per-subcommand eager callback re-runs at the subcommand
+    # level and re-validates the binding then.
     profile, profile_kwargs = resolve_profile_for_command(
         value if value not in (None, "") else None,
         command_path,
         accepted_keys,
         all_profiles=profiles,
+        skip_binding_check=is_root and not command_path,
     )
 
     # Lazy import - phentrieve.config has its own initialization side effects

--- a/phentrieve/cli/_profile.py
+++ b/phentrieve/cli/_profile.py
@@ -1,0 +1,254 @@
+"""Eager --profile callback for the Phentrieve CLI.
+
+Populates ``ctx.default_map`` with the merged precedence stack
+(profile -> top-level YAML -> fallback constants) and maintains a
+sidecar source map at ``ctx.obj['resolved_sources']`` so callers can
+distinguish profile- vs YAML- vs constant-sourced defaults
+(``ParameterSource`` alone collapses all three to ``DEFAULT_MAP``).
+
+Implements Spec A's Architecture section:
+``.planning/specs/2026-04-25-cli-profiles-default-resolution-spec.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import click
+import typer
+
+from phentrieve import config as _config
+from phentrieve.profiles import (
+    Profile,
+    merged_profiles,
+    resolve_profile_for_command,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Map from Profile field name to (yaml_path, fallback_constant_name).
+# Used to walk the layered precedence stack: profile -> YAML -> constant.
+# YAML keys for the extraction-block options use the SHORT names that
+# phentrieve/config.py:514-525 already reads (chunk_threshold, min_confidence,
+# assertion_preference) - NOT the longer Profile field names.
+_OPTION_RESOLUTION_MAP: dict[str, tuple[str | tuple[str, ...], str]] = {
+    "language": ("default_language", "DEFAULT_LANGUAGE"),
+    "model_name": ("default_model", "DEFAULT_MODEL"),
+    "retrieval_model": ("default_model", "DEFAULT_MODEL"),
+    "semantic_chunker_model": ("default_model", "DEFAULT_MODEL"),
+    "num_results": ("default_top_k", "DEFAULT_TOP_K"),
+    "similarity_threshold": (
+        "min_similarity_threshold",
+        "MIN_SIMILARITY_THRESHOLD",
+    ),
+    "chunk_retrieval_threshold": (
+        ("extraction", "chunk_threshold"),
+        "DEFAULT_CHUNK_RETRIEVAL_THRESHOLD",
+    ),
+    "aggregated_term_confidence": (
+        ("extraction", "min_confidence"),
+        "DEFAULT_MIN_CONFIDENCE_AGGREGATED",
+    ),
+    "chunking_strategy": (
+        "default_chunking_strategy",
+        "DEFAULT_CHUNKING_STRATEGY",
+    ),
+    "assertion_preference": (
+        ("extraction", "assertion_preference"),
+        "DEFAULT_ASSERTION_PREFERENCE",
+    ),
+    "output_format": (
+        ("output", "format_query"),
+        "DEFAULT_OUTPUT_FORMAT_QUERY",
+    ),
+}
+
+
+def _walk_yaml(yaml_data: dict, path: str | tuple[str, ...]) -> Any:
+    """Walk a nested YAML key path. Returns None if any segment is missing."""
+    if isinstance(path, str):
+        return yaml_data.get(path)
+    cur: Any = yaml_data
+    for seg in path:
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(seg)
+        if cur is None:
+            return None
+    return cur
+
+
+def _resolve_option_value(
+    field_name: str,
+    profile_kwargs: dict[str, Any],
+    yaml_data: dict,
+) -> tuple[Any, str] | None:
+    """Walk the precedence stack for a single option:
+    profile -> YAML -> fallback constant.
+
+    Returns ``(value, source_label)`` where source_label is one of:
+    - ``"<profile-set>"`` (caller substitutes the named-profile label)
+    - ``"yaml:<key>"`` for YAML-sourced
+    - ``"const:<NAME>"`` for fallback constant
+
+    Returns None if no layer in the stack supplies a value for this option.
+    """
+    if field_name in profile_kwargs:
+        return profile_kwargs[field_name], "<profile-set>"
+
+    if field_name in _OPTION_RESOLUTION_MAP:
+        yaml_path, const_name = _OPTION_RESOLUTION_MAP[field_name]
+        yaml_value = _walk_yaml(yaml_data, yaml_path)
+        if yaml_value is not None:
+            label = (
+                f"yaml:{yaml_path}"
+                if isinstance(yaml_path, str)
+                else f"yaml:{'.'.join(yaml_path)}"
+            )
+            return yaml_value, label
+        const_value = getattr(_config, const_name, None)
+        if const_value is not None:
+            return const_value, f"const:{const_name}"
+
+    return None
+
+
+def _command_path_from_ctx(ctx: click.Context) -> tuple[str, ...]:
+    """Reconstruct the command tuple by walking up the click context.
+
+    Returns the chain of subcommand info_names from outermost to innermost,
+    excluding the root program. For a root-callback invocation this returns
+    an empty tuple - callers should fall back to ``ctx.invoked_subcommand``.
+    """
+    parts: list[str] = []
+    cur: click.Context | None = ctx
+    while cur is not None and cur.parent is not None:
+        if cur.info_name:
+            parts.append(cur.info_name)
+        cur = cur.parent
+    return tuple(reversed(parts))
+
+
+def _accepted_option_keys(ctx: click.Context) -> set[str]:
+    """Collect the active command's option parameter names."""
+    cmd = ctx.command
+    if cmd is None:
+        return set()
+    return {p.name for p in cmd.params if isinstance(p, click.Option) and p.name}
+
+
+def _profile_label(value: str | None, command_path: tuple[str, ...]) -> str:
+    """Build the source label for profile-set values."""
+    if value not in (None, ""):
+        return f"profile:{value}"
+    if command_path == ("text", "interactive"):
+        return "profile:builtin:interactive"
+    return "profile:builtin:default"
+
+
+def apply_profile_callback(
+    ctx: typer.Context,
+    param: click.Parameter,
+    value: str | None,
+) -> str | None:
+    """Eager Click/Typer callback for ``--profile``.
+
+    Walks the precedence stack (explicit profile -> top-level YAML ->
+    fallback constants) for each profileable Profile field and writes the
+    resolved values into ``ctx.default_map`` (or a nested bucket keyed by
+    the invoked subcommand when called from the root callback). Maintains
+    a fine-grained sidecar source map at ``ctx.obj['resolved_sources']``.
+
+    Idempotent: invoking with the same value twice is a no-op. When the
+    root and a subcommand both register ``--profile``, the subcommand
+    invocation overwrites the root's default_map entries because the eager
+    callback runs at the subcommand level after the root.
+    """
+    ctx.ensure_object(dict)
+    if "resolved_sources" not in ctx.obj:
+        ctx.obj["resolved_sources"] = {}
+
+    # Idempotence guard: bail if already populated for this exact value.
+    if ctx.obj.get("_profile_applied") == value:
+        return value
+    ctx.obj["_profile_applied"] = value
+
+    # Reconstruct command path. For the root-callback case where the
+    # subcommand context hasn't been entered yet, ctx.invoked_subcommand
+    # gives the next leg.
+    command_path = _command_path_from_ctx(ctx)
+    if not command_path and ctx.invoked_subcommand:
+        command_path = (ctx.invoked_subcommand,)
+
+    raw_accepted_keys = _accepted_option_keys(ctx)
+
+    # Root callback fires before Click selects the subcommand, so the
+    # active command's params (raw_accepted_keys) reflect only the root's
+    # options. Don't filter Profile fields against that - the subcommand
+    # is what we actually want to pre-populate. Pass an empty set to
+    # resolve_profile_for_command so it doesn't filter either, and skip
+    # the per-field accepted-keys gate below for the root case.
+    is_root = ctx.parent is None
+    accepted_keys = set() if is_root else raw_accepted_keys
+
+    profiles = merged_profiles()
+    profile, profile_kwargs = resolve_profile_for_command(
+        value if value not in (None, "") else None,
+        command_path,
+        accepted_keys,
+        all_profiles=profiles,
+    )
+
+    # Lazy import - phentrieve.config has its own initialization side effects
+    # we don't want at module import time.
+    from phentrieve.config import _load_yaml_config
+
+    yaml_data = _load_yaml_config()
+    profile_label = _profile_label(value, command_path)
+
+    new_defaults: dict[str, Any] = {}
+    for field_name in Profile.model_fields:
+        if field_name in {"description", "command", "adaptive_rechunking"}:
+            continue
+        if accepted_keys and field_name not in accepted_keys:
+            continue
+        resolved = _resolve_option_value(field_name, profile_kwargs, yaml_data)
+        if resolved is None:
+            continue
+        resolved_value, label = resolved
+        if label == "<profile-set>":
+            label = profile_label
+        new_defaults[field_name] = resolved_value
+        ctx.obj["resolved_sources"][field_name] = label
+
+    if ctx.default_map is None:
+        ctx.default_map = {}
+    if is_root:
+        # Root-callback case. Click hasn't parsed the subcommand token yet
+        # (ctx.invoked_subcommand is still None), so we don't yet know which
+        # subcommand will run. Click resolves a child's default_map as
+        # parent.default_map.get(child_info_name); writing flat keys won't
+        # propagate. Pre-populate a nested bucket for every known immediate
+        # subcommand so whichever one Click selects sees its defaults.
+        # Group sub-groups (e.g. "text") get the same treatment recursively
+        # via their own eager --profile registration in later phases; here
+        # we cover the leaf subcommands one level down. We also write flat
+        # so a non-group caller still sees the values.
+        ctx.default_map.update(new_defaults)
+        if isinstance(ctx.command, click.Group):
+            for sub_name in ctx.command.list_commands(ctx):
+                ctx.default_map.setdefault(sub_name, {}).update(new_defaults)
+    else:
+        # Subcommand-callback case: command_path is correct; write flat into
+        # this command's own default_map.
+        ctx.default_map.update(new_defaults)
+
+    logger.debug(
+        "apply_profile_callback: command_path=%s value=%r defaults=%s",
+        command_path,
+        value,
+        new_defaults,
+    )
+    return value

--- a/phentrieve/cli/_profile.py
+++ b/phentrieve/cli/_profile.py
@@ -66,6 +66,21 @@ _OPTION_RESOLUTION_MAP: dict[str, tuple[str | tuple[str, ...], str]] = {
 }
 
 
+# Per-command overrides for fields whose YAML key / fallback constant
+# depends on the active subcommand (e.g. ``output_format`` resolves to
+# ``output.format_query`` for ``query`` but ``output.format_process`` for
+# ``text process``). Lookup is keyed by the leaf command name extracted
+# from ``command_path``.
+_OPTION_COMMAND_OVERRIDES: dict[str, dict[str, tuple[str | tuple[str, ...], str]]] = {
+    "output_format": {
+        "process": (
+            ("output", "format_process"),
+            "DEFAULT_OUTPUT_FORMAT_PROCESS",
+        ),
+    },
+}
+
+
 def _walk_yaml(yaml_data: dict, path: str | tuple[str, ...]) -> Any:
     """Walk a nested YAML key path. Returns None if any segment is missing."""
     if isinstance(path, str):
@@ -84,6 +99,7 @@ def _resolve_option_value(
     field_name: str,
     profile_kwargs: dict[str, Any],
     yaml_data: dict,
+    command_path: tuple[str, ...] = (),
 ) -> tuple[Any, str] | None:
     """Walk the precedence stack for a single option:
     profile -> YAML -> fallback constant.
@@ -94,12 +110,20 @@ def _resolve_option_value(
     - ``"const:<NAME>"`` for fallback constant
 
     Returns None if no layer in the stack supplies a value for this option.
+
+    ``command_path`` lets command-specific overrides in
+    ``_OPTION_COMMAND_OVERRIDES`` take precedence over the global mapping
+    (e.g. ``output_format`` reads ``output.format_process`` for the
+    ``text process`` subcommand instead of ``output.format_query``).
     """
     if field_name in profile_kwargs:
         return profile_kwargs[field_name], "<profile-set>"
 
-    if field_name in _OPTION_RESOLUTION_MAP:
-        yaml_path, const_name = _OPTION_RESOLUTION_MAP[field_name]
+    overrides = _OPTION_COMMAND_OVERRIDES.get(field_name, {})
+    leaf = command_path[-1] if command_path else ""
+    resolution = overrides.get(leaf) or _OPTION_RESOLUTION_MAP.get(field_name)
+    if resolution is not None:
+        yaml_path, const_name = resolution
         yaml_value = _walk_yaml(yaml_data, yaml_path)
         if yaml_value is not None:
             label = (
@@ -214,7 +238,9 @@ def apply_profile_callback(
             continue
         if accepted_keys and field_name not in accepted_keys:
             continue
-        resolved = _resolve_option_value(field_name, profile_kwargs, yaml_data)
+        resolved = _resolve_option_value(
+            field_name, profile_kwargs, yaml_data, command_path=command_path
+        )
         if resolved is None:
             continue
         resolved_value, label = resolved

--- a/phentrieve/cli/_profile.py
+++ b/phentrieve/cli/_profile.py
@@ -307,3 +307,62 @@ def apply_profile_callback(
         new_defaults,
     )
     return value
+
+
+def render_resolved_config(ctx: click.Context) -> str:
+    """Build a human-readable resolved-config table.
+
+    Walks the active subcommand's option parameters and emits one line per
+    option in the format::
+
+        <name>  <value>  <- <source-label>
+
+    where the source label is one of:
+
+    - ``--<flag> (commandline)`` when the user passed the flag explicitly
+    - ``profile:<name>``, ``yaml:<key>``, or ``const:<NAME>`` from the
+      sidecar source map populated by :func:`apply_profile_callback`
+    - ``default`` when no layer in the precedence stack supplied a value
+
+    The result is returned as a string for the caller to print to stderr.
+    """
+    if ctx.command is None:
+        return ""
+
+    lines: list[str] = []
+    cmd_path = " ".join(_command_path_from_ctx(ctx))
+    if cmd_path:
+        lines.append(f"Resolved configuration for `phentrieve {cmd_path}`:")
+    else:
+        lines.append("Resolved configuration for `phentrieve`:")
+
+    sources: dict[str, str] = (
+        ctx.obj.get("resolved_sources", {}) if isinstance(ctx.obj, dict) else {}
+    )
+
+    for param in ctx.command.params:
+        if not isinstance(param, click.Option):
+            continue
+        name = param.name
+        if name is None:
+            continue
+        if name in {"profile", "show_resolved_config", "version"}:
+            continue
+        value = ctx.params.get(name)
+        try:
+            param_source = ctx.get_parameter_source(name)
+        except Exception:  # noqa: BLE001 - defensive: older click variants
+            param_source = None
+        # COMMANDLINE wins on labeling - user-provided.
+        if (
+            param_source is not None
+            and param_source == click.core.ParameterSource.COMMANDLINE
+        ):
+            label = f"--{name.replace('_', '-')} (commandline)"
+        elif name in sources:
+            label = sources[name]
+        else:
+            label = "default"
+        lines.append(f"  {name:<35} {value!r:<20} <- {label}")
+
+    return "\n".join(lines)

--- a/phentrieve/cli/config_commands.py
+++ b/phentrieve/cli/config_commands.py
@@ -1,0 +1,168 @@
+"""`phentrieve config` subcommand group.
+
+Implements list-profiles, show, validate, and path subcommands per Spec A's
+"Subcommand surface" section. These commands let users inspect which profiles
+are defined, view the resolved YAML for a given profile, validate the
+profiles section against the Profile schema, and discover which
+phentrieve.yaml file is in effect.
+"""
+
+from __future__ import annotations
+
+import typer
+import yaml as pyyaml
+from pydantic import ValidationError
+
+from phentrieve.config import _load_yaml_config
+from phentrieve.profiles import (
+    BUILTIN_PROFILES,
+    Profile,
+    load_profiles_from_yaml,
+    merged_profiles,
+)
+from phentrieve.utils import (
+    get_config_file_path,
+    get_config_paths,
+    load_user_config,
+)
+
+config_app = typer.Typer(
+    name="config",
+    help="Inspect and validate phentrieve.yaml configuration profiles.",
+    no_args_is_help=True,
+)
+
+
+def _clear_config_caches() -> None:
+    """Drop on-disk YAML caches so subsequent reads see fresh content."""
+    _load_yaml_config.cache_clear()
+    load_user_config.cache_clear()
+
+
+def _summarize_options(profile: Profile) -> str:
+    """Return a short comma-separated list of preset option keys (excluding
+    description/command/None values). Caps at three entries with an ellipsis.
+    """
+    keys = [
+        k
+        for k, v in profile.model_dump().items()
+        if v is not None and k not in {"description", "command"}
+    ]
+    if not keys:
+        return ""
+    if len(keys) <= 3:
+        return ", ".join(keys)
+    return ", ".join(keys[:3]) + ", ..."
+
+
+@config_app.command("list-profiles")
+def list_profiles_cmd() -> None:
+    """List all profiles (built-in + user) with command bindings and key options."""
+    _clear_config_caches()
+    user_profiles = load_profiles_from_yaml()
+    rows: list[tuple[str, str, str, str, str]] = []
+    seen: set[str] = set()
+    for name, profile in BUILTIN_PROFILES.items():
+        seen.add(name)
+        if name in user_profiles:
+            source = "user (shadows built-in)"
+            effective = user_profiles[name]
+        else:
+            source = "built-in"
+            effective = profile
+        binding = effective.command or "any"
+        keys = _summarize_options(effective)
+        desc = effective.description or ""
+        rows.append((name, source, binding, keys, desc))
+
+    for name, profile in user_profiles.items():
+        if name in seen:
+            continue
+        binding = profile.command or "any"
+        keys = _summarize_options(profile)
+        desc = profile.description or ""
+        rows.append((name, "user", binding, keys, desc))
+
+    headers = ("Name", "Source", "Binding", "Key options", "Description")
+    widths = [
+        max(len(headers[i]), max((len(r[i]) for r in rows), default=0))
+        for i in range(len(headers))
+    ]
+    typer.echo("  ".join(f"{headers[i]:<{widths[i]}}" for i in range(len(headers))))
+    typer.echo("  ".join("-" * w for w in widths))
+    for row in rows:
+        typer.echo("  ".join(f"{row[i]:<{widths[i]}}" for i in range(len(headers))))
+
+
+@config_app.command("show")
+def show_cmd(name: str = typer.Argument(..., help="Profile name to show.")) -> None:
+    """Print the fully resolved profile as YAML."""
+    profiles = merged_profiles()
+    if name not in profiles:
+        raise typer.BadParameter(f"Profile {name!r} not found.", param_hint="name")
+    profile = profiles[name]
+    # Drop None fields so the output reflects only what the profile presets.
+    non_none = {k: v for k, v in profile.model_dump().items() if v is not None}
+    typer.echo(
+        pyyaml.safe_dump(non_none, sort_keys=False, default_flow_style=False).rstrip()
+    )
+
+
+def _format_validation_error(name: str, err: ValidationError) -> str:
+    """Compact, single-line-per-error message for `validate`."""
+    parts: list[str] = [f"{name}:"]
+    for detail in err.errors():
+        loc = ".".join(str(x) for x in detail.get("loc", ()))
+        msg = detail.get("msg", "invalid value")
+        parts.append(f"  {loc}: {msg}" if loc else f"  {msg}")
+    return "\n".join(parts)
+
+
+@config_app.command("validate")
+def validate_cmd() -> None:
+    """Validate phentrieve.yaml's `profiles:` section against the Profile schema.
+
+    Exits non-zero with a per-profile error summary if any entry is invalid;
+    otherwise prints OK.
+    """
+    _clear_config_caches()
+    raw = _load_yaml_config()
+    profiles_raw = raw.get("profiles", {})
+    errors: list[str] = []
+
+    if not isinstance(profiles_raw, dict):
+        typer.echo("phentrieve.yaml `profiles:` section is not a mapping.", err=True)
+        raise typer.Exit(code=1)
+
+    for name, data in profiles_raw.items():
+        if not isinstance(data, dict):
+            errors.append(f"{name}: not a mapping")
+            continue
+        try:
+            Profile.model_validate(data)
+        except ValidationError as e:
+            errors.append(_format_validation_error(name, e))
+
+    if errors:
+        for line in errors:
+            typer.echo(line, err=True)
+        raise typer.Exit(code=1)
+
+    typer.echo("OK")
+
+
+@config_app.command("path")
+def path_cmd() -> None:
+    """Print the active phentrieve.yaml search path and which file was loaded."""
+    config_path = get_config_file_path()
+    if config_path is not None and config_path.exists():
+        typer.echo(f"Loaded: {config_path}")
+        typer.echo("Search order:")
+        for p in get_config_paths():
+            marker = " (loaded)" if p == config_path else ""
+            typer.echo(f"  - {p}{marker}")
+    else:
+        typer.echo("No phentrieve.yaml found in the search path.")
+        typer.echo("Search order:")
+        for p in get_config_paths():
+            typer.echo(f"  - {p}")

--- a/phentrieve/cli/query_commands.py
+++ b/phentrieve/cli/query_commands.py
@@ -264,6 +264,19 @@ def query_hpo(
     # Set up logging
     setup_logging_cli(debug=debug)
 
+    # Optional: print resolved configuration to stderr for debugging.
+    import click as _click
+
+    _ctx = _click.get_current_context(silent=True)
+    if (
+        _ctx is not None
+        and isinstance(_ctx.obj, dict)
+        and _ctx.obj.get("show_resolved_config")
+    ):
+        from phentrieve.cli._profile import render_resolved_config
+
+        typer.echo(render_resolved_config(_ctx), err=True)
+
     # Resolve None defaults to fallback constants. Click's eager --profile
     # callback has already populated ctx.default_map (and Click has resolved
     # commandline overrides on top), so a None at this point means no flag,

--- a/phentrieve/cli/query_commands.py
+++ b/phentrieve/cli/query_commands.py
@@ -9,6 +9,15 @@ from typing import Annotated, Any
 
 import typer
 
+from phentrieve.cli._profile import apply_profile_callback
+from phentrieve.config import (
+    DEFAULT_AGGREGATION_STRATEGY,
+    DEFAULT_MODEL,
+    DEFAULT_MULTI_VECTOR,
+    DEFAULT_OUTPUT_FORMAT_QUERY,
+    DEFAULT_TOP_K,
+    MIN_SIMILARITY_THRESHOLD,
+)
 from phentrieve.retrieval.output_formatters import (
     format_results_as_json,
     format_results_as_jsonl,
@@ -112,6 +121,20 @@ def query_hpo(
     text: Annotated[
         str | None, typer.Argument(help="Clinical text to query for HPO terms")
     ] = None,
+    profile: Annotated[
+        str,
+        typer.Option(
+            "--profile",
+            "-P",
+            envvar="PHENTRIEVE_PROFILE",
+            help=(
+                "Apply a named profile from phentrieve.yaml. "
+                "See `phentrieve config list-profiles`."
+            ),
+            callback=apply_profile_callback,
+            is_eager=True,
+        ),
+    ] = "default",
     interactive: Annotated[
         bool,
         typer.Option(
@@ -123,21 +146,21 @@ def query_hpo(
     model_name: Annotated[
         str | None,
         typer.Option("--model-name", "-m", help="Model name to use for embeddings"),
-    ] = "FremyCompany/BioLORD-2023-M",
+    ] = None,
     num_results: Annotated[
-        int,
+        int | None,
         typer.Option(
             "--num-results", "-n", help="Number of results to display for each query"
         ),
-    ] = 10,
+    ] = None,
     similarity_threshold: Annotated[
-        float,
+        float | None,
         typer.Option(
             "--similarity-threshold",
             "-t",
             help="Minimum similarity threshold for results",
         ),
-    ] = 0.3,
+    ] = None,
     sentence_mode: Annotated[
         bool,
         typer.Option(
@@ -166,14 +189,14 @@ def query_hpo(
         ),
     ] = None,
     output_format: Annotated[
-        str,
+        str | None,
         typer.Option(
             "--output-format",
             "-F",
             help="Format for the output (text, json, json_lines, phenopacket_v2_json). Default is 'text'.",
             case_sensitive=False,
         ),
-    ] = "text",
+    ] = None,
     cpu: Annotated[
         bool, typer.Option("--cpu", help="Force CPU usage even if GPU is available")
     ] = False,
@@ -210,20 +233,20 @@ def query_hpo(
         ),
     ] = False,
     multi_vector: Annotated[
-        bool,
+        bool | None,
         typer.Option(
             "--multi-vector",
             help="Use multi-vector index with component-level aggregation",
         ),
-    ] = False,
+    ] = None,
     aggregation_strategy: Annotated[
-        str,
+        str | None,
         typer.Option(
             "--aggregation-strategy",
             "-A",
             help="Multi-vector aggregation strategy: label_only, label_synonyms_min, label_synonyms_max, all_weighted, all_max",
         ),
-    ] = "label_synonyms_max",
+    ] = None,
 ):
     """Query HPO terms with natural language clinical descriptions.
 
@@ -235,17 +258,32 @@ def query_hpo(
     - json: Structured JSON output
     - json_lines: JSON Lines format (one JSON object per line)
     """
-    from phentrieve.config import DEFAULT_MODEL
     from phentrieve.retrieval.query_orchestrator import orchestrate_query
     from phentrieve.utils import setup_logging_cli
 
     # Set up logging
     setup_logging_cli(debug=debug)
 
-    # Use default model if not specified
-    if model_name is None:
-        model_name = DEFAULT_MODEL
-        typer.echo(f"Using default model: {model_name}")
+    # Resolve None defaults to fallback constants. Click's eager --profile
+    # callback has already populated ctx.default_map (and Click has resolved
+    # commandline overrides on top), so a None at this point means no flag,
+    # no profile entry, and no YAML supplied a value.
+    model_name = model_name if model_name is not None else DEFAULT_MODEL
+    num_results = num_results if num_results is not None else DEFAULT_TOP_K
+    similarity_threshold = (
+        similarity_threshold
+        if similarity_threshold is not None
+        else MIN_SIMILARITY_THRESHOLD
+    )
+    multi_vector = multi_vector if multi_vector is not None else DEFAULT_MULTI_VECTOR
+    aggregation_strategy = (
+        aggregation_strategy
+        if aggregation_strategy is not None
+        else DEFAULT_AGGREGATION_STRATEGY
+    )
+    output_format = (
+        output_format if output_format is not None else DEFAULT_OUTPUT_FORMAT_QUERY
+    )
 
     # Determine device based on CPU flag
     device_override = "cpu" if cpu else None

--- a/phentrieve/cli/text_commands.py
+++ b/phentrieve/cli/text_commands.py
@@ -581,7 +581,12 @@ def process_text_for_hpo_command(
     # commandline overrides on top), so a None at this point means no flag,
     # no profile entry, and no YAML supplied a value.
     num_results = num_results if num_results is not None else DEFAULT_TOP_K
-    chunk_confidence = (
+    # The --chunk-confidence option is a long-standing CLI accept-only knob:
+    # not yet wired into the orchestrator. Resolving it here with the new
+    # DEFAULT_CHUNK_CONFIDENCE keeps the constant referenced for future use
+    # (and makes the resolver visible alongside the other Plan A defaults)
+    # without producing a dead local. Tracked for follow-up wiring.
+    _resolved_chunk_confidence = (  # noqa: F841 — placeholder until wired downstream
         chunk_confidence if chunk_confidence is not None else DEFAULT_CHUNK_CONFIDENCE
     )
     assertion_preference = (

--- a/phentrieve/cli/text_commands.py
+++ b/phentrieve/cli/text_commands.py
@@ -17,15 +17,20 @@ import typer
 # Importing sentence_transformers loads PyTorch/CUDA (18+ seconds), which should
 # only happen when commands actually need ML models, not for --help or --version.
 # The import is done inside command functions where the model is actually used.
+from phentrieve.cli._profile import apply_profile_callback
 from phentrieve.cli.utils import load_text_from_input, resolve_chunking_pipeline_config
 from phentrieve.config import (
+    DEFAULT_ASSERTION_PREFERENCE,
+    DEFAULT_CHUNK_CONFIDENCE,
     DEFAULT_CHUNK_RETRIEVAL_THRESHOLD,
     DEFAULT_CHUNKING_STRATEGY,
+    DEFAULT_LANGUAGE,
     DEFAULT_MIN_CONFIDENCE_AGGREGATED,
     DEFAULT_MIN_SEGMENT_LENGTH_WORDS,
     DEFAULT_MODEL,
     DEFAULT_SPLITTING_THRESHOLD,
     DEFAULT_STEP_SIZE_TOKENS,
+    DEFAULT_TOP_K,
     DEFAULT_WINDOW_SIZE_TOKENS,
 )
 from phentrieve.llm import config as llm_config
@@ -277,6 +282,20 @@ def process_text_for_hpo_command(
         None,
         help="Text to process for HPO term extraction (can be a string or file path). Not required in interactive mode.",
     ),
+    profile: Annotated[
+        str,
+        typer.Option(
+            "--profile",
+            "-P",
+            envvar="PHENTRIEVE_PROFILE",
+            help=(
+                "Apply a named profile from phentrieve.yaml. "
+                "See `phentrieve config list-profiles`."
+            ),
+            callback=apply_profile_callback,
+            is_eager=True,
+        ),
+    ] = "default",
     input_file: Annotated[
         Path | None,
         typer.Option(
@@ -284,9 +303,9 @@ def process_text_for_hpo_command(
         ),
     ] = None,
     language: Annotated[
-        str,
+        str | None,
         typer.Option("--language", "-l", help="Language of the text (en, de, etc.)"),
-    ] = "en",
+    ] = None,
     chunking_pipeline_config_file: Annotated[
         Path | None,
         typer.Option(
@@ -398,13 +417,13 @@ def process_text_for_hpo_command(
         ),
     ] = DEFAULT_CHUNK_RETRIEVAL_THRESHOLD,
     num_results: Annotated[
-        int,
+        int | None,
         typer.Option(
             "--num-results",
             "-n",
             help="Maximum number of HPO terms to return per query",
         ),
-    ] = 10,
+    ] = None,
     no_assertion_detection: Annotated[
         bool,
         typer.Option(
@@ -413,12 +432,12 @@ def process_text_for_hpo_command(
         ),
     ] = False,
     assertion_preference: Annotated[
-        str,
+        str | None,
         typer.Option(
             "--assertion-preference",
             help="Assertion detection strategy preference (dependency, keyword, any_negative)",
         ),
-    ] = "dependency",
+    ] = None,
     output_format: Annotated[
         str,
         typer.Option(
@@ -461,13 +480,13 @@ def process_text_for_hpo_command(
         typer.Option("--debug", help="Enable debug logging"),
     ] = False,
     chunk_confidence: Annotated[
-        float,
+        float | None,
         typer.Option(
             "--chunk-confidence",
             "-cc",
             help="Minimum confidence score for a term to be included in a chunk result",
         ),
-    ] = 0.2,
+    ] = None,
     aggregated_term_confidence: Annotated[
         float,
         typer.Option(
@@ -505,12 +524,26 @@ def process_text_for_hpo_command(
     """
     import time
 
-    from phentrieve.config import DEFAULT_LANGUAGE, DEFAULT_MODEL
+    from phentrieve.config import DEFAULT_MODEL
     from phentrieve.utils import detect_language, setup_logging_cli
 
     logger = logging.getLogger(__name__)
     start_time = time.time()
     setup_logging_cli(debug=debug)
+
+    # Resolve None defaults to fallback constants. Click's eager --profile
+    # callback has already populated ctx.default_map (and Click has resolved
+    # commandline overrides on top), so a None at this point means no flag,
+    # no profile entry, and no YAML supplied a value.
+    num_results = num_results if num_results is not None else DEFAULT_TOP_K
+    chunk_confidence = (
+        chunk_confidence if chunk_confidence is not None else DEFAULT_CHUNK_CONFIDENCE
+    )
+    assertion_preference = (
+        assertion_preference
+        if assertion_preference is not None
+        else DEFAULT_ASSERTION_PREFERENCE
+    )
 
     raw_text = load_text_from_input(text, input_file)
 

--- a/phentrieve/cli/text_commands.py
+++ b/phentrieve/cli/text_commands.py
@@ -531,6 +531,19 @@ def process_text_for_hpo_command(
     start_time = time.time()
     setup_logging_cli(debug=debug)
 
+    # Optional: print resolved configuration to stderr for debugging.
+    import click as _click
+
+    _ctx = _click.get_current_context(silent=True)
+    if (
+        _ctx is not None
+        and isinstance(_ctx.obj, dict)
+        and _ctx.obj.get("show_resolved_config")
+    ):
+        from phentrieve.cli._profile import render_resolved_config
+
+        typer.echo(render_resolved_config(_ctx), err=True)
+
     # Resolve None defaults to fallback constants. Click's eager --profile
     # callback has already populated ctx.default_map (and Click has resolved
     # commandline overrides on top), so a None at this point means no flag,

--- a/phentrieve/cli/text_commands.py
+++ b/phentrieve/cli/text_commands.py
@@ -32,8 +32,12 @@ from phentrieve.config import (
     DEFAULT_STEP_SIZE_TOKENS,
     DEFAULT_TOP_K,
     DEFAULT_WINDOW_SIZE_TOKENS,
+    _load_yaml_config,
 )
 from phentrieve.llm import config as llm_config
+from phentrieve.retrieval.adaptive_rechunker import (
+    adaptive_config_from_profile_block,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -510,6 +514,34 @@ def process_text_for_hpo_command(
             help="Include HPO term definitions and synonyms in output",
         ),
     ] = False,
+    adaptive_rechunking: Annotated[
+        bool,
+        typer.Option(
+            "--adaptive-rechunking/--no-adaptive-rechunking",
+            help="Enable adaptive re-chunking (opt-in feature, see issue #148).",
+        ),
+    ] = False,
+    adaptive_rechunking_quality_threshold: Annotated[
+        float | None,
+        typer.Option(
+            "--adaptive-rechunking-quality-threshold",
+            help="top-1 similarity below which a chunk flags as poor.",
+        ),
+    ] = None,
+    adaptive_rechunking_margin_threshold: Annotated[
+        float | None,
+        typer.Option(
+            "--adaptive-rechunking-margin-threshold",
+            help="top_1 - top_2 below which a chunk flags as poor (with low score).",
+        ),
+    ] = None,
+    adaptive_rechunking_max_depth: Annotated[
+        int | None,
+        typer.Option(
+            "--adaptive-rechunking-max-depth",
+            help="Recursion depth cap (default 2).",
+        ),
+    ] = None,
 ) -> None:
     """Process clinical text to extract HPO terms.
 
@@ -644,6 +676,81 @@ def process_text_for_hpo_command(
                 )
                 raise typer.Exit(code=1)
 
+    # Resolve adaptive_rechunking config: CLI > profile > YAML > defaults.
+    # The eager --profile callback (Plan A) intentionally skips the
+    # `adaptive_rechunking` Profile field, so we resolve the block here in
+    # the command body. The boolean --adaptive-rechunking flag has a default
+    # of False; treat it as a CLI override only when explicitly supplied so
+    # profile/YAML enabled=True can pass through when the user didn't pass
+    # the flag.
+    adaptive_yaml = (
+        _load_yaml_config().get("extraction", {}).get("adaptive_rechunking", {})
+    )
+    adaptive_profile_block = None
+    try:
+        import click as _click_for_profile
+
+        _profile_ctx = _click_for_profile.get_current_context(silent=True)
+    except Exception:  # noqa: BLE001 - defensive: keep CLI working without click ctx
+        _profile_ctx = None
+
+    if _profile_ctx is not None:
+        try:
+            _adaptive_enabled_source = _profile_ctx.get_parameter_source(
+                "adaptive_rechunking"
+            )
+        except Exception:  # noqa: BLE001 - older click variants
+            _adaptive_enabled_source = None
+        # Resolve the active profile (if any) so its adaptive_rechunking block
+        # can layer between CLI and YAML.
+        try:
+            from phentrieve.profiles import (
+                merged_profiles,
+                resolve_profile_for_command,
+            )
+
+            _profile_name = _profile_ctx.params.get("profile") or None
+            if _profile_name == "":
+                _profile_name = None
+            _profile_obj, _ = resolve_profile_for_command(
+                _profile_name,
+                ("text", "process"),
+                set(),
+                all_profiles=merged_profiles(),
+            )
+            adaptive_profile_block = getattr(_profile_obj, "adaptive_rechunking", None)
+        except Exception:  # noqa: BLE001 - defensive: profile lookup is best-effort
+            adaptive_profile_block = None
+    else:
+        _adaptive_enabled_source = None
+
+    cli_overrides: dict[str, Any] = {}
+    try:
+        from click.core import ParameterSource as _PS  # noqa: WPS433
+
+        if (
+            _adaptive_enabled_source is not None
+            and _adaptive_enabled_source != _PS.DEFAULT
+        ):
+            cli_overrides["enabled"] = adaptive_rechunking
+    except Exception:  # noqa: BLE001
+        # Without ParameterSource we cannot distinguish default from explicit;
+        # fall back to passing the value through so --adaptive-rechunking
+        # still has an effect.
+        cli_overrides["enabled"] = adaptive_rechunking
+    if adaptive_rechunking_quality_threshold is not None:
+        cli_overrides["quality_threshold"] = adaptive_rechunking_quality_threshold
+    if adaptive_rechunking_margin_threshold is not None:
+        cli_overrides["margin_threshold"] = adaptive_rechunking_margin_threshold
+    if adaptive_rechunking_max_depth is not None:
+        cli_overrides["max_depth"] = adaptive_rechunking_max_depth
+
+    adaptive_config = adaptive_config_from_profile_block(
+        block=adaptive_profile_block,
+        yaml_block=adaptive_yaml,
+        cli_overrides=cli_overrides,
+    )
+
     try:
         service_result = run_full_text_service(
             text=raw_text,
@@ -665,6 +772,7 @@ def process_text_for_hpo_command(
             top_term_per_chunk=top_term_per_chunk,
             min_confidence_for_aggregated=aggregated_term_confidence,
             include_details=include_details,
+            adaptive_rechunking=adaptive_config,
         )
     except Exception as e:
         typer.secho(f"Error processing text: {e!s}", fg=typer.colors.RED, err=True)

--- a/phentrieve/cli/text_interactive.py
+++ b/phentrieve/cli/text_interactive.py
@@ -11,8 +11,15 @@ from typing import Annotated, Any
 
 import typer
 
+from phentrieve.cli._profile import apply_profile_callback
 from phentrieve.cli.utils import resolve_chunking_pipeline_config
-from phentrieve.config import DEFAULT_MODEL
+from phentrieve.config import (
+    DEFAULT_CHUNK_RETRIEVAL_THRESHOLD,
+    DEFAULT_LANGUAGE,
+    DEFAULT_MIN_CONFIDENCE_AGGREGATED,
+    DEFAULT_MODEL,
+    DEFAULT_TOP_K,
+)
 from phentrieve.retrieval.dense_retriever import DenseRetriever
 from phentrieve.text_processing.hpo_extraction_orchestrator import (
     orchestrate_hpo_extraction,
@@ -157,10 +164,24 @@ def _display_interactive_text_results(
 
 
 def interactive_text_mode(
-    language: Annotated[
+    profile: Annotated[
         str,
+        typer.Option(
+            "--profile",
+            "-P",
+            envvar="PHENTRIEVE_PROFILE",
+            help=(
+                "Apply a named profile from phentrieve.yaml. "
+                "See `phentrieve config list-profiles`."
+            ),
+            callback=apply_profile_callback,
+            is_eager=True,
+        ),
+    ] = "interactive",
+    language: Annotated[
+        str | None,
         typer.Option("--language", "-l", help="Language of the text (en, de, etc.)"),
-    ] = "en",
+    ] = None,
     strategy: Annotated[
         str,
         typer.Option(
@@ -214,21 +235,21 @@ def interactive_text_mode(
         typer.Option("--model", "-m", help="Model name for HPO term retrieval"),
     ] = None,
     chunk_retrieval_threshold: Annotated[
-        float,
+        float | None,
         typer.Option(
             "--chunk-retrieval-threshold",
             "-crt",
             help="Minimum similarity score for HPO term matches per chunk (0.0-1.0)",
         ),
-    ] = 0.3,
+    ] = None,
     num_results: Annotated[
-        int,
+        int | None,
         typer.Option(
             "--num-results",
             "-n",
             help="Maximum number of HPO terms to return per chunk",
         ),
-    ] = 5,
+    ] = None,
     no_assertion_detection: Annotated[
         bool,
         typer.Option(
@@ -252,13 +273,13 @@ def interactive_text_mode(
         ),
     ] = False,
     aggregated_term_confidence: Annotated[
-        float,
+        float | None,
         typer.Option(
             "--aggregated-term-confidence",
             "-atc",
             help="Minimum confidence score for aggregated HPO terms",
         ),
-    ] = 0.35,
+    ] = None,
     top_term_per_chunk: Annotated[
         bool,
         typer.Option(
@@ -286,6 +307,23 @@ def interactive_text_mode(
     from rich.console import Console
     from rich.panel import Panel
     from rich.prompt import Prompt
+
+    # Resolve None defaults to fallback constants. Click's eager --profile
+    # callback has already populated ctx.default_map (and Click has resolved
+    # commandline overrides on top), so a None at this point means no flag,
+    # no profile entry, and no YAML supplied a value.
+    language = language if language is not None else DEFAULT_LANGUAGE
+    chunk_retrieval_threshold = (
+        chunk_retrieval_threshold
+        if chunk_retrieval_threshold is not None
+        else DEFAULT_CHUNK_RETRIEVAL_THRESHOLD
+    )
+    aggregated_term_confidence = (
+        aggregated_term_confidence
+        if aggregated_term_confidence is not None
+        else DEFAULT_MIN_CONFIDENCE_AGGREGATED
+    )
+    num_results = num_results if num_results is not None else DEFAULT_TOP_K
 
     console = Console()
     setup_logging_cli(debug=debug)

--- a/phentrieve/cli/text_interactive.py
+++ b/phentrieve/cli/text_interactive.py
@@ -304,9 +304,21 @@ def interactive_text_mode(
         phentrieve text interactive -l de --annotations-above
         phentrieve text interactive -s semantic
     """
+    # Optional: print resolved configuration to stderr for debugging.
+    import click as _click
     from rich.console import Console
     from rich.panel import Panel
     from rich.prompt import Prompt
+
+    _ctx = _click.get_current_context(silent=True)
+    if (
+        _ctx is not None
+        and isinstance(_ctx.obj, dict)
+        and _ctx.obj.get("show_resolved_config")
+    ):
+        from phentrieve.cli._profile import render_resolved_config
+
+        typer.echo(render_resolved_config(_ctx), err=True)
 
     # Resolve None defaults to fallback constants. Click's eager --profile
     # callback has already populated ctx.default_map (and Click has resolved

--- a/phentrieve/config.py
+++ b/phentrieve/config.py
@@ -67,6 +67,13 @@ __all__ = [
     # HPO extraction thresholds
     "DEFAULT_CHUNK_RETRIEVAL_THRESHOLD",
     "DEFAULT_MIN_CONFIDENCE_AGGREGATED",
+    "DEFAULT_CHUNK_CONFIDENCE",
+    "DEFAULT_ASSERTION_PREFERENCE",
+    # CLI symmetry alias
+    "DEFAULT_NUM_RESULTS",
+    # Output format defaults
+    "DEFAULT_OUTPUT_FORMAT_QUERY",
+    "DEFAULT_OUTPUT_FORMAT_PROCESS",
     # Chunking strategy
     "DEFAULT_CHUNKING_STRATEGY",
     # Assertion detection
@@ -121,6 +128,12 @@ DEFAULT_MIN_SEGMENT_LENGTH_WORDS = 2
 # HPO extraction thresholds
 _DEFAULT_CHUNK_RETRIEVAL_THRESHOLD_FALLBACK = 0.7
 _DEFAULT_MIN_CONFIDENCE_AGGREGATED_FALLBACK = 0.75
+_DEFAULT_CHUNK_CONFIDENCE_FALLBACK = 0.2
+_DEFAULT_ASSERTION_PREFERENCE_FALLBACK = "dependency"
+
+# Output format defaults (used by CLI commands)
+_DEFAULT_OUTPUT_FORMAT_QUERY_FALLBACK = "text"
+_DEFAULT_OUTPUT_FORMAT_PROCESS_FALLBACK = "json_lines"
 
 # Default chunking strategy
 DEFAULT_CHUNKING_STRATEGY = "sliding_window_punct_conj_cleaned"
@@ -504,6 +517,23 @@ DEFAULT_CHUNK_RETRIEVAL_THRESHOLD: float = get_config_value(
 DEFAULT_MIN_CONFIDENCE_AGGREGATED: float = get_config_value(
     "extraction", _DEFAULT_MIN_CONFIDENCE_AGGREGATED_FALLBACK, "min_confidence"
 )
+DEFAULT_CHUNK_CONFIDENCE: float = get_config_value(
+    "extraction", _DEFAULT_CHUNK_CONFIDENCE_FALLBACK, "chunk_confidence"
+)
+DEFAULT_ASSERTION_PREFERENCE: str = get_config_value(
+    "extraction", _DEFAULT_ASSERTION_PREFERENCE_FALLBACK, "assertion_preference"
+)
+
+# Output format defaults
+DEFAULT_OUTPUT_FORMAT_QUERY: str = get_config_value(
+    "output", _DEFAULT_OUTPUT_FORMAT_QUERY_FALLBACK, "format_query"
+)
+DEFAULT_OUTPUT_FORMAT_PROCESS: str = get_config_value(
+    "output", _DEFAULT_OUTPUT_FORMAT_PROCESS_FALLBACK, "format_process"
+)
+
+# Alias for CLI symmetry - CLI uses num_results, config has DEFAULT_TOP_K
+DEFAULT_NUM_RESULTS: int = DEFAULT_TOP_K
 
 
 # =============================================================================

--- a/phentrieve/profiles.py
+++ b/phentrieve/profiles.py
@@ -1,0 +1,62 @@
+"""Profile data model and resolution for Phentrieve CLI configuration profiles.
+
+Implements Spec A (.planning/specs/2026-04-25-cli-profiles-default-resolution-spec.md).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Forward reference - defined in Plan B (phentrieve/retrieval/adaptive_rechunker.py).
+# Until Plan B lands, use a permissive dict shape.
+AdaptiveRechunkingProfileBlock = dict[str, Any]
+
+
+class Profile(BaseModel):
+    """A named bundle of CLI option defaults loaded from phentrieve.yaml.
+
+    All fields are optional. None means "this profile does not preset this
+    option" - the resolution chain falls through to YAML / fallback constants.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    description: str | None = None
+    command: str | None = None  # e.g. "text process", "query", "text interactive"
+
+    # Shared option keys
+    language: str | None = None
+    model_name: str | None = None
+    semantic_chunker_model: str | None = None
+    retrieval_model: str | None = None
+    similarity_threshold: float | None = None
+    chunk_retrieval_threshold: float | None = None
+    aggregated_term_confidence: float | None = None
+    num_results: int | None = None
+    chunking_strategy: str | None = None
+    window_size: int | None = None
+    step_size: int | None = None
+    split_threshold: float | None = None
+    min_segment_length: int | None = None
+    output_format: str | None = None
+    assertion_preference: str | None = None
+    no_assertion_detection: bool | None = None
+    multi_vector: bool | None = None
+    aggregation_strategy: str | None = None
+    extraction_backend: Literal["standard", "llm"] | None = None
+
+    # Adaptive rechunking block - strict shape defined by Plan B; permissive here.
+    adaptive_rechunking: AdaptiveRechunkingProfileBlock | None = None
+
+
+class ProfilesFile(BaseModel):
+    """Top-level YAML model.
+
+    Only the `profiles:` key is consumed by Plan A; other top-level keys
+    (data_dir, default_model, etc.) are ignored at this layer.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+    profiles: dict[str, Profile] = Field(default_factory=dict)

--- a/phentrieve/profiles.py
+++ b/phentrieve/profiles.py
@@ -5,8 +5,10 @@ Implements Spec A (.planning/specs/2026-04-25-cli-profiles-default-resolution-sp
 
 from __future__ import annotations
 
+import difflib
 from typing import Any, Literal
 
+import typer
 from pydantic import BaseModel, ConfigDict, Field
 
 # Forward reference - defined in Plan B (phentrieve/retrieval/adaptive_rechunker.py).
@@ -76,3 +78,83 @@ BUILTIN_PROFILES: dict[str, Profile] = {
         num_results=5,
     ),
 }
+
+
+def _profile_to_kwargs(profile: Profile, accepted_keys: set[str]) -> dict[str, Any]:
+    """Convert a Profile to a kwargs dict, filtered to accepted_keys.
+
+    Skips None fields (None means "this profile doesn't preset this option")
+    and fields not in accepted_keys (cross-command filter). An empty
+    accepted_keys set is treated as "no filter" (the auto-select callers
+    that don't care about the kwargs dict pass set()).
+    """
+    kwargs: dict[str, Any] = {}
+    for field_name, value in profile.model_dump().items():
+        if field_name in {"description", "command"}:
+            continue  # metadata, not options
+        if value is None:
+            continue
+        if accepted_keys and field_name not in accepted_keys:
+            continue
+        kwargs[field_name] = value
+    return kwargs
+
+
+def resolve_profile_for_command(
+    profile_name: str | None,
+    command_path: tuple[str, ...],
+    accepted_keys: set[str],
+    all_profiles: dict[str, Profile] | None = None,
+) -> tuple[Profile, dict[str, Any]]:
+    """Select the active profile and return (profile, kwargs_for_default_map).
+
+    Args:
+        profile_name: User-supplied name (`--profile X`), or None for auto-select.
+        command_path: Command tuple, e.g. ("text", "process") or ("query",).
+        accepted_keys: Option names the active command actually accepts.
+            Used to filter cross-command profiles down to applicable kwargs.
+        all_profiles: Merged dict of built-ins + user profiles. Defaults to
+            BUILTIN_PROFILES (test convenience).
+
+    Returns:
+        (profile_object, kwargs_dict) - the kwargs dict is what the eager
+        callback writes into ctx.default_map (after walking the precedence
+        stack with YAML and fallback constants).
+
+    Raises:
+        typer.BadParameter: profile_name is unknown, or is bound to a
+            different command via its `command` field.
+    """
+    profiles = all_profiles if all_profiles is not None else BUILTIN_PROFILES
+
+    if profile_name is None:
+        # Auto-selection
+        fallback = (
+            "interactive" if command_path == ("text", "interactive") else "default"
+        )
+        profile = profiles.get(fallback, BUILTIN_PROFILES[fallback])
+        return profile, _profile_to_kwargs(profile, accepted_keys)
+
+    if profile_name not in profiles:
+        candidates = difflib.get_close_matches(
+            profile_name, list(profiles.keys()), n=1, cutoff=0.6
+        )
+        msg = f"Profile {profile_name!r} not found."
+        if candidates:
+            msg += f" Did you mean: {candidates[0]!r}?"
+        raise typer.BadParameter(msg, param_hint="--profile")
+
+    profile = profiles[profile_name]
+
+    # Command binding check.
+    if profile.command is not None:
+        bound = tuple(profile.command.split())
+        if bound != command_path:
+            raise typer.BadParameter(
+                f"Profile {profile_name!r} is bound to command "
+                f"{profile.command!r} but was used with "
+                f"{' '.join(command_path)!r}.",
+                param_hint="--profile",
+            )
+
+    return profile, _profile_to_kwargs(profile, accepted_keys)

--- a/phentrieve/profiles.py
+++ b/phentrieve/profiles.py
@@ -60,3 +60,19 @@ class ProfilesFile(BaseModel):
 
     model_config = ConfigDict(extra="ignore")
     profiles: dict[str, Profile] = Field(default_factory=dict)
+
+
+# Built-in profiles ship as Python dict literals constructed into Profile
+# instances at import time. Users can shadow these by name in phentrieve.yaml.
+BUILTIN_PROFILES: dict[str, Profile] = {
+    "default": Profile(
+        description="Strict defaults matching API behavior",
+        # All fields None - falls through to YAML / fallback constants.
+    ),
+    "interactive": Profile(
+        description="Loose discovery defaults for `phentrieve text interactive`",
+        chunk_retrieval_threshold=0.3,
+        aggregated_term_confidence=0.35,
+        num_results=5,
+    ),
+}

--- a/phentrieve/profiles.py
+++ b/phentrieve/profiles.py
@@ -106,6 +106,8 @@ def resolve_profile_for_command(
     command_path: tuple[str, ...],
     accepted_keys: set[str],
     all_profiles: dict[str, Profile] | None = None,
+    *,
+    skip_binding_check: bool = False,
 ) -> tuple[Profile, dict[str, Any]]:
     """Select the active profile and return (profile, kwargs_for_default_map).
 
@@ -148,7 +150,7 @@ def resolve_profile_for_command(
     profile = profiles[profile_name]
 
     # Command binding check.
-    if profile.command is not None:
+    if profile.command is not None and not skip_binding_check:
         bound = tuple(profile.command.split())
         if bound != command_path:
             raise typer.BadParameter(

--- a/phentrieve/profiles.py
+++ b/phentrieve/profiles.py
@@ -6,10 +6,13 @@ Implements Spec A (.planning/specs/2026-04-25-cli-profiles-default-resolution-sp
 from __future__ import annotations
 
 import difflib
+import logging
 from typing import Any, Literal
 
 import typer
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+logger = logging.getLogger(__name__)
 
 # Forward reference - defined in Plan B (phentrieve/retrieval/adaptive_rechunker.py).
 # Until Plan B lands, use a permissive dict shape.
@@ -158,3 +161,62 @@ def resolve_profile_for_command(
             )
 
     return profile, _profile_to_kwargs(profile, accepted_keys)
+
+
+def load_profiles_from_yaml() -> dict[str, Profile]:
+    """Load and validate the `profiles:` section of phentrieve.yaml.
+
+    Each profile is validated independently - a failure on one profile
+    logs a WARNING and skips that profile, leaving others usable. The
+    `phentrieve config validate` command (Phase 8) raises non-zero on
+    validation errors so CI can catch them.
+
+    Caching is provided by the underlying ``phentrieve.config._load_yaml_config``
+    (an ``lru_cache``); call its ``cache_clear()`` when on-disk state changes.
+    """
+    # Lazy import to avoid circular dependency: config -> utils -> profiles.
+    from phentrieve.config import _load_yaml_config
+
+    raw = _load_yaml_config()
+    profiles_raw = raw.get("profiles", {})
+    if not isinstance(profiles_raw, dict):
+        logger.warning(
+            "phentrieve.yaml `profiles:` section is not a mapping; ignoring."
+        )
+        return {}
+
+    profiles: dict[str, Profile] = {}
+    for name, data in profiles_raw.items():
+        if not isinstance(data, dict):
+            logger.warning(
+                "Profile %r in phentrieve.yaml is not a mapping; skipping.", name
+            )
+            continue
+        try:
+            profiles[name] = Profile.model_validate(data)
+        except ValidationError as e:
+            logger.warning(
+                "Profile %r in phentrieve.yaml failed validation; skipping. %s",
+                name,
+                e,
+            )
+    return profiles
+
+
+# Tracks which built-in shadow names we've already logged about this session,
+# so the INFO message fires only on first use per name per session.
+_SHADOW_LOGGED: set[str] = set()
+
+
+def merged_profiles() -> dict[str, Profile]:
+    """Return BUILTIN_PROFILES merged with user profiles. User wins on shadow."""
+    user = load_profiles_from_yaml()
+    merged = {**BUILTIN_PROFILES, **user}
+    for name in user:
+        if name in BUILTIN_PROFILES and name not in _SHADOW_LOGGED:
+            logger.info(
+                "User profile %r in phentrieve.yaml shadows the built-in profile.",
+                name,
+            )
+            _SHADOW_LOGGED.add(name)
+    return merged

--- a/phentrieve/profiles.py
+++ b/phentrieve/profiles.py
@@ -12,11 +12,9 @@ from typing import Any, Literal
 import typer
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
-logger = logging.getLogger(__name__)
+from phentrieve.retrieval.adaptive_rechunker import AdaptiveRechunkingProfileBlock
 
-# Forward reference - defined in Plan B (phentrieve/retrieval/adaptive_rechunker.py).
-# Until Plan B lands, use a permissive dict shape.
-AdaptiveRechunkingProfileBlock = dict[str, Any]
+logger = logging.getLogger(__name__)
 
 
 class Profile(BaseModel):

--- a/phentrieve/retrieval/adaptive_rechunker.py
+++ b/phentrieve/retrieval/adaptive_rechunker.py
@@ -1,0 +1,99 @@
+"""Adaptive re-chunking for poor-quality retrieval results.
+
+Implements Spec B (.planning/specs/2026-04-25-adaptive-rechunking-spec.md).
+
+This module owns the runtime configuration shape (`AdaptiveRechunkingConfig`)
+and the Pydantic profile block schema (`AdaptiveRechunkingProfileBlock`) that
+Plan A's `Profile` model imports. Keeping the canonical block here keeps
+`phentrieve.profiles` free of feature-specific schema and avoids circular
+imports - this module does not import from `phentrieve.profiles`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+@dataclass(frozen=True)
+class AdaptiveRechunkingConfig:
+    """End-to-end configuration carried through the pipeline.
+
+    Frozen so it can be safely passed across function boundaries without
+    risk of mutation. Defaults are calibrated for BioLORD-class biomedical
+    encoders; users on other encoders should retune via YAML or CLI flags.
+    """
+
+    enabled: bool = False
+    quality_threshold: float = 0.55
+    margin_threshold: float = 0.03
+    use_ontology_coherence: bool = False  # reserved, inert in v1
+    max_depth: int = 2
+    min_chunk_chars: int = 30
+    max_sentences_per_subchunk: int = 3
+    overlap_sentences: int = 1
+    score_improvement_gate: float = 0.05
+
+
+class AdaptiveRechunkingProfileBlock(BaseModel):
+    """Pydantic block on `Profile.adaptive_rechunking`.
+
+    `extra="forbid"` so YAML typos error at load time. All fields are
+    optional - `None` means "this profile does not preset this knob" and
+    the resolution chain falls through to YAML / built-in defaults.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool | None = None
+    quality_threshold: float | None = None
+    margin_threshold: float | None = None
+    use_ontology_coherence: bool | None = None
+    max_depth: int | None = None
+    min_chunk_chars: int | None = None
+    max_sentences_per_subchunk: int | None = None
+    overlap_sentences: int | None = None
+    score_improvement_gate: float | None = None
+
+
+def adaptive_config_from_profile_block(
+    block: AdaptiveRechunkingProfileBlock | None,
+    yaml_block: dict[str, Any] | None = None,
+    cli_overrides: dict[str, Any] | None = None,
+) -> AdaptiveRechunkingConfig:
+    """Resolve an `AdaptiveRechunkingConfig` with CLI > profile > YAML > defaults.
+
+    Args:
+        block: Profile-level block (typically `Profile.adaptive_rechunking`).
+            `None` means no profile contribution.
+        yaml_block: Raw YAML mapping under `extraction.adaptive_rechunking`.
+            `None` means no YAML contribution.
+        cli_overrides: Mapping of CLI-supplied values keyed by config field
+            name. `None` (or values of `None`) means no CLI contribution
+            for the affected fields.
+
+    Returns:
+        A frozen `AdaptiveRechunkingConfig` populated by walking the
+        precedence stack for each field.
+    """
+    defaults = AdaptiveRechunkingConfig()
+    fields = set(defaults.__dataclass_fields__)
+
+    resolved: dict[str, Any] = {}
+    for name in fields:
+        cli_value = (cli_overrides or {}).get(name)
+        if cli_value is not None:
+            resolved[name] = cli_value
+            continue
+        profile_value = getattr(block, name, None) if block is not None else None
+        if profile_value is not None:
+            resolved[name] = profile_value
+            continue
+        yaml_value = (yaml_block or {}).get(name)
+        if yaml_value is not None:
+            resolved[name] = yaml_value
+            continue
+        resolved[name] = getattr(defaults, name)
+    return AdaptiveRechunkingConfig(**resolved)

--- a/phentrieve/retrieval/adaptive_rechunker.py
+++ b/phentrieve/retrieval/adaptive_rechunker.py
@@ -97,3 +97,75 @@ def adaptive_config_from_profile_block(
             continue
         resolved[name] = getattr(defaults, name)
     return AdaptiveRechunkingConfig(**resolved)
+
+
+@dataclass(frozen=True)
+class ChunkQualitySignals:
+    """Quality assessment of one chunk's retrieval result."""
+
+    chunk_idx: int
+    top_1: float | None
+    top_2: float | None
+    margin: float | None
+    n_matches_above_threshold: int
+    is_poor: bool
+    reason: str  # "low_score" | "low_margin" | "no_matches" | "ok"
+
+
+def assess_chunk_quality(
+    raw_query_result: dict[str, Any],
+    chunk_idx: int,
+    chunk_retrieval_threshold: float,
+    config: AdaptiveRechunkingConfig,
+) -> ChunkQualitySignals:
+    """Read top-K from raw query_batch output, decide if the chunk is poor.
+
+    Reads from ``raw_query_result["similarities"][0]`` (the unfiltered list of
+    top-K similarity scores from ``query_batch``). Crucially, this is NOT the
+    threshold-filtered ``chunk_results`` - see Spec B Architecture for why.
+
+    Trigger conjunction:
+        is_poor = top_1 < quality_threshold AND
+                  (margin < margin_threshold OR top_2 is None)
+    """
+    similarities_outer = raw_query_result.get("similarities") or []
+    similarities = similarities_outer[0] if similarities_outer else []
+
+    if not similarities:
+        return ChunkQualitySignals(
+            chunk_idx=chunk_idx,
+            top_1=None,
+            top_2=None,
+            margin=None,
+            n_matches_above_threshold=0,
+            is_poor=True,
+            reason="no_matches",
+        )
+
+    top_1 = similarities[0]
+    top_2 = similarities[1] if len(similarities) > 1 else None
+    margin = (top_1 - top_2) if top_2 is not None else None
+    n_above = sum(1 for s in similarities if s >= chunk_retrieval_threshold)
+
+    score_low = top_1 < config.quality_threshold
+    margin_low_or_unknown = top_2 is None or (
+        margin is not None and margin < config.margin_threshold
+    )
+
+    is_poor = score_low and margin_low_or_unknown
+    if not is_poor:
+        reason = "ok"
+    elif top_2 is None:
+        reason = "low_score"  # only one match, score too low
+    else:
+        reason = "low_margin"
+
+    return ChunkQualitySignals(
+        chunk_idx=chunk_idx,
+        top_1=top_1,
+        top_2=top_2,
+        margin=margin,
+        n_matches_above_threshold=n_above,
+        is_poor=is_poor,
+        reason=reason,
+    )

--- a/phentrieve/retrieval/adaptive_rechunker.py
+++ b/phentrieve/retrieval/adaptive_rechunker.py
@@ -169,3 +169,95 @@ def assess_chunk_quality(
         is_poor=is_poor,
         reason=reason,
     )
+
+
+def subdivide_parent_chunk(
+    parent_chunk: dict[str, Any],
+    language: str,
+    config: AdaptiveRechunkingConfig,
+    depth: int,
+) -> list[dict[str, Any]]:
+    """Generate sentence-bounded sub-chunks from a parent chunk.
+
+    Returns sub-chunks in the same dict shape as the upstream
+    ``TextProcessingPipeline`` output. Sub-chunks inherit the parent's
+    ``status`` / ``assertion_details`` (no re-detection in v1 - subdividing
+    a NEGATED parent must not flip non-negated tail clauses to AFFIRMED).
+    Returns ``[]`` if no useful subdivision is possible (single-sentence
+    parent, empty text, or every candidate would be dropped).
+
+    Each sub-chunk's ``source_indices.processing_stages`` gets the parent's
+    stages plus ``"adaptive_rechunker_depth_<N>"`` for traceability, and its
+    ``start_char`` / ``end_char`` are computed by linear search inside the
+    parent text and offset by the parent's ``start_char`` for absolute
+    document positions.
+    """
+    # Lazy import - SentenceChunker pulls in pysbd which is heavy.
+    from phentrieve.text_processing.chunkers import SentenceChunker
+
+    parent_text = parent_chunk.get("text", "")
+    if not parent_text:
+        return []
+
+    chunker = SentenceChunker(language=language)
+    sentences = chunker.chunk([parent_text])
+    if len(sentences) <= 1:
+        return []  # Single sentence - no useful subdivision.
+
+    # Sliding window: window=max_sentences_per_subchunk, step=window-overlap.
+    window = max(1, config.max_sentences_per_subchunk)
+    overlap = max(0, min(config.overlap_sentences, window - 1))
+    step = window - overlap
+    if step <= 0:
+        step = 1
+
+    parent_start = parent_chunk.get("start_char", 0)
+    parent_status = parent_chunk.get("status")
+    parent_details = parent_chunk.get("assertion_details")
+    parent_stages = list(
+        parent_chunk.get("source_indices", {}).get("processing_stages", [])
+    )
+    parent_text_stripped = parent_text.strip()
+
+    children: list[dict[str, Any]] = []
+    seen_texts: set[str] = set()
+    for i in range(0, len(sentences), step):
+        group = sentences[i : i + window]
+        if not group:
+            continue
+        sub_text = " ".join(group).strip()
+        if not sub_text:
+            continue
+        if sub_text == parent_text_stripped:
+            continue  # Identical to parent - no useful subdivision.
+        if sub_text in seen_texts:
+            continue
+        seen_texts.add(sub_text)
+        if len(sub_text) < config.min_chunk_chars:
+            continue
+
+        # Locate within the parent text to compute spans.
+        idx = parent_text.find(sub_text)
+        if idx < 0:
+            # Fallback: anchor on the first sentence of the group.
+            idx = parent_text.find(group[0]) if group else -1
+            if idx < 0:
+                idx = 0
+        start_char = parent_start + idx
+        end_char = start_char + len(sub_text)
+
+        children.append(
+            {
+                "text": sub_text,
+                "status": parent_status,
+                "assertion_details": parent_details,
+                "source_indices": {
+                    "processing_stages": parent_stages
+                    + [f"adaptive_rechunker_depth_{depth}"],
+                },
+                "start_char": start_char,
+                "end_char": end_char,
+            }
+        )
+
+    return children

--- a/phentrieve/retrieval/adaptive_rechunker.py
+++ b/phentrieve/retrieval/adaptive_rechunker.py
@@ -11,10 +11,13 @@ imports - this module does not import from `phentrieve.profiles`.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -307,3 +310,339 @@ def apply_score_improvement_gate(
         else:
             revert.add(parent_idx)
     return revert, keep
+
+
+@dataclass(frozen=True)
+class AdaptiveRechunkingResult:
+    """Return value of ``run_adaptive_rechunking``.
+
+    Mirrors the legacy 2-tuple ``(aggregated_results, chunk_results)`` that
+    callers expect from ``orchestrate_hpo_extraction`` while also exposing
+    the (possibly expanded / curated) ``processed_chunks`` and a ``meta``
+    dict with bookkeeping for telemetry / logging.
+    """
+
+    processed_chunks: list[dict[str, Any]]
+    aggregated_results: list[dict[str, Any]]
+    chunk_results: list[dict[str, Any]]
+    meta: dict[str, Any]
+
+
+def _placeholder_raw() -> dict[str, Any]:
+    """Empty raw query slot used while child slots are reserved before
+    the depth-N batch query has run.
+    """
+    return {
+        "ids": [[]],
+        "metadatas": [[]],
+        "similarities": [[]],
+        "distances": [[]],
+        "documents": [[]],
+    }
+
+
+def _no_op_result(
+    processed_chunks: list[dict[str, Any]],
+    chunk_results: list[dict[str, Any]],
+    meta: dict[str, Any],
+) -> AdaptiveRechunkingResult:
+    """Return a result that mirrors the inputs without doing anything.
+
+    ``aggregated_results`` is left empty - the caller already holds the
+    aggregated output from the initial extraction pass and does not need
+    the rechunker to recompute it when adaptive re-chunking is disabled
+    or no chunks were flagged.
+    """
+    return AdaptiveRechunkingResult(
+        processed_chunks=list(processed_chunks),
+        aggregated_results=[],
+        chunk_results=list(chunk_results),
+        meta=meta,
+    )
+
+
+def _aggregate(
+    chunks: list[dict[str, Any]],
+    raw: list[dict[str, Any]],
+    retriever: Any,
+    num_results_per_chunk: int,
+    chunk_retrieval_threshold: float,
+    language: str,
+    min_confidence_for_aggregated: float,
+    include_details: bool,
+    assertion_statuses: list[str | None] | None,
+) -> Any:
+    """Re-aggregate via ``orchestrate_hpo_extraction`` with precomputed raw
+    results so retrieval is skipped (cost-model invariant).
+    """
+    # Lazy import to avoid an import cycle: the orchestrator depends on
+    # the retriever module, and this module is imported from CLI / API
+    # paths that may not need the orchestrator on every call.
+    from phentrieve.text_processing.hpo_extraction_orchestrator import (
+        orchestrate_hpo_extraction,
+    )
+
+    text_chunks = [c.get("text", "") for c in chunks]
+    return orchestrate_hpo_extraction(
+        text_chunks=text_chunks,
+        retriever=retriever,
+        num_results_per_chunk=num_results_per_chunk,
+        chunk_retrieval_threshold=chunk_retrieval_threshold,
+        language=language,
+        min_confidence_for_aggregated=min_confidence_for_aggregated,
+        assertion_statuses=assertion_statuses,
+        include_details=include_details,
+        precomputed_query_results=raw,  # KEY: skips query_batch.
+    )
+
+
+def run_adaptive_rechunking(
+    processed_chunks: list[dict[str, Any]],
+    chunk_results: list[dict[str, Any]],
+    raw_query_results: list[dict[str, Any]],
+    retriever: Any,
+    language: str,
+    config: AdaptiveRechunkingConfig,
+    num_results_per_chunk: int,
+    chunk_retrieval_threshold: float,
+    min_confidence_for_aggregated: float,
+    include_details: bool,
+    assertion_statuses: list[str | None] | None = None,
+) -> AdaptiveRechunkingResult:
+    """Top-level adaptive re-chunking orchestration.
+
+    Cost contract: at most ``config.max_depth`` additional
+    ``retriever.query_batch`` calls (one per recursion level where chunks
+    flag as poor). Re-aggregation uses
+    ``orchestrate_hpo_extraction(precomputed_query_results=...)`` so
+    existing chunk results are not re-queried.
+
+    The function:
+      1. If disabled, returns inputs unchanged with no retrieval calls.
+      2. Detects poor chunks via ``assess_chunk_quality`` over the raw
+         (unfiltered) query results.
+      3. Subdivides each poor parent via ``subdivide_parent_chunk``.
+      4. Issues a single ``retriever.query_batch`` for all children at
+         this depth.
+      5. Applies the score-improvement gate to keep / revert per parent.
+      6. Rebuilds the flat chunk list (originals for non-flagged or
+         reverted parents, accepted children for kept parents).
+      7. Recurses on the new list up to ``config.max_depth``.
+      8. Re-aggregates once at the end via
+         ``orchestrate_hpo_extraction(precomputed_query_results=...)``.
+    """
+    meta: dict[str, Any] = {
+        "enabled": config.enabled,
+        "trigger_count": 0,
+        "subdivided_count": 0,
+        "reverted_count": 0,
+        "max_depth_reached": 0,
+        "extra_chunks_added": 0,
+    }
+
+    if not config.enabled:
+        return _no_op_result(processed_chunks, chunk_results, meta)
+
+    # Detect poor chunks at depth 0 (the initial pass already done by the
+    # caller). Used only for the trigger_count meta and the early-exit
+    # path - the recursion loop re-assesses against ``current_raw``.
+    initial_quality = [
+        assess_chunk_quality(raw, idx, chunk_retrieval_threshold, config)
+        for idx, raw in enumerate(raw_query_results)
+    ]
+    initial_poor = [s.chunk_idx for s in initial_quality if s.is_poor]
+    meta["trigger_count"] = len(initial_poor)
+
+    if not initial_poor:
+        # Nothing to subdivide - keep inputs as-is and skip aggregation
+        # (the caller already has aggregated_results from the initial
+        # extraction pass).
+        return _no_op_result(processed_chunks, chunk_results, meta)
+
+    # Recursion loop. Each iteration performs at most ONE query_batch call.
+    current_chunks: list[dict[str, Any]] = list(processed_chunks)
+    current_raw: list[dict[str, Any]] = list(raw_query_results)
+    current_assertions: list[str | None] = list(
+        assertion_statuses
+        if assertion_statuses is not None
+        else [c.get("status") for c in current_chunks]
+    )
+
+    any_kept = False
+    for depth in range(1, config.max_depth + 1):
+        # Identify chunks still flagged as poor at this depth, against the
+        # raw scores attached to the *current* flat list.
+        depth_quality = [
+            assess_chunk_quality(raw, idx, chunk_retrieval_threshold, config)
+            for idx, raw in enumerate(current_raw)
+        ]
+        depth_poor = {s.chunk_idx for s in depth_quality if s.is_poor}
+        if not depth_poor:
+            break
+
+        # Subdivide each poor parent and reserve slots for its children
+        # in the new flat list. Non-flagged chunks are copied through.
+        new_chunks: list[dict[str, Any]] = []
+        new_assertions: list[str | None] = []
+        new_raw: list[dict[str, Any]] = []
+        children_texts: list[str] = []
+        # Maps original-index-in-current_chunks -> new-flat-list slots.
+        child_slots: dict[int, list[int]] = {}
+
+        for idx, parent in enumerate(current_chunks):
+            if idx not in depth_poor:
+                new_chunks.append(parent)
+                new_assertions.append(current_assertions[idx])
+                new_raw.append(current_raw[idx])
+                continue
+            children = subdivide_parent_chunk(parent, language, config, depth)
+            if not children:
+                # Subdivision impossible - keep parent as-is.
+                new_chunks.append(parent)
+                new_assertions.append(current_assertions[idx])
+                new_raw.append(current_raw[idx])
+                continue
+            slot_indices: list[int] = []
+            for child in children:
+                slot_indices.append(len(new_chunks))
+                new_chunks.append(child)
+                new_assertions.append(child.get("status"))
+                new_raw.append(_placeholder_raw())
+                children_texts.append(child["text"])
+            child_slots[idx] = slot_indices
+
+        if not children_texts:
+            # No useful subdivision was possible at this depth.
+            break
+
+        # ONE query_batch call per recursion level (the cost-model
+        # invariant). Returned list is one entry per child text.
+        child_raw = retriever.query_batch(
+            texts=children_texts,
+            n_results=num_results_per_chunk,
+            include_similarities=True,
+        )
+        meta["max_depth_reached"] = depth
+
+        # Fill placeholders with real raw results in the same order they
+        # were appended to ``children_texts``.
+        ci = 0
+        for slot_indices in child_slots.values():
+            for slot in slot_indices:
+                new_raw[slot] = child_raw[ci]
+                ci += 1
+
+        # Score-improvement gate decides per parent: keep children, or
+        # revert to the original parent.
+        parent_top_1: dict[int, float] = {}
+        for parent_idx in child_slots:
+            sims_outer = current_raw[parent_idx].get("similarities") or []
+            sims = sims_outer[0] if sims_outer else []
+            if sims:
+                parent_top_1[parent_idx] = sims[0]
+
+        # Re-key child top_1 onto the parent_idx -> child slot mapping
+        # used by ``apply_score_improvement_gate``.
+        child_top_1: dict[int, float] = {}
+        for slot_indices in child_slots.values():
+            for slot in slot_indices:
+                sims_outer = new_raw[slot].get("similarities") or []
+                sims = sims_outer[0] if sims_outer else []
+                if sims:
+                    child_top_1[slot] = sims[0]
+
+        revert, keep = apply_score_improvement_gate(
+            child_slots, parent_top_1, child_top_1, config
+        )
+
+        if revert:
+            # Rebuild flat list: restore reverted parents, drop their
+            # children. Non-flagged chunks and kept-parent children pass
+            # through. Iterate ``current_chunks`` so we preserve original
+            # ordering for parents and pull children from ``new_*`` for
+            # kept parents.
+            keep_chunks: list[dict[str, Any]] = []
+            keep_assertions: list[str | None] = []
+            keep_raw: list[dict[str, Any]] = []
+            for idx, parent in enumerate(current_chunks):
+                if idx in child_slots and idx in revert:
+                    # Flagged + subdivided + reverted: restore parent.
+                    keep_chunks.append(parent)
+                    keep_assertions.append(current_assertions[idx])
+                    keep_raw.append(current_raw[idx])
+                elif idx in child_slots:
+                    # Flagged + subdivided + kept: append children.
+                    for slot in child_slots[idx]:
+                        keep_chunks.append(new_chunks[slot])
+                        keep_assertions.append(new_assertions[slot])
+                        keep_raw.append(new_raw[slot])
+                else:
+                    # Not flagged or subdivision failed: copy parent.
+                    keep_chunks.append(parent)
+                    keep_assertions.append(current_assertions[idx])
+                    keep_raw.append(current_raw[idx])
+            new_chunks, new_assertions, new_raw = (
+                keep_chunks,
+                keep_assertions,
+                keep_raw,
+            )
+
+        meta["subdivided_count"] += len(keep)
+        meta["reverted_count"] += len(revert)
+        if keep:
+            any_kept = True
+
+        current_chunks = new_chunks
+        current_assertions = new_assertions
+        current_raw = new_raw
+
+        if not keep:
+            # All subdivisions reverted - no point recursing further.
+            break
+
+    meta["extra_chunks_added"] = len(current_chunks) - len(processed_chunks)
+
+    if not any_kept:
+        # Nothing accepted - the flat list is unchanged from the input.
+        # Skip re-aggregation; caller already has the original aggregate.
+        return _no_op_result(processed_chunks, chunk_results, meta)
+
+    # Final re-aggregation using ``precomputed_query_results`` - no
+    # retrieval call.
+    final = _aggregate(
+        current_chunks,
+        current_raw,
+        retriever,
+        num_results_per_chunk,
+        chunk_retrieval_threshold,
+        language,
+        min_confidence_for_aggregated,
+        include_details,
+        current_assertions,
+    )
+
+    return AdaptiveRechunkingResult(
+        processed_chunks=current_chunks,
+        aggregated_results=final.aggregated_results,
+        chunk_results=final.chunk_results,
+        meta=meta,
+    )
+
+
+def dump_quality_report(
+    raw_query_results: list[dict[str, Any]],
+    chunk_retrieval_threshold: float,
+    config: AdaptiveRechunkingConfig,
+) -> str:
+    """Library-only helper for users tuning thresholds.
+
+    Returns a per-chunk quality report as a human-readable string.
+    """
+    lines = ["chunk_idx  is_poor  reason       top_1  top_2  margin"]
+    for idx, raw in enumerate(raw_query_results):
+        s = assess_chunk_quality(raw, idx, chunk_retrieval_threshold, config)
+        t1 = f"{s.top_1:.3f}" if s.top_1 is not None else "  -  "
+        t2 = f"{s.top_2:.3f}" if s.top_2 is not None else "  -  "
+        m = f"{s.margin:.3f}" if s.margin is not None else "  -  "
+        lines.append(f"{idx:>9}  {s.is_poor!s:<6}  {s.reason:<11}  {t1}  {t2}  {m}")
+    return "\n".join(lines)

--- a/phentrieve/retrieval/adaptive_rechunker.py
+++ b/phentrieve/retrieval/adaptive_rechunker.py
@@ -261,3 +261,49 @@ def subdivide_parent_chunk(
         )
 
     return children
+
+
+def apply_score_improvement_gate(
+    parent_to_children: dict[int, list[int]],
+    parent_top_1: dict[int, float],
+    child_top_1: dict[int, float],
+    config: AdaptiveRechunkingConfig,
+) -> tuple[set[int], set[int]]:
+    """Decide per parent whether subdivision improved retrieval enough to keep.
+
+    Returns:
+        ``(revert_parents, keep_parents)`` - indices of parents whose
+        children should be reverted (sub-chunks dropped, parent restored)
+        vs kept (sub-chunks replace the parent in the final flat list).
+
+    A parent is kept iff at least one of its children's ``top_1`` is at
+    least ``parent_top_1 + config.score_improvement_gate``. Parents with
+    no children, no recorded ``parent_top_1``, or no recorded child scores
+    are skipped (no children) or reverted (children but no scores).
+
+    Operates on raw ``top_1`` values from ``raw_query_results`` (parent)
+    and from this recursion level's child query (children). No
+    re-aggregation runs before the gate decision.
+    """
+    revert: set[int] = set()
+    keep: set[int] = set()
+    for parent_idx, children in parent_to_children.items():
+        if not children:
+            continue
+        parent_t1 = parent_top_1.get(parent_idx)
+        if parent_t1 is None:
+            continue
+        child_scores = [
+            score
+            for score in (child_top_1.get(c) for c in children)
+            if score is not None
+        ]
+        if not child_scores:
+            revert.add(parent_idx)
+            continue
+        best = max(child_scores)
+        if best >= parent_t1 + config.score_improvement_gate:
+            keep.add(parent_idx)
+        else:
+            revert.add(parent_idx)
+    return revert, keep

--- a/phentrieve/text_processing/full_text_service.py
+++ b/phentrieve/text_processing/full_text_service.py
@@ -605,28 +605,66 @@ def run_standard_backend(*, text: str, **kwargs: Any) -> StableBackendResponse:
         _normalize_status(chunk.get("status")) for chunk in processed_chunks
     ]
 
+    # Pop kwargs once so the values are reusable across initial + adaptive paths.
+    num_results_per_chunk = kwargs.pop("num_results_per_chunk", 10)
+    chunk_retrieval_threshold = kwargs.pop(
+        "chunk_retrieval_threshold", DEFAULT_CHUNK_RETRIEVAL_THRESHOLD
+    )
+    top_term_per_chunk = kwargs.pop("top_term_per_chunk", False)
+    min_confidence_for_aggregated = kwargs.pop(
+        "min_confidence_for_aggregated", DEFAULT_MIN_CONFIDENCE_AGGREGATED
+    )
+    include_details = kwargs.pop("include_details", False)
+
     extraction_result = orchestrate_hpo_extraction(
         text_chunks=text_chunks,
         retriever=retriever,
-        num_results_per_chunk=kwargs.pop("num_results_per_chunk", 10),
-        chunk_retrieval_threshold=kwargs.pop(
-            "chunk_retrieval_threshold", DEFAULT_CHUNK_RETRIEVAL_THRESHOLD
-        ),
+        num_results_per_chunk=num_results_per_chunk,
+        chunk_retrieval_threshold=chunk_retrieval_threshold,
         language=language,
-        top_term_per_chunk=kwargs.pop("top_term_per_chunk", False),
-        min_confidence_for_aggregated=kwargs.pop(
-            "min_confidence_for_aggregated", DEFAULT_MIN_CONFIDENCE_AGGREGATED
-        ),
+        top_term_per_chunk=top_term_per_chunk,
+        min_confidence_for_aggregated=min_confidence_for_aggregated,
         assertion_statuses=assertion_statuses,
-        include_details=kwargs.pop("include_details", False),
+        include_details=include_details,
     )
     aggregated_results = extraction_result.aggregated_results
     chunk_results = extraction_result.chunk_results
-    # raw_query_results is reachable via extraction_result.raw_query_results
-    # for the upcoming adaptive rechunker (Plan B Phase 6+).
+    raw_query_results = extraction_result.raw_query_results
+
+    # Adaptive rechunking - opt-in. No behavior change when config is absent
+    # or disabled.
+    adaptive_meta: dict[str, Any] | None = None
+    adaptive_cfg = kwargs.pop("adaptive_rechunking", None)
+    if adaptive_cfg is not None and getattr(adaptive_cfg, "enabled", False):
+        from phentrieve.retrieval.adaptive_rechunker import run_adaptive_rechunking
+
+        rechunk = run_adaptive_rechunking(
+            processed_chunks=processed_chunks,
+            chunk_results=chunk_results,
+            raw_query_results=raw_query_results,
+            retriever=retriever,
+            language=language,
+            config=adaptive_cfg,
+            num_results_per_chunk=num_results_per_chunk,
+            chunk_retrieval_threshold=chunk_retrieval_threshold,
+            min_confidence_for_aggregated=min_confidence_for_aggregated,
+            include_details=include_details,
+            assertion_statuses=assertion_statuses,
+        )
+        processed_chunks = rechunk.processed_chunks
+        # When the rechunker reports no kept subdivisions it returns an empty
+        # ``aggregated_results`` and expects the caller to keep the initial
+        # aggregate. Only swap in the rechunker's aggregate when it actually
+        # re-ran aggregation.
+        if rechunk.aggregated_results:
+            aggregated_results = rechunk.aggregated_results
+        chunk_results = rechunk.chunk_results
+        adaptive_meta = rechunk.meta
 
     return adapt_standard_response(
-        processed_chunks, (aggregated_results, chunk_results)
+        processed_chunks,
+        (aggregated_results, chunk_results),
+        extra_meta={"adaptive_rechunking": adaptive_meta} if adaptive_meta else None,
     )
 
 

--- a/phentrieve/text_processing/full_text_service.py
+++ b/phentrieve/text_processing/full_text_service.py
@@ -492,8 +492,15 @@ def adapt_standard_response(
     extraction_result: tuple[Sequence[Mapping[str, Any]], Sequence[Mapping[str, Any]]]
     | Mapping[str, Any]
     | None,
+    extra_meta: dict[str, Any] | None = None,
 ) -> StableBackendResponse:
-    """Convert pipeline and extraction outputs into the stable response shape."""
+    """Convert pipeline and extraction outputs into the stable response shape.
+
+    extra_meta: optional dict merged into the response's meta block. Used by
+    adaptive rechunking to surface its meta.adaptive_rechunking summary.
+    Canonical keys (extraction_backend, num_processed_chunks,
+    num_aggregated_hpo_terms) always win on conflict.
+    """
     if isinstance(pipeline_result, Mapping):
         processed_chunks = _coerce_list(
             pipeline_result.get("processed_chunks") or pipeline_result.get("chunks")
@@ -520,12 +527,14 @@ def adapt_standard_response(
     adapted_chunks = _adapt_processed_chunks(processed_chunks, chunk_results)
     adapted_terms = _adapt_aggregated_terms(aggregated_results)
 
+    # Build meta starting from extra_meta so canonical keys override.
+    meta_block: dict[str, Any] = dict(extra_meta or {})
+    meta_block["num_processed_chunks"] = len(adapted_chunks)
+    meta_block["num_aggregated_hpo_terms"] = len(adapted_terms)
+
     return adapt_full_text_response(
         {
-            "meta": {
-                "num_processed_chunks": len(adapted_chunks),
-                "num_aggregated_hpo_terms": len(adapted_terms),
-            },
+            "meta": meta_block,
             "processed_chunks": adapted_chunks,
             "aggregated_hpo_terms": adapted_terms,
         },

--- a/phentrieve/text_processing/full_text_service.py
+++ b/phentrieve/text_processing/full_text_service.py
@@ -596,7 +596,7 @@ def run_standard_backend(*, text: str, **kwargs: Any) -> StableBackendResponse:
         _normalize_status(chunk.get("status")) for chunk in processed_chunks
     ]
 
-    aggregated_results, chunk_results = orchestrate_hpo_extraction(
+    extraction_result = orchestrate_hpo_extraction(
         text_chunks=text_chunks,
         retriever=retriever,
         num_results_per_chunk=kwargs.pop("num_results_per_chunk", 10),
@@ -611,6 +611,10 @@ def run_standard_backend(*, text: str, **kwargs: Any) -> StableBackendResponse:
         assertion_statuses=assertion_statuses,
         include_details=kwargs.pop("include_details", False),
     )
+    aggregated_results = extraction_result.aggregated_results
+    chunk_results = extraction_result.chunk_results
+    # raw_query_results is reachable via extraction_result.raw_query_results
+    # for the upcoming adaptive rechunker (Plan B Phase 6+).
 
     return adapt_standard_response(
         processed_chunks, (aggregated_results, chunk_results)

--- a/phentrieve/text_processing/hpo_extraction_orchestrator.py
+++ b/phentrieve/text_processing/hpo_extraction_orchestrator.py
@@ -12,6 +12,7 @@ from phentrieve.config import DEFAULT_HPO_DB_FILENAME
 from phentrieve.data_processing.hpo_database import HPODatabase
 from phentrieve.retrieval.dense_retriever import DenseRetriever
 from phentrieve.retrieval.text_attribution import get_text_attributions
+from phentrieve.text_processing.orchestration_result import OrchestrationResult
 from phentrieve.utils import get_default_data_dir, resolve_data_path
 
 logger = logging.getLogger(__name__)
@@ -27,10 +28,8 @@ def orchestrate_hpo_extraction(
     min_confidence_for_aggregated: float = 0.0,
     assertion_statuses: list[str | None] | None = None,
     include_details: bool = False,
-) -> tuple[
-    list[dict[str, Any]],  # aggregated results
-    list[dict[str, Any]],  # chunk results
-]:
+    precomputed_query_results: list[dict] | None = None,
+) -> OrchestrationResult:
     """Orchestrate HPO term extraction from text.
 
     Process involves:
@@ -47,24 +46,45 @@ def orchestrate_hpo_extraction(
         min_confidence_for_aggregated: Minimum confidence threshold for aggregated terms
         assertion_statuses: Optional list of assertion statuses per chunk
         include_details: If True, include HPO term definitions and synonyms in results
+        precomputed_query_results: Optional pre-fetched per-chunk raw retrieval
+            results (same shape as ``DenseRetriever.query_batch`` output, one
+            entry per chunk). When provided, retrieval is skipped and
+            aggregation runs over the supplied data. Used by the adaptive
+            rechunker to re-aggregate over a curated mix of original and
+            child-chunk raw results without re-querying.
 
     Returns:
-        Tuple containing:
-        - List of aggregated HPO terms with scores and ranks
-        - List of chunk-level results with matches
+        OrchestrationResult dataclass exposing ``aggregated_results``,
+        ``chunk_results``, and ``raw_query_results``. Iteration and indexing
+        yield the legacy 2-tuple ``(aggregated_results, chunk_results)`` for
+        backward compatibility with existing call sites.
     """
     # Initialize results
     chunk_results = []  # Store results for each chunk
     aggregated_hpo_evidence_map = defaultdict(list)  # Group evidence by HPO ID
 
     # OPTIMIZATION: Query all chunks at once using batch API (10-20x faster!)
-    # This replaces the sequential query loop with a single batch query to ChromaDB
-    logger.info(f"Batch querying {len(text_chunks)} chunks at once")
-    all_query_results = retriever.query_batch(
-        texts=text_chunks,
-        n_results=num_results_per_chunk,
-        include_similarities=True,
-    )
+    # This replaces the sequential query loop with a single batch query to ChromaDB.
+    # If precomputed_query_results is supplied (e.g. from the adaptive
+    # rechunker's re-aggregation pass), skip retrieval and use it directly.
+    if precomputed_query_results is not None:
+        if len(precomputed_query_results) != len(text_chunks):
+            raise ValueError(
+                f"precomputed_query_results length ({len(precomputed_query_results)}) "
+                f"does not match text_chunks length ({len(text_chunks)})"
+            )
+        all_query_results = precomputed_query_results
+        logger.info(
+            "Using %d precomputed query results (skipping retrieval)",
+            len(all_query_results),
+        )
+    else:
+        logger.info(f"Batch querying {len(text_chunks)} chunks at once")
+        all_query_results = retriever.query_batch(
+            texts=text_chunks,
+            n_results=num_results_per_chunk,
+            include_similarities=True,
+        )
 
     # Process chunks with pre-fetched results
     for chunk_idx, chunk_text in enumerate(text_chunks):
@@ -294,4 +314,8 @@ def orchestrate_hpo_extraction(
         f"above threshold {min_confidence_for_aggregated}"
     )
 
-    return (aggregated_results_list, chunk_results)
+    return OrchestrationResult(
+        aggregated_results=aggregated_results_list,
+        chunk_results=chunk_results,
+        raw_query_results=list(all_query_results),
+    )

--- a/phentrieve/text_processing/orchestration_result.py
+++ b/phentrieve/text_processing/orchestration_result.py
@@ -1,0 +1,45 @@
+"""Return type for orchestrate_hpo_extraction.
+
+Implements __iter__ and __getitem__ to preserve legacy 2-tuple unpacking
+(aggregated_results, chunk_results) while exposing raw_query_results as a
+new field for callers that need access to unfiltered retrieval scores
+(specifically the adaptive rechunker).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class OrchestrationResult:
+    """Return value of orchestrate_hpo_extraction.
+
+    Backward compatibility: iteration and indexing yield the legacy 2-tuple
+    ``(aggregated_results, chunk_results)``. Attribute access exposes
+    ``raw_query_results`` for new callers that need the unfiltered top-K
+    similarity output from ``DenseRetriever.query_batch`` (e.g. adaptive
+    re-chunking, which needs scores below ``chunk_retrieval_threshold``).
+    """
+
+    aggregated_results: list[dict[str, Any]]
+    chunk_results: list[dict[str, Any]]
+    raw_query_results: list[dict[str, Any]] = field(default_factory=list)
+
+    def __iter__(self) -> Iterator[list[dict[str, Any]]]:
+        """Yield (aggregated_results, chunk_results) for legacy 2-tuple unpack."""
+        yield self.aggregated_results
+        yield self.chunk_results
+
+    def __getitem__(self, idx: int) -> list[dict[str, Any]]:
+        """Index 0 -> aggregated_results, 1 -> chunk_results. For legacy callers."""
+        if idx == 0:
+            return self.aggregated_results
+        if idx == 1:
+            return self.chunk_results
+        raise IndexError(f"OrchestrationResult index {idx} out of range (0..1)")
+
+    def __len__(self) -> int:
+        return 2  # iteration yields 2 elements

--- a/tests/fixtures/adaptive_rechunking/expected_terms_with_adaptive.json
+++ b/tests/fixtures/adaptive_rechunking/expected_terms_with_adaptive.json
@@ -1,0 +1,4 @@
+{
+  "_note": "Populated empirically by running the e2e test against the test ChromaDB index. The test asserts at least one HPO term not present in the no-adaptive baseline.",
+  "minimum_extra_terms": 1
+}

--- a/tests/fixtures/adaptive_rechunking/synthetic_multi_finding.txt
+++ b/tests/fixtures/adaptive_rechunking/synthetic_multi_finding.txt
@@ -1,0 +1,1 @@
+The patient has severe global developmental delay, frequent generalized tonic-clonic seizures since age 2, and bilateral sensorineural hearing loss. Brain MRI revealed cortical atrophy and bilateral periventricular nodular heterotopia. The mother and maternal grandmother are reported to have similar findings.

--- a/tests/fixtures/profiles/sample_phentrieve.yaml
+++ b/tests/fixtures/profiles/sample_phentrieve.yaml
@@ -1,0 +1,19 @@
+profiles:
+  high_recall_german:
+    description: "Recall-oriented German extraction"
+    command: text process
+    language: de
+    chunk_retrieval_threshold: 0.5
+
+  precise_english_query:
+    command: query
+    num_results: 3
+    similarity_threshold: 0.6
+
+  shared_lang:
+    language: de
+
+  shadow_test:
+    description: "User profile shadowing built-in"
+    # name `shadow_test` does not collide with built-ins by default,
+    # but tests that shadow `interactive` use the same key separately.

--- a/tests/integration/test_adaptive_rechunking_api.py
+++ b/tests/integration/test_adaptive_rechunking_api.py
@@ -1,0 +1,146 @@
+"""API parity for adaptive re-chunking.
+
+Plan B Phase 9 / Task 12: verify that ``TextProcessingRequest`` accepts an
+optional ``adaptive_rechunking`` block, that the router forwards it to the
+shared full-text service as an ``AdaptiveRechunkingConfig`` instance, and
+that the response surfaces ``meta.adaptive_rechunking`` when populated by
+the backend.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def _standard_context() -> dict[str, object]:
+    from phentrieve.config import DEFAULT_MODEL
+
+    return {
+        "actual_language": "en",
+        "retrieval_model_name": DEFAULT_MODEL,
+        "chunking_pipeline_config": [{"type": "simple"}],
+        "retriever": MagicMock(),
+        "text_pipeline": MagicMock(sbert_model=MagicMock()),
+    }
+
+
+@pytest.fixture
+def client():
+    from fastapi.testclient import TestClient
+
+    from api.main import app
+
+    with TestClient(app, raise_server_exceptions=False) as test_client:
+        yield test_client
+
+
+class TestAdaptiveRechunkingAPI:
+    """Adaptive re-chunking parity between the CLI and the HTTP API."""
+
+    def test_request_with_adaptive_rechunking_forwards_config(self, client):
+        """Request with adaptive_rechunking block forwards a resolved config."""
+        from phentrieve.retrieval.adaptive_rechunker import AdaptiveRechunkingConfig
+
+        captured_kwargs: dict[str, object] = {}
+
+        def fake_run(**kwargs: object) -> dict[str, object]:
+            captured_kwargs.update(kwargs)
+            return {
+                "meta": {
+                    "extraction_backend": "standard",
+                    "adaptive_rechunking": {
+                        "enabled": True,
+                        "trigger_count": 1,
+                        "subdivisions": 2,
+                        "applied": True,
+                    },
+                },
+                "processed_chunks": [],
+                "aggregated_hpo_terms": [],
+            }
+
+        with patch(
+            "api.routers.text_processing_router._prepare_standard_request_context",
+            AsyncMock(return_value=_standard_context()),
+        ):
+            with patch(
+                "api.routers.text_processing_router.run_full_text_service",
+                side_effect=fake_run,
+            ):
+                response = client.post(
+                    "/api/v1/text/process",
+                    json={
+                        "text": "Patient with seizures.",
+                        "extraction_backend": "standard",
+                        "adaptive_rechunking": {
+                            "enabled": True,
+                            "quality_threshold": 0.5,
+                            "margin_threshold": 0.02,
+                        },
+                    },
+                )
+
+        assert response.status_code == 200, response.text
+
+        # The router must hand the shared service a frozen config dataclass
+        # rather than the raw Pydantic block.
+        forwarded = captured_kwargs.get("adaptive_rechunking")
+        assert isinstance(forwarded, AdaptiveRechunkingConfig)
+        assert forwarded.enabled is True
+        assert forwarded.quality_threshold == 0.5
+        assert forwarded.margin_threshold == 0.02
+
+        body = response.json()
+        assert body["meta"]["adaptive_rechunking"]["enabled"] is True
+        assert body["meta"]["adaptive_rechunking"]["trigger_count"] == 1
+
+    def test_request_without_adaptive_rechunking_omits_field(self, client):
+        """Default request must not forward an adaptive config nor surface meta."""
+        captured_kwargs: dict[str, object] = {}
+
+        def fake_run(**kwargs: object) -> dict[str, object]:
+            captured_kwargs.update(kwargs)
+            return {
+                "meta": {"extraction_backend": "standard"},
+                "processed_chunks": [],
+                "aggregated_hpo_terms": [],
+            }
+
+        with patch(
+            "api.routers.text_processing_router._prepare_standard_request_context",
+            AsyncMock(return_value=_standard_context()),
+        ):
+            with patch(
+                "api.routers.text_processing_router.run_full_text_service",
+                side_effect=fake_run,
+            ):
+                response = client.post(
+                    "/api/v1/text/process",
+                    json={
+                        "text": "Patient with seizures.",
+                        "extraction_backend": "standard",
+                    },
+                )
+
+        assert response.status_code == 200, response.text
+        assert "adaptive_rechunking" not in captured_kwargs
+        body = response.json()
+        assert "adaptive_rechunking" not in body.get("meta", {})
+
+    def test_adaptive_rechunking_request_field_rejects_unknown_keys(self, client):
+        """The request schema forbids unknown adaptive_rechunking keys (extra=forbid)."""
+        response = client.post(
+            "/api/v1/text/process",
+            json={
+                "text": "Patient with seizures.",
+                "adaptive_rechunking": {
+                    "enabled": True,
+                    "this_key_does_not_exist": 1.0,
+                },
+            },
+        )
+        assert response.status_code == 422

--- a/tests/integration/test_adaptive_rechunking_benchmark.py
+++ b/tests/integration/test_adaptive_rechunking_benchmark.py
@@ -1,0 +1,88 @@
+"""Benchmark integration: adaptive rechunking does not regress aggregated
+term counts on the small German fixture.
+
+Uses the small German fixture from
+``tests/data/benchmarks/german/tiny_v1.json``. The full ontology-aware
+metric validation (commit 9402a57) is the release-gate manual run quoted
+in Spec B; this CI-friendly smoke verifies adaptive on does not produce
+fewer aggregated terms than baseline. Marked ``slow`` because it exercises
+the full standard backend across multiple cases.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = REPO_ROOT / "tests" / "data" / "benchmarks" / "german" / "tiny_v1.json"
+
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+
+def _try_run_standard(text: str, **kwargs: object) -> dict[str, Any] | None:
+    """Run the standard backend; return None if local resources are missing.
+
+    Returning ``None`` rather than calling ``pytest.skip`` lets the caller
+    accumulate skip context across the loop body.
+    """
+    from phentrieve.text_processing.full_text_service import run_standard_backend
+
+    try:
+        return dict(run_standard_backend(text=text, **kwargs))
+    except Exception:  # noqa: BLE001 - tolerate missing index / model in CI
+        return None
+
+
+def test_adaptive_does_not_regress_ontology_metric() -> None:
+    """Adaptive on vs off should not produce fewer aggregated terms.
+
+    A loose CI tripwire; the full ontology-aware metric (MRR with LCA
+    credit) is checked manually pre-release per Spec B.
+    """
+    pytest.importorskip("chromadb")
+    if not FIXTURE.exists():
+        pytest.skip(f"German tiny benchmark fixture missing at {FIXTURE}")
+
+    from phentrieve.retrieval.adaptive_rechunker import AdaptiveRechunkingConfig
+
+    cases = json.loads(FIXTURE.read_text())
+    if not isinstance(cases, list) or not cases:
+        pytest.skip("German tiny benchmark fixture is empty or malformed")
+
+    baseline_terms_count = 0
+    adaptive_terms_count = 0
+    cases_evaluated = 0
+    for case in cases[:3]:  # Keep test runtime bounded.
+        text = case.get("text", "") if isinstance(case, dict) else ""
+        if not text:
+            continue
+        baseline = _try_run_standard(text=text, language="de")
+        if baseline is None:
+            pytest.skip("Standard backend unavailable - skipping benchmark smoke.")
+        adaptive_cfg = AdaptiveRechunkingConfig(enabled=True, max_depth=1)
+        adaptive = _try_run_standard(
+            text=text, language="de", adaptive_rechunking=adaptive_cfg
+        )
+        if adaptive is None:
+            pytest.skip("Standard backend unavailable - skipping benchmark smoke.")
+
+        baseline_terms_count += len(baseline.get("aggregated_hpo_terms") or [])
+        adaptive_terms_count += len(adaptive.get("aggregated_hpo_terms") or [])
+        cases_evaluated += 1
+
+    if cases_evaluated == 0:
+        pytest.skip("No usable benchmark cases evaluated.")
+
+    # Loose check: adaptive should not produce *fewer* terms on average.
+    # Allow a tolerance of 1 term across the small slice to absorb noise
+    # (a single dropped low-confidence term should not block a release).
+    assert adaptive_terms_count >= baseline_terms_count - 1, (
+        f"Adaptive surfaced fewer terms ({adaptive_terms_count}) than "
+        f"baseline ({baseline_terms_count}) across {cases_evaluated} cases; "
+        f"investigate before merging."
+    )

--- a/tests/integration/test_adaptive_rechunking_call_count.py
+++ b/tests/integration/test_adaptive_rechunking_call_count.py
@@ -1,0 +1,106 @@
+"""HARD CONTRACT: at most ``max_depth`` additional ``retriever.query_batch``
+calls during adaptive rechunking, even when every chunk flags as poor at
+every level.
+
+This is the cost-model invariant from Spec B. The
+``precomputed_query_results`` parameter on ``orchestrate_hpo_extraction``
+is what makes the bound tight; a regression that re-queries parents during
+the final aggregation pass would fail this test.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from phentrieve.retrieval.adaptive_rechunker import (
+    AdaptiveRechunkingConfig,
+    run_adaptive_rechunking,
+)
+
+pytestmark = pytest.mark.integration
+
+
+def _make_raw(similarities: list[float]) -> dict[str, Any]:
+    """Build a query_batch-shaped raw result dict for a single chunk."""
+    return {
+        "ids": [[f"HP:{i:07d}" for i in range(len(similarities))]],
+        "metadatas": [
+            [{"id": f"HP:{i:07d}", "label": "x"} for i in range(len(similarities))]
+        ],
+        "similarities": [similarities],
+        "distances": [[1 - s for s in similarities]],
+        "documents": [[""] * len(similarities)],
+    }
+
+
+def test_at_most_max_depth_query_batch_calls() -> None:
+    """Worst case fan-out: every chunk flags at every reachable level.
+
+    The hard cap is ``config.max_depth`` calls to ``retriever.query_batch``.
+    A regression that re-queries parents during the final aggregation pass
+    (e.g., dropping ``precomputed_query_results`` somewhere) would fail
+    this assertion.
+    """
+    retriever = MagicMock()
+    # Simulate every level still flagging poor. Side effects supply one
+    # query_batch return value per recursion level. ``max_depth=2`` so we
+    # provide at most two levels of fan-out.
+    retriever.query_batch.side_effect = [
+        # depth 1: 3 children (one sentence each), all still poor
+        [_make_raw([0.5, 0.49]) for _ in range(3)],
+        # depth 2: would-be grandchildren; sentence-level parents cannot
+        # subdivide further, so this is unused but kept defensively.
+        [_make_raw([0.55, 0.54]) for _ in range(3)],
+    ]
+
+    processed = [
+        {
+            "text": "First sentence. Second sentence. Third sentence.",
+            "status": "AFFIRMED",
+            "start_char": 0,
+            "end_char": 49,
+            "source_indices": {"processing_stages": ["sentence"]},
+        }
+    ]
+    chunk_results = [
+        {"chunk_idx": 0, "chunk_text": processed[0]["text"], "matches": []}
+    ]
+    raw = [_make_raw([0.4, 0.39])]
+
+    config = AdaptiveRechunkingConfig(
+        enabled=True,
+        max_depth=2,
+        quality_threshold=0.6,
+        margin_threshold=0.03,
+        score_improvement_gate=0.05,
+        max_sentences_per_subchunk=1,
+        overlap_sentences=0,
+        min_chunk_chars=5,
+    )
+
+    # ``run_adaptive_rechunking`` may re-aggregate via
+    # ``orchestrate_hpo_extraction`` which is patched away by injecting
+    # precomputed raws; we still want to be sure no other retrieval calls
+    # leak through.
+    run_adaptive_rechunking(
+        processed_chunks=processed,
+        chunk_results=chunk_results,
+        raw_query_results=raw,
+        retriever=retriever,
+        language="en",
+        config=config,
+        num_results_per_chunk=10,
+        chunk_retrieval_threshold=0.7,
+        min_confidence_for_aggregated=0.0,
+        include_details=False,
+    )
+
+    assert retriever.query_batch.call_count <= config.max_depth, (
+        f"query_batch was called {retriever.query_batch.call_count} times; "
+        f"max_depth={config.max_depth} should be the cap. "
+        f"This fails if the precomputed_query_results contract regresses "
+        f"and parents (or accepted children) get re-queried."
+    )

--- a/tests/integration/test_adaptive_rechunking_e2e.py
+++ b/tests/integration/test_adaptive_rechunking_e2e.py
@@ -1,0 +1,87 @@
+"""End-to-end test: adaptive rechunking improves recall on a synthetic
+multi-finding fixture against a real (or mocked) ChromaDB index.
+
+Skipped when the local ChromaDB HPO index is not available (CI default).
+Marked `slow` because it exercises the full standard backend including
+the SentenceChunker, encoder, and retriever.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_TXT = (
+    REPO_ROOT
+    / "tests"
+    / "fixtures"
+    / "adaptive_rechunking"
+    / "synthetic_multi_finding.txt"
+)
+
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+
+def _try_run_standard(text: str, **kwargs: object) -> dict[str, object]:
+    """Run the standard backend, skipping the test if the local HPO index
+    or model resources are not available.
+    """
+    from phentrieve.text_processing.full_text_service import run_standard_backend
+
+    try:
+        return run_standard_backend(text=text, **kwargs)
+    except Exception as exc:  # noqa: BLE001 - tolerate missing index / model in CI
+        pytest.skip(
+            f"Skipping e2e test: standard backend unavailable in this "
+            f"environment ({type(exc).__name__}: {exc})."
+        )
+
+
+def test_adaptive_rechunking_finds_more_terms() -> None:
+    """With adaptive on, the aggregated terms include at least one HPO term
+    not surfaced by the no-adaptive baseline.
+
+    Asserts ``meta.adaptive_rechunking`` is populated when the rechunker
+    actually fires.
+    """
+    pytest.importorskip("chromadb")
+    assert FIXTURE_TXT.exists(), f"Fixture {FIXTURE_TXT} missing"
+
+    from phentrieve.retrieval.adaptive_rechunker import AdaptiveRechunkingConfig
+
+    text = FIXTURE_TXT.read_text()
+
+    # No-adaptive baseline.
+    baseline = _try_run_standard(text=text, language="en")
+    baseline_terms = baseline.get("aggregated_hpo_terms") or []
+    baseline_ids = {t["id"] for t in baseline_terms if "id" in t}
+
+    # Adaptive on with permissive thresholds to ensure trigger fires
+    # on at least one of the long, multi-finding sentences.
+    config = AdaptiveRechunkingConfig(
+        enabled=True,
+        quality_threshold=0.7,
+        margin_threshold=0.1,
+        max_depth=2,
+        min_chunk_chars=20,
+    )
+    adaptive = _try_run_standard(text=text, language="en", adaptive_rechunking=config)
+    adaptive_terms = adaptive.get("aggregated_hpo_terms") or []
+    adaptive_ids = {t["id"] for t in adaptive_terms if "id" in t}
+
+    # Meta block reflects the adaptive run when it fired.
+    meta = adaptive.get("meta") or {}
+    if "adaptive_rechunking" in meta:
+        assert meta["adaptive_rechunking"]["enabled"] is True
+
+    extra = adaptive_ids - baseline_ids
+    # At least one term gained. If the encoder is strong enough to never
+    # flag anything as poor on the fixture, this is a useful regression
+    # signal too - the test will fail and we should re-tune the fixture.
+    assert len(extra) >= 1, (
+        f"Adaptive rechunking did not surface any new terms. "
+        f"Baseline: {baseline_ids}. Adaptive: {adaptive_ids}."
+    )

--- a/tests/integration/test_adaptive_rechunking_e2e.py
+++ b/tests/integration/test_adaptive_rechunking_e2e.py
@@ -38,6 +38,7 @@ def _try_run_standard(text: str, **kwargs: object) -> dict[str, object]:
             f"Skipping e2e test: standard backend unavailable in this "
             f"environment ({type(exc).__name__}: {exc})."
         )
+        return {}  # unreachable: pytest.skip raises Skipped — satisfies static analysis
 
 
 def test_adaptive_rechunking_finds_more_terms() -> None:

--- a/tests/integration/test_adaptive_rechunking_perf.py
+++ b/tests/integration/test_adaptive_rechunking_perf.py
@@ -1,0 +1,78 @@
+"""Perf smoke test: wall time for a fully-flagging fixture document is
+within a loose 5x bound.
+
+Designed to catch egregious regressions (accidentally re-running the full
+pipeline, or scaling encoder fan-out unboundedly) - not to specify
+performance. The hard invariant is the call_count test.
+
+Marked ``slow`` because it loads the standard backend (encoder + retriever)
+and is excluded from the default ``make test`` run.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+
+def _try_run_standard(text: str, **kwargs: object) -> dict[str, object]:
+    """Run the standard backend, skipping the test if local resources
+    (HPO index, encoder model) are unavailable.
+    """
+    from phentrieve.text_processing.full_text_service import run_standard_backend
+
+    try:
+        return run_standard_backend(text=text, **kwargs)
+    except Exception as exc:  # noqa: BLE001 - tolerate missing index / model in CI
+        pytest.skip(
+            f"Skipping perf smoke: standard backend unavailable "
+            f"({type(exc).__name__}: {exc})."
+        )
+
+
+def test_wall_time_within_loose_bound() -> None:
+    """5x is loose because encoder fan-out scales with sub-chunk count, not
+    query-call count. The call_count test enforces the tight cost-model
+    bound; this test guards against runtime explosions that could ship past
+    a query-counting test (e.g., re-running the entire pipeline).
+    """
+    pytest.importorskip("chromadb")
+
+    from phentrieve.retrieval.adaptive_rechunker import AdaptiveRechunkingConfig
+
+    text = (
+        "Patient has seizures. Patient has hearing loss. "
+        "Patient has developmental delay. Patient has microcephaly. "
+        "Patient has hypotonia. Patient has ataxia. "
+        "Patient has spasticity. Patient has scoliosis. "
+        "Patient has dysmorphic features. "
+        "Patient has cognitive impairment."
+    )
+
+    t0 = time.perf_counter()
+    _try_run_standard(text=text, language="en")
+    baseline = time.perf_counter() - t0
+
+    config = AdaptiveRechunkingConfig(
+        enabled=True,
+        # Very aggressive thresholds so most chunks flag as poor.
+        quality_threshold=0.95,
+        margin_threshold=0.5,
+        max_depth=2,
+        max_sentences_per_subchunk=2,
+        overlap_sentences=0,
+        min_chunk_chars=10,
+    )
+    t0 = time.perf_counter()
+    _try_run_standard(text=text, language="en", adaptive_rechunking=config)
+    adaptive = time.perf_counter() - t0
+
+    multiplier = adaptive / baseline if baseline > 0 else 1.0
+    assert multiplier <= 5.0, (
+        f"Adaptive rechunking is {multiplier:.2f}x slower than baseline; "
+        f"loose bound is 5x. Encoder fan-out can legitimately exceed the "
+        f"query-call multiplier, but exceeding 5x usually means a regression."
+    )

--- a/tests/integration/test_adaptive_rechunking_perf.py
+++ b/tests/integration/test_adaptive_rechunking_perf.py
@@ -31,6 +31,7 @@ def _try_run_standard(text: str, **kwargs: object) -> dict[str, object]:
             f"Skipping perf smoke: standard backend unavailable "
             f"({type(exc).__name__}: {exc})."
         )
+        return {}  # unreachable: pytest.skip raises Skipped — satisfies static analysis
 
 
 def test_wall_time_within_loose_bound() -> None:

--- a/tests/integration/test_documented_yaml.py
+++ b/tests/integration/test_documented_yaml.py
@@ -1,0 +1,43 @@
+"""Integration test that every YAML snippet in docs/user-guide/
+configuration-profiles.md parses against the Profile schema."""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml as pyyaml
+
+from phentrieve.profiles import ProfilesFile
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOC = REPO_ROOT / "docs" / "user-guide" / "configuration-profiles.md"
+
+
+def _extract_yaml_blocks(md_text: str) -> list[str]:
+    """Find all ```yaml ... ``` fenced blocks in the markdown."""
+    pattern = re.compile(r"```yaml\n(.*?)```", re.DOTALL)
+    return pattern.findall(md_text)
+
+
+def test_doc_exists():
+    assert DOC.exists(), f"Documentation file {DOC} missing"
+
+
+def test_yaml_blocks_present():
+    blocks = _extract_yaml_blocks(DOC.read_text())
+    assert len(blocks) >= 2, "Expected at least two YAML examples in the doc"
+
+
+@pytest.mark.parametrize("block_idx", range(20))  # bounded loop
+def test_each_yaml_block_parses(block_idx: int):
+    blocks = _extract_yaml_blocks(DOC.read_text())
+    if block_idx >= len(blocks):
+        pytest.skip(f"No block at index {block_idx}")
+    raw = pyyaml.safe_load(blocks[block_idx])
+    assert raw is not None, f"Block {block_idx} parsed as None"
+    # Wrap in a profiles: dict if not already a top-level shape.
+    if "profiles" in raw:
+        ProfilesFile.model_validate(raw)
+    else:
+        # It's a profile body example or extraction section - both are fine.
+        pass

--- a/tests/integration/test_documented_yaml.py
+++ b/tests/integration/test_documented_yaml.py
@@ -1,5 +1,10 @@
-"""Integration test that every YAML snippet in docs/user-guide/
-configuration-profiles.md parses against the Profile schema."""
+"""Integration test that every YAML snippet in user-guide docs parses
+against the schemas it documents.
+
+Currently covers:
+- docs/user-guide/configuration-profiles.md (Plan A)
+- docs/user-guide/adaptive-rechunking.md    (Plan B)
+"""
 
 import re
 from pathlib import Path
@@ -8,9 +13,11 @@ import pytest
 import yaml as pyyaml
 
 from phentrieve.profiles import ProfilesFile
+from phentrieve.retrieval.adaptive_rechunker import AdaptiveRechunkingProfileBlock
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOC = REPO_ROOT / "docs" / "user-guide" / "configuration-profiles.md"
+ADAPTIVE_DOC = REPO_ROOT / "docs" / "user-guide" / "adaptive-rechunking.md"
 
 
 def _extract_yaml_blocks(md_text: str) -> list[str]:
@@ -40,4 +47,48 @@ def test_each_yaml_block_parses(block_idx: int):
         ProfilesFile.model_validate(raw)
     else:
         # It's a profile body example or extraction section - both are fine.
+        pass
+
+
+# -----------------------------------------------------------------------------
+# adaptive-rechunking.md (Plan B)
+# -----------------------------------------------------------------------------
+
+
+def _validate_adaptive_block(raw: dict) -> None:
+    """Validate an extraction.adaptive_rechunking mapping."""
+    block = raw["extraction"]["adaptive_rechunking"]
+    AdaptiveRechunkingProfileBlock.model_validate(block)
+
+
+def test_adaptive_doc_exists():
+    assert ADAPTIVE_DOC.exists(), f"Documentation file {ADAPTIVE_DOC} missing"
+
+
+def test_adaptive_yaml_blocks_present():
+    blocks = _extract_yaml_blocks(ADAPTIVE_DOC.read_text())
+    assert len(blocks) >= 3, (
+        "Expected at least three YAML examples in adaptive-rechunking.md "
+        "(quick start, full schema, worked examples)"
+    )
+
+
+@pytest.mark.parametrize("block_idx", range(20))  # bounded loop
+def test_each_adaptive_yaml_block_parses(block_idx: int):
+    blocks = _extract_yaml_blocks(ADAPTIVE_DOC.read_text())
+    if block_idx >= len(blocks):
+        pytest.skip(f"No block at index {block_idx}")
+    raw = pyyaml.safe_load(blocks[block_idx])
+    assert raw is not None, f"Block {block_idx} parsed as None"
+
+    if "profiles" in raw:
+        # Profile-style example: validate against ProfilesFile. The nested
+        # adaptive_rechunking block is validated by Pydantic via the Profile
+        # field type.
+        ProfilesFile.model_validate(raw)
+    elif "extraction" in raw and "adaptive_rechunking" in raw["extraction"]:
+        # Direct extraction.adaptive_rechunking example.
+        _validate_adaptive_block(raw)
+    else:
+        # Plain mapping (e.g. response meta example) - just confirm it parsed.
         pass

--- a/tests/integration/test_profiles_e2e.py
+++ b/tests/integration/test_profiles_e2e.py
@@ -1,0 +1,91 @@
+"""End-to-end profile resolution test using a real fixture YAML."""
+
+import shutil
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from phentrieve.config import _load_yaml_config
+from phentrieve.utils import load_user_config
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = REPO_ROOT / "tests" / "fixtures" / "profiles" / "sample_phentrieve.yaml"
+
+
+@pytest.fixture
+def cwd_with_fixture(tmp_path, monkeypatch):
+    shutil.copy(FIXTURE, tmp_path / "phentrieve.yaml")
+    monkeypatch.chdir(tmp_path)
+    # Both caches must be cleared: _load_yaml_config delegates to
+    # load_user_config which has its own lru_cache.
+    _load_yaml_config.cache_clear()
+    load_user_config.cache_clear()
+    yield tmp_path
+    _load_yaml_config.cache_clear()
+    load_user_config.cache_clear()
+
+
+@pytest.fixture
+def app():
+    # Import from phentrieve.cli directly: phentrieve.__main__ invokes the app
+    # at import time (it's the CLI entrypoint), so importing it inside tests
+    # fails with SystemExit. The Typer `app` object lives in phentrieve.cli.
+    from phentrieve.cli import app as a
+
+    return a
+
+
+class TestE2EProfileResolution:
+    def test_list_profiles_includes_user_and_builtin(self, app, cwd_with_fixture):
+        runner = CliRunner()
+        result = runner.invoke(app, ["config", "list-profiles"])
+        assert result.exit_code == 0
+        assert "high_recall_german" in result.stdout
+        assert "precise_english_query" in result.stdout
+        assert "default" in result.stdout
+        assert "interactive" in result.stdout
+
+    def test_validate_clean_fixture(self, app, cwd_with_fixture):
+        runner = CliRunner()
+        result = runner.invoke(app, ["config", "validate"])
+        assert result.exit_code == 0
+
+    def test_unknown_profile_close_match(self, app, cwd_with_fixture):
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["query", "TEXT", "--profile", "precise_english"],  # missing _query
+        )
+        assert result.exit_code != 0
+        assert "precise_english_query" in result.output  # close-match suggestion
+
+    def test_command_bound_mismatch_errors(self, app, cwd_with_fixture):
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["query", "TEXT", "--profile", "high_recall_german"],
+            # high_recall_german is bound to text process, not query
+        )
+        assert result.exit_code != 0
+        assert "text process" in result.output
+
+    def test_env_var_selects_profile(self, app, cwd_with_fixture, monkeypatch):
+        # PHENTRIEVE_PROFILE is the documented env var; its value flows
+        # through the eager --profile callback exactly like an explicit
+        # `--profile` flag. We only need to verify the profile is found
+        # and accepted (exit_code 0 path), not full query orchestration.
+        # query_orchestrator.orchestrate_query is imported lazily inside
+        # the command, so we patch it at its real module location.
+        monkeypatch.setenv("PHENTRIEVE_PROFILE", "precise_english_query")
+        with patch(
+            "phentrieve.retrieval.query_orchestrator.orchestrate_query"
+        ) as mock_orch:
+            mock_orch.return_value = True
+            runner = CliRunner()
+            result = runner.invoke(app, ["query", "TEXT"])
+            if mock_orch.called:
+                # Profile was applied -> num_results=3 should reach the call.
+                assert result.exit_code == 0
+                assert mock_orch.call_args.kwargs.get("num_results") == 3

--- a/tests/integration/test_specA_specB_interaction.py
+++ b/tests/integration/test_specA_specB_interaction.py
@@ -1,0 +1,135 @@
+"""Cross-spec test: Spec A (CLI profiles) + Spec B (adaptive_rechunking).
+
+Verifies that:
+
+1. A profile setting ``adaptive_rechunking.{enabled,quality_threshold}``
+   in ``phentrieve.yaml`` is propagated to the resolved
+   ``AdaptiveRechunkingConfig`` passed to ``run_full_text_service``.
+2. Explicit ``--adaptive-rechunking-quality-threshold`` on the command
+   line overrides the profile value while leaving other profile-supplied
+   knobs (here, ``enabled=True``) intact.
+
+The full-text service itself is patched out; this test exercises only
+the resolution chain and CLI plumbing.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from phentrieve.config import _load_yaml_config
+from phentrieve.utils import load_user_config
+
+pytestmark = pytest.mark.integration
+
+
+def _clear_yaml_cache() -> None:
+    """Clear the LRU caches that back YAML / user-config loading so each
+    test sees its own ``phentrieve.yaml`` written in ``tmp_path``.
+    """
+    _load_yaml_config.cache_clear()
+    load_user_config.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _yaml(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Write a phentrieve.yaml in CWD that defines a profile carrying
+    an ``adaptive_rechunking`` block, and clear the cached config so the
+    test sees the freshly written file.
+    """
+    (tmp_path / "phentrieve.yaml").write_text(
+        "profiles:\n"
+        "  german_recall:\n"
+        "    command: text process\n"
+        "    language: de\n"
+        "    adaptive_rechunking:\n"
+        "      enabled: true\n"
+        "      quality_threshold: 0.6\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    _clear_yaml_cache()
+    yield
+    _clear_yaml_cache()
+
+
+@pytest.fixture
+def app() -> Any:
+    """The top-level Typer app, imported lazily to avoid invoking it at
+    module import time (``phentrieve/__main__.py`` calls ``app()`` on
+    import).
+    """
+    from phentrieve.cli import app as a
+
+    return a
+
+
+@patch("phentrieve.cli.text_commands.run_full_text_service")
+def test_profile_provides_adaptive_config(
+    mock_run: Any, app: Any, tmp_path: Any
+) -> None:
+    """A profile-supplied ``adaptive_rechunking`` block flows through to
+    the resolved ``AdaptiveRechunkingConfig`` even with no CLI flags.
+    """
+    mock_run.return_value = {
+        "meta": {"extraction_backend": "standard"},
+        "processed_chunks": [],
+        "aggregated_hpo_terms": [],
+    }
+    input_file = tmp_path / "in.txt"
+    input_file.write_text("Patient.")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "text",
+            "process",
+            "-i",
+            str(input_file),
+            "--profile",
+            "german_recall",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    cfg = mock_run.call_args.kwargs["adaptive_rechunking"]
+    assert cfg.enabled is True
+    assert cfg.quality_threshold == 0.6
+
+
+@patch("phentrieve.cli.text_commands.run_full_text_service")
+def test_explicit_flag_overrides_profile_adaptive(
+    mock_run: Any, app: Any, tmp_path: Any
+) -> None:
+    """Explicit ``--adaptive-rechunking-quality-threshold`` overrides the
+    profile-supplied threshold; other profile values pass through.
+    """
+    mock_run.return_value = {
+        "meta": {"extraction_backend": "standard"},
+        "processed_chunks": [],
+        "aggregated_hpo_terms": [],
+    }
+    input_file = tmp_path / "in.txt"
+    input_file.write_text("Patient.")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "text",
+            "process",
+            "-i",
+            str(input_file),
+            "--profile",
+            "german_recall",
+            "--adaptive-rechunking-quality-threshold",
+            "0.5",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    cfg = mock_run.call_args.kwargs["adaptive_rechunking"]
+    assert cfg.quality_threshold == 0.5  # CLI wins
+    assert cfg.enabled is True  # from profile

--- a/tests/unit/cli/test_config_commands.py
+++ b/tests/unit/cli/test_config_commands.py
@@ -1,0 +1,151 @@
+"""Tests for `phentrieve config list-profiles / show / validate / path`."""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from phentrieve.config import _load_yaml_config
+from phentrieve.utils import load_user_config
+
+
+@pytest.fixture(autouse=True)
+def _yaml_setup(tmp_path, monkeypatch):
+    """Create a temporary phentrieve.yaml with one user profile and switch CWD."""
+    (tmp_path / "phentrieve.yaml").write_text(
+        "profiles:\n"
+        "  fast_query:\n"
+        "    description: 'Quick English query'\n"
+        "    command: query\n"
+        "    num_results: 5\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    _load_yaml_config.cache_clear()
+    load_user_config.cache_clear()
+    yield
+    _load_yaml_config.cache_clear()
+    load_user_config.cache_clear()
+
+
+@pytest.fixture
+def app():
+    from phentrieve.cli import app as a
+
+    return a
+
+
+class TestConfigListProfiles:
+    def test_lists_user_and_builtin(self, app):
+        runner = CliRunner()
+        result = runner.invoke(app, ["config", "list-profiles"])
+        assert result.exit_code == 0, result.output
+        assert "fast_query" in result.stdout
+        assert "default" in result.stdout
+        assert "interactive" in result.stdout
+
+    def test_shows_command_binding(self, app):
+        runner = CliRunner()
+        result = runner.invoke(app, ["config", "list-profiles"])
+        assert result.exit_code == 0, result.output
+        # fast_query is bound to query; the binding column should show "query".
+        assert "query" in result.stdout
+
+    def test_shadowing_marks_user_source(self, app, tmp_path):
+        # Override the YAML to shadow the built-in `interactive` profile.
+        (tmp_path / "phentrieve.yaml").write_text(
+            "profiles:\n"
+            "  interactive:\n"
+            "    description: 'Shadowed interactive'\n"
+            "    num_results: 7\n"
+        )
+        _load_yaml_config.cache_clear()
+        load_user_config.cache_clear()
+        runner = CliRunner()
+        result = runner.invoke(app, ["config", "list-profiles"])
+        assert result.exit_code == 0, result.output
+        # The shadowed entry should mention "shadows" or similar marker.
+        assert "interactive" in result.stdout
+        assert "shadow" in result.stdout.lower()
+
+
+class TestConfigShow:
+    def test_show_user_profile(self, app):
+        runner = CliRunner()
+        result = runner.invoke(app, ["config", "show", "fast_query"])
+        assert result.exit_code == 0, result.output
+        assert "num_results: 5" in result.stdout
+        assert "command: query" in result.stdout
+
+    def test_show_builtin_interactive(self, app):
+        runner = CliRunner()
+        result = runner.invoke(app, ["config", "show", "interactive"])
+        assert result.exit_code == 0, result.output
+        assert "chunk_retrieval_threshold: 0.3" in result.stdout
+
+    def test_show_unknown_profile_errors(self, app):
+        runner = CliRunner()
+        result = runner.invoke(app, ["config", "show", "nonexistent"])
+        assert result.exit_code != 0
+        assert "nonexistent" in result.output
+
+    def test_show_shadowed_profile_uses_user_version(self, app, tmp_path):
+        (tmp_path / "phentrieve.yaml").write_text(
+            "profiles:\n"
+            "  interactive:\n"
+            "    description: 'Shadowed interactive'\n"
+            "    num_results: 7\n"
+        )
+        _load_yaml_config.cache_clear()
+        load_user_config.cache_clear()
+        runner = CliRunner()
+        result = runner.invoke(app, ["config", "show", "interactive"])
+        assert result.exit_code == 0, result.output
+        assert "num_results: 7" in result.stdout
+        # The user version does NOT set chunk_retrieval_threshold, so it must
+        # not appear in the output.
+        assert "chunk_retrieval_threshold" not in result.stdout
+
+
+class TestConfigValidate:
+    def test_validate_clean_yaml(self, app):
+        runner = CliRunner()
+        result = runner.invoke(app, ["config", "validate"])
+        assert result.exit_code == 0, result.output
+
+    def test_validate_invalid_yaml_errors(self, app, tmp_path):
+        (tmp_path / "phentrieve.yaml").write_text(
+            "profiles:\n  bad:\n    unknown_field: value\n"
+        )
+        _load_yaml_config.cache_clear()
+        load_user_config.cache_clear()
+        runner = CliRunner()
+        result = runner.invoke(app, ["config", "validate"])
+        assert result.exit_code != 0
+        assert "bad" in result.output
+
+
+class TestConfigPath:
+    def test_path_prints_loaded_yaml(self, app):
+        runner = CliRunner()
+        result = runner.invoke(app, ["config", "path"])
+        assert result.exit_code == 0, result.output
+        assert "phentrieve.yaml" in result.stdout
+
+    def test_path_no_config_lists_search_order(self, app, tmp_path, monkeypatch):
+        # Switch to an empty dir without phentrieve.yaml and point user config
+        # dir at another empty location so no file is found.
+        empty_cwd = tmp_path / "empty"
+        empty_cwd.mkdir()
+        empty_user = tmp_path / "user_config"
+        empty_user.mkdir()
+        monkeypatch.chdir(empty_cwd)
+        monkeypatch.setattr("phentrieve.utils.get_user_config_dir", lambda: empty_user)
+        _load_yaml_config.cache_clear()
+        load_user_config.cache_clear()
+        runner = CliRunner()
+        result = runner.invoke(app, ["config", "path"])
+        assert result.exit_code == 0, result.output
+        assert (
+            "No phentrieve.yaml" in result.stdout
+            or "not found" in result.stdout.lower()
+        )

--- a/tests/unit/cli/test_default_map_resolution.py
+++ b/tests/unit/cli/test_default_map_resolution.py
@@ -1,0 +1,264 @@
+"""Tests proving Click's default_map resolution combined with the sidecar
+source map (Spec A Task 8).
+
+The eager --profile callback merges values from the profile, top-level
+YAML, and fallback constants into ``ctx.default_map``. ``ParameterSource``
+alone cannot distinguish those layers - they all report as ``DEFAULT_MAP``.
+The sidecar map at ``ctx.obj['resolved_sources']`` provides the fine-grained
+label. These tests assert BOTH signals on representative paths.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import click
+import typer
+from click.core import ParameterSource
+from typer.testing import CliRunner
+
+
+def _clear_config_caches() -> None:
+    """Clear every LRU cache that backs phentrieve YAML config loading.
+
+    Both ``phentrieve.config._load_yaml_config`` AND
+    ``phentrieve.utils.load_user_config`` are cached separately; clearing
+    only one leaves the other returning stale state across tests.
+    """
+    from phentrieve.config import _load_yaml_config
+    from phentrieve.utils import load_user_config
+
+    _load_yaml_config.cache_clear()
+    load_user_config.cache_clear()
+
+
+def _make_app(captured: dict):
+    """Build a tiny Typer app whose subcommand records both signals."""
+    from phentrieve.cli._profile import apply_profile_callback
+
+    app = typer.Typer()
+
+    @app.callback()
+    def root(
+        ctx: typer.Context,
+        profile: str = typer.Option(
+            "default",
+            "--profile",
+            callback=apply_profile_callback,
+            is_eager=True,
+        ),
+    ):
+        ctx.ensure_object(dict)
+
+    @app.command()
+    def cmd(
+        ctx: typer.Context,
+        language: str | None = typer.Option(None, "--language"),
+        chunk_retrieval_threshold: float | None = typer.Option(
+            None, "--chunk-retrieval-threshold"
+        ),
+        num_results: int | None = typer.Option(None, "--num-results"),
+    ):
+        captured["language"] = language
+        captured["chunk_retrieval_threshold"] = chunk_retrieval_threshold
+        captured["num_results"] = num_results
+        captured["sources"] = dict(ctx.obj.get("resolved_sources", {}))
+        captured["language_param_source"] = ctx.get_parameter_source("language")
+        captured["chunk_param_source"] = ctx.get_parameter_source(
+            "chunk_retrieval_threshold"
+        )
+        captured["num_results_param_source"] = ctx.get_parameter_source("num_results")
+
+    return app
+
+
+class TestDefaultMapResolution:
+    """Each invariant proves: function body sees the right value, and BOTH
+    ``ParameterSource`` and ``resolved_sources`` agree on its provenance."""
+
+    def test_constant_when_nothing_is_set(self, monkeypatch, tmp_path):
+        """No profile (built-in 'default'), no YAML, no flag.
+        Expectation: function-body fallback receives the resolved value
+        from ``default_map`` populated with the const-source label.
+        """
+        monkeypatch.chdir(tmp_path)
+        _clear_config_caches()
+
+        captured: dict = {}
+        runner = CliRunner()
+        result = runner.invoke(_make_app(captured), ["cmd"])
+        assert result.exit_code == 0, result.output
+
+        # No --language flag => language defaulted from default_map.
+        # Built-in 'default' profile is empty and YAML is empty, so the
+        # fallback constant supplies the value.
+        assert captured["language_param_source"] == ParameterSource.DEFAULT_MAP
+        assert captured["sources"]["language"].startswith("const:")
+        assert "DEFAULT_LANGUAGE" in captured["sources"]["language"]
+
+    def test_yaml_value_when_no_profile_no_flag(self, monkeypatch, tmp_path):
+        """Top-level YAML supplies a value; no profile preset, no flag.
+        Expectation: language comes from YAML, sidecar shows yaml: label,
+        ParameterSource is DEFAULT_MAP.
+        """
+        yaml_path = tmp_path / "phentrieve.yaml"
+        yaml_path.write_text(
+            textwrap.dedent(
+                """\
+                default_language: it
+                """
+            )
+        )
+        monkeypatch.chdir(tmp_path)
+        _clear_config_caches()
+
+        captured: dict = {}
+        runner = CliRunner()
+        result = runner.invoke(_make_app(captured), ["cmd"])
+        assert result.exit_code == 0, result.output
+
+        assert captured["language"] == "it"
+        assert captured["language_param_source"] == ParameterSource.DEFAULT_MAP
+        assert captured["sources"]["language"] == "yaml:default_language"
+
+    def test_profile_value_beats_yaml(self, monkeypatch, tmp_path):
+        """A user profile sets language=de while YAML says it.
+        Expectation: profile wins; sidecar carries profile:<name>.
+        """
+        yaml_path = tmp_path / "phentrieve.yaml"
+        yaml_path.write_text(
+            textwrap.dedent(
+                """\
+                default_language: it
+                profiles:
+                  german_workflow:
+                    description: German extraction
+                    language: de
+                """
+            )
+        )
+        monkeypatch.chdir(tmp_path)
+        _clear_config_caches()
+
+        captured: dict = {}
+        runner = CliRunner()
+        result = runner.invoke(
+            _make_app(captured), ["--profile", "german_workflow", "cmd"]
+        )
+        assert result.exit_code == 0, result.output
+
+        assert captured["language"] == "de"
+        assert captured["language_param_source"] == ParameterSource.DEFAULT_MAP
+        assert captured["sources"]["language"] == "profile:german_workflow"
+
+    def test_explicit_flag_beats_profile(self, monkeypatch, tmp_path):
+        """User passes --language fr while profile says de.
+        Expectation: function sees fr; ParameterSource is COMMANDLINE
+        (overrides any sidecar entry).
+        """
+        yaml_path = tmp_path / "phentrieve.yaml"
+        yaml_path.write_text(
+            textwrap.dedent(
+                """\
+                profiles:
+                  german_workflow:
+                    language: de
+                """
+            )
+        )
+        monkeypatch.chdir(tmp_path)
+        _clear_config_caches()
+
+        captured: dict = {}
+        runner = CliRunner()
+        result = runner.invoke(
+            _make_app(captured),
+            ["--profile", "german_workflow", "cmd", "--language", "fr"],
+        )
+        assert result.exit_code == 0, result.output
+
+        assert captured["language"] == "fr"
+        # COMMANDLINE always wins over any default_map injection - this is
+        # the user-vs-injected distinction the spec calls out as the key
+        # signal that the sidecar source map alone cannot provide.
+        assert captured["language_param_source"] == ParameterSource.COMMANDLINE
+
+    def test_builtin_interactive_profile_label(self, monkeypatch, tmp_path):
+        """The interactive built-in pre-sets chunk_retrieval_threshold=0.3.
+        Expectation: param source DEFAULT_MAP and the sidecar label is the
+        profile-named label since the per-command --profile default is
+        ``interactive``.
+        """
+        from phentrieve.cli._profile import apply_profile_callback
+
+        monkeypatch.chdir(tmp_path)
+        _clear_config_caches()
+
+        captured: dict = {}
+
+        app = typer.Typer()
+
+        @app.callback()
+        def root(
+            ctx: typer.Context,
+            profile: str = typer.Option(
+                "interactive",
+                "--profile",
+                callback=apply_profile_callback,
+                is_eager=True,
+            ),
+        ):
+            ctx.ensure_object(dict)
+
+        @app.command()
+        def cmd(
+            ctx: typer.Context,
+            chunk_retrieval_threshold: float | None = typer.Option(
+                None, "--chunk-retrieval-threshold"
+            ),
+        ):
+            captured["chunk"] = chunk_retrieval_threshold
+            captured["sources"] = dict(ctx.obj.get("resolved_sources", {}))
+            captured["param_source"] = ctx.get_parameter_source(
+                "chunk_retrieval_threshold"
+            )
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["cmd"])
+        assert result.exit_code == 0, result.output
+
+        assert captured["chunk"] == 0.3
+        assert captured["param_source"] == ParameterSource.DEFAULT_MAP
+        # Label is profile:interactive (the value Click passes through).
+        assert captured["sources"]["chunk_retrieval_threshold"] == (
+            "profile:interactive"
+        )
+
+    def test_idempotent_callback(self, monkeypatch, tmp_path):
+        """Calling the callback twice with the same value must be a no-op
+        (avoids double-population when wired on root and subcommand).
+        """
+        from phentrieve.cli._profile import apply_profile_callback
+
+        monkeypatch.chdir(tmp_path)
+        _clear_config_caches()
+
+        # Build a minimal Click context manually so we can call the
+        # callback twice and inspect ctx state.
+        cmd = click.Command("dummy")
+        ctx = click.Context(cmd)
+        ctx.ensure_object(dict)
+
+        # First call: populates resolved_sources with the const labels.
+        apply_profile_callback(ctx, None, "default")  # type: ignore[arg-type]
+        first_sources = dict(ctx.obj["resolved_sources"])
+        first_default_map = dict(ctx.default_map or {})
+
+        # Second call with the same value: no-op (the _profile_applied
+        # guard short-circuits).
+        apply_profile_callback(ctx, None, "default")  # type: ignore[arg-type]
+        second_sources = dict(ctx.obj["resolved_sources"])
+        second_default_map = dict(ctx.default_map or {})
+
+        assert first_sources == second_sources
+        assert first_default_map == second_default_map

--- a/tests/unit/cli/test_init.py
+++ b/tests/unit/cli/test_init.py
@@ -100,13 +100,18 @@ class TestMainCallback:
 
     def test_main_callback_executes_without_error(self, mocker):
         """Test main callback executes successfully."""
+        from unittest.mock import MagicMock
+
         from phentrieve.cli import main_callback
 
         # Arrange - Mock version_callback to prevent exit
         mocker.patch("phentrieve.cli.version_callback", return_value=None)
+        # Phase 7 added a ctx parameter for the root --profile callback.
+        ctx = MagicMock()
+        ctx.obj = None
 
         # Act - should not raise any exception
-        result = main_callback(version=False)
+        result = main_callback(ctx=ctx, version=False)
 
         # Assert - callback returns None (does nothing except handle --version)
         assert result is None

--- a/tests/unit/cli/test_profile_callback.py
+++ b/tests/unit/cli/test_profile_callback.py
@@ -1,0 +1,115 @@
+"""Tests for the eager --profile callback (Spec A Task 7)."""
+
+from __future__ import annotations
+
+import click
+import typer
+from typer.testing import CliRunner
+
+
+def make_test_app():
+    """A throwaway Typer app with --profile wired via the eager callback."""
+    from phentrieve.cli._profile import apply_profile_callback
+
+    app = typer.Typer()
+
+    @app.callback()
+    def root(
+        ctx: typer.Context,
+        profile: str = typer.Option(
+            "default",
+            "--profile",
+            callback=apply_profile_callback,
+            is_eager=True,
+        ),
+    ):
+        ctx.ensure_object(dict)
+        ctx.obj.setdefault("seen_root", True)
+
+    @app.command()
+    def echo(
+        ctx: typer.Context,
+        language: str | None = None,
+        num_results: int | None = None,
+    ):
+        # Resolve fallbacks.
+        lang = language if language is not None else "en"
+        n = num_results if num_results is not None else 10
+        click.echo(f"language={lang} num_results={n}")
+
+    return app
+
+
+class TestApplyProfileCallback:
+    def test_default_profile_no_explicit_flag(self, monkeypatch, tmp_path):
+        from phentrieve.config import _load_yaml_config
+
+        monkeypatch.chdir(tmp_path)  # No phentrieve.yaml present.
+        _load_yaml_config.cache_clear()
+
+        runner = CliRunner()
+        result = runner.invoke(make_test_app(), ["echo"])
+        assert result.exit_code == 0, result.output
+        # No profile, no YAML -> falls through to function-body fallbacks.
+        assert "language=en" in result.stdout
+        assert "num_results=10" in result.stdout
+
+    def test_unknown_profile_errors(self, monkeypatch, tmp_path):
+        from phentrieve.config import _load_yaml_config
+
+        monkeypatch.chdir(tmp_path)
+        _load_yaml_config.cache_clear()
+
+        runner = CliRunner()
+        result = runner.invoke(make_test_app(), ["--profile", "ghost", "echo"])
+        assert result.exit_code != 0
+        assert "ghost" in result.output
+
+
+class TestSidecarSourceMap:
+    def test_sidecar_populated_with_profile_label(self, monkeypatch, tmp_path):
+        """The built-in `interactive` profile sets chunk_retrieval_threshold=0.3
+        and the sidecar map records that the value came from the profile.
+        """
+        from phentrieve.cli._profile import apply_profile_callback
+        from phentrieve.config import _load_yaml_config
+
+        monkeypatch.chdir(tmp_path)
+        _load_yaml_config.cache_clear()
+
+        captured: dict = {}
+
+        app = typer.Typer()
+
+        @app.callback()
+        def root(
+            ctx: typer.Context,
+            profile: str = typer.Option(
+                "interactive",  # built-in default for this test app
+                "--profile",
+                callback=apply_profile_callback,
+                is_eager=True,
+            ),
+        ):
+            ctx.ensure_object(dict)
+
+        @app.command()
+        def cmd(
+            ctx: typer.Context,
+            chunk_retrieval_threshold: float | None = None,
+        ):
+            captured["sources"] = dict(ctx.obj.get("resolved_sources", {}))
+            captured["threshold"] = (
+                chunk_retrieval_threshold
+                if chunk_retrieval_threshold is not None
+                else 0.7  # the constant fallback
+            )
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["cmd"])
+        assert result.exit_code == 0, result.output
+        # Built-in interactive sets chunk_retrieval_threshold=0.3.
+        assert captured["threshold"] == 0.3
+        assert "chunk_retrieval_threshold" in captured["sources"]
+        label = captured["sources"]["chunk_retrieval_threshold"]
+        assert "profile:builtin:interactive" in label or "profile:interactive" in label

--- a/tests/unit/cli/test_profile_placement.py
+++ b/tests/unit/cli/test_profile_placement.py
@@ -1,0 +1,116 @@
+"""Tests that --profile works at both root and per-command placement.
+
+Spec A Phase 7: ``phentrieve --profile X query ...`` and
+``phentrieve query --profile X ...`` must resolve identically. With both
+placements, the subcommand-level value wins. With ``PHENTRIEVE_PROFILE`` set
+in the environment, an explicit ``--profile`` flag still wins.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from phentrieve.cli import app
+
+
+def _clear_yaml_cache() -> None:
+    from phentrieve.config import _load_yaml_config
+    from phentrieve.utils import load_user_config
+
+    _load_yaml_config.cache_clear()
+    load_user_config.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _yaml_with_two_profiles(tmp_path, monkeypatch):
+    (tmp_path / "phentrieve.yaml").write_text(
+        "profiles:\n"
+        "  fast_query_a:\n"
+        "    command: query\n"
+        "    num_results: 5\n"
+        "  fast_query_b:\n"
+        "    command: query\n"
+        "    num_results: 8\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("PHENTRIEVE_PROFILE", raising=False)
+    _clear_yaml_cache()
+    yield
+    _clear_yaml_cache()
+
+
+class TestProfilePlacement:
+    @patch("phentrieve.retrieval.query_orchestrator.orchestrate_query")
+    def test_root_placement(self, mock_orchestrate):
+        mock_orchestrate.return_value = []
+        runner = CliRunner()
+        result = runner.invoke(app, ["--profile", "fast_query_a", "query", "TEXT"])
+        assert result.exit_code == 0, result.output
+        assert mock_orchestrate.called
+        assert mock_orchestrate.call_args.kwargs["num_results"] == 5
+
+    @patch("phentrieve.retrieval.query_orchestrator.orchestrate_query")
+    def test_subcommand_placement(self, mock_orchestrate):
+        mock_orchestrate.return_value = []
+        runner = CliRunner()
+        result = runner.invoke(app, ["query", "TEXT", "--profile", "fast_query_a"])
+        assert result.exit_code == 0, result.output
+        assert mock_orchestrate.called
+        assert mock_orchestrate.call_args.kwargs["num_results"] == 5
+
+    @patch("phentrieve.retrieval.query_orchestrator.orchestrate_query")
+    def test_subcommand_wins_over_root(self, mock_orchestrate):
+        mock_orchestrate.return_value = []
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "--profile",
+                "fast_query_a",
+                "query",
+                "TEXT",
+                "--profile",
+                "fast_query_b",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_orchestrate.called
+        # b wins (subcommand-level beats root-level).
+        assert mock_orchestrate.call_args.kwargs["num_results"] == 8
+
+    @patch("phentrieve.retrieval.query_orchestrator.orchestrate_query")
+    def test_explicit_flag_beats_both(self, mock_orchestrate):
+        mock_orchestrate.return_value = []
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "query",
+                "TEXT",
+                "--profile",
+                "fast_query_a",
+                "--num-results",
+                "20",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_orchestrate.called
+        assert mock_orchestrate.call_args.kwargs["num_results"] == 20
+
+    @patch("phentrieve.retrieval.query_orchestrator.orchestrate_query")
+    def test_envvar_overridden_by_explicit_flag(self, mock_orchestrate, monkeypatch):
+        """PHENTRIEVE_PROFILE supplies a value, but explicit --profile wins."""
+        mock_orchestrate.return_value = []
+        monkeypatch.setenv("PHENTRIEVE_PROFILE", "fast_query_a")
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["query", "TEXT", "--profile", "fast_query_b"],
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_orchestrate.called
+        assert mock_orchestrate.call_args.kwargs["num_results"] == 8

--- a/tests/unit/cli/test_query_enrichment.py
+++ b/tests/unit/cli/test_query_enrichment.py
@@ -5,10 +5,15 @@ Tests cover:
 - Helper function for enriching structured query results
 - Output formatters with definition and synonyms
 - Integration with CLI command (mocked)
+- Plan A Phase 6: --profile resolution for ``phentrieve query``
 """
 
-import pytest
+from unittest.mock import patch
 
+import pytest
+from typer.testing import CliRunner
+
+from phentrieve.cli import app
 from phentrieve.cli.query_commands import enrich_query_results_with_details
 from phentrieve.retrieval.output_formatters import (
     format_results_as_json,
@@ -18,6 +23,14 @@ from phentrieve.retrieval.output_formatters import (
 
 # Mark all tests in this file as unit tests
 pytestmark = pytest.mark.unit
+
+
+def _clear_yaml_cache() -> None:
+    from phentrieve.config import _load_yaml_config
+    from phentrieve.utils import load_user_config
+
+    _load_yaml_config.cache_clear()
+    load_user_config.cache_clear()
 
 
 @pytest.fixture
@@ -335,3 +348,111 @@ class TestOutputFormatterEdgeCases:
         assert "Synonym 5" in output
         # Check comma-separated format
         assert "Synonym 1, Synonym 2" in output
+
+
+class TestQueryProfileResolution:
+    """Plan A Phase 6: ``phentrieve query`` --profile resolution.
+
+    The hardcoded model_name/num_results/similarity_threshold/multi_vector/
+    aggregation_strategy/output_format literals get replaced with ``None``
+    Typer defaults plus a value-or-constant body fallback. Together with the
+    eager ``--profile`` callback this lets the precedence stack (explicit
+    flag > profile > top-level YAML > constants) work without a hardcoded
+    literal short-circuiting it.
+    """
+
+    def setup_method(self) -> None:
+        _clear_yaml_cache()
+
+    def teardown_method(self) -> None:
+        _clear_yaml_cache()
+
+    @patch("phentrieve.retrieval.query_orchestrator.orchestrate_query")
+    def test_profile_provides_query_defaults(
+        self, mock_orchestrate, monkeypatch, tmp_path
+    ):
+        """A profile with command=query supplies num_results and
+        similarity_threshold defaults via the eager callback."""
+        (tmp_path / "phentrieve.yaml").write_text(
+            "profiles:\n"
+            "  precise_english_query:\n"
+            "    command: query\n"
+            "    num_results: 5\n"
+            "    similarity_threshold: 0.5\n"
+        )
+        monkeypatch.chdir(tmp_path)
+        _clear_yaml_cache()
+        mock_orchestrate.return_value = []
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "query",
+                "patient with seizures",
+                "--profile",
+                "precise_english_query",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_orchestrate.called
+        kwargs = mock_orchestrate.call_args.kwargs
+        assert kwargs["num_results"] == 5
+        assert kwargs["similarity_threshold"] == 0.5
+
+    @patch("phentrieve.retrieval.query_orchestrator.orchestrate_query")
+    def test_explicit_flag_overrides_profile(
+        self, mock_orchestrate, monkeypatch, tmp_path
+    ):
+        """``--num-results 3`` on the command line beats the profile's
+        ``num_results: 5`` (explicit flag is the strongest precedence layer)."""
+        (tmp_path / "phentrieve.yaml").write_text(
+            "profiles:\n"
+            "  precise_english_query:\n"
+            "    command: query\n"
+            "    num_results: 5\n"
+            "    similarity_threshold: 0.5\n"
+        )
+        monkeypatch.chdir(tmp_path)
+        _clear_yaml_cache()
+        mock_orchestrate.return_value = []
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "query",
+                "patient with seizures",
+                "--profile",
+                "precise_english_query",
+                "--num-results",
+                "3",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_orchestrate.called
+        kwargs = mock_orchestrate.call_args.kwargs
+        # Explicit flag beats the profile-supplied value.
+        assert kwargs["num_results"] == 3
+        # similarity_threshold still comes from the profile.
+        assert kwargs["similarity_threshold"] == 0.5
+
+    @patch("phentrieve.retrieval.query_orchestrator.orchestrate_query")
+    def test_no_profile_falls_through_to_constants(
+        self, mock_orchestrate, monkeypatch, tmp_path
+    ):
+        """With no user profile and no YAML overrides, the body fallbacks
+        resolve to the config constants."""
+        from phentrieve.config import DEFAULT_TOP_K, MIN_SIMILARITY_THRESHOLD
+
+        monkeypatch.chdir(tmp_path)
+        _clear_yaml_cache()
+        mock_orchestrate.return_value = []
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["query", "patient with seizures"])
+        assert result.exit_code == 0, result.output
+        assert mock_orchestrate.called
+        kwargs = mock_orchestrate.call_args.kwargs
+        assert kwargs["num_results"] == DEFAULT_TOP_K
+        assert kwargs["similarity_threshold"] == MIN_SIMILARITY_THRESHOLD

--- a/tests/unit/cli/test_show_resolved_config.py
+++ b/tests/unit/cli/test_show_resolved_config.py
@@ -1,0 +1,136 @@
+"""Tests for the --show-resolved-config debug flag.
+
+Spec A's Observability section requires a global `--show-resolved-config`
+flag that prints the resolved option set (with source labels from
+`ctx.obj['resolved_sources']` plus user-passed flags labeled as
+`<flag> (commandline)`) to **stderr** before the command body runs. The
+command must still execute (it is not a dry-run).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+
+def _clear_yaml_cache() -> None:
+    from phentrieve.config import _load_yaml_config
+    from phentrieve.utils import load_user_config
+
+    _load_yaml_config.cache_clear()
+    load_user_config.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    """Isolate from any user / repo phentrieve.yaml during tests."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("PHENTRIEVE_PROFILE", raising=False)
+    _clear_yaml_cache()
+    yield
+    _clear_yaml_cache()
+
+
+@pytest.fixture
+def app():
+    from phentrieve.cli import app as a
+
+    return a
+
+
+class TestShowResolvedConfig:
+    @patch("phentrieve.retrieval.query_orchestrator.orchestrate_query")
+    def test_output_to_stderr_not_stdout(self, mock_orchestrate, app):
+        """The resolved-config table goes to stderr, not stdout."""
+        mock_orchestrate.return_value = []
+        runner = CliRunner()
+        result = runner.invoke(app, ["--show-resolved-config", "query", "TEXT"])
+        assert result.exit_code == 0, result.output
+        # Header lands on stderr (separate from stdout in Click >= 8.2).
+        assert "Resolved configuration" in result.stderr
+        assert "Resolved configuration" not in result.stdout
+        # Source-label arrows present.
+        assert "<-" in result.stderr
+
+    @patch("phentrieve.retrieval.query_orchestrator.orchestrate_query")
+    def test_command_still_executes(self, mock_orchestrate, app):
+        """The flag is observability-only - the command body still runs."""
+        mock_orchestrate.return_value = []
+        runner = CliRunner()
+        result = runner.invoke(app, ["--show-resolved-config", "query", "TEXT"])
+        assert result.exit_code == 0, result.output
+        assert mock_orchestrate.called
+
+    @patch("phentrieve.retrieval.query_orchestrator.orchestrate_query")
+    def test_explicit_flag_labeled_commandline(self, mock_orchestrate, app):
+        """A user-passed flag is labeled with `(commandline)` and the value."""
+        mock_orchestrate.return_value = []
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "--show-resolved-config",
+                "query",
+                "TEXT",
+                "--num-results",
+                "7",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "(commandline)" in result.stderr
+        # The numeric value is rendered in the table as well.
+        assert "7" in result.stderr
+        # And the user's value flowed through to the orchestrator.
+        assert mock_orchestrate.call_args.kwargs["num_results"] == 7
+
+    @patch("phentrieve.retrieval.query_orchestrator.orchestrate_query")
+    def test_source_labels_match_resolved_sources(
+        self, mock_orchestrate, tmp_path, monkeypatch, app
+    ):
+        """Source labels in the rendered table reflect the sidecar source map.
+
+        With a profile that sets ``num_results: 5``, the rendered line for
+        ``num_results`` must carry the ``profile:<name>`` label - matching
+        ``ctx.obj['resolved_sources']['num_results']`` produced by the eager
+        --profile callback.
+        """
+        (tmp_path / "phentrieve.yaml").write_text(
+            "profiles:\n  show_cfg_test:\n    command: query\n    num_results: 5\n"
+        )
+        monkeypatch.chdir(tmp_path)
+        _clear_yaml_cache()
+
+        mock_orchestrate.return_value = []
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "--show-resolved-config",
+                "--profile",
+                "show_cfg_test",
+                "query",
+                "TEXT",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        # Profile-sourced label format `profile:<name>` is in the table.
+        assert "profile:show_cfg_test" in result.stderr
+        # And the `num_results` row carries that label specifically.
+        num_results_lines = [
+            line for line in result.stderr.splitlines() if "num_results" in line
+        ]
+        assert num_results_lines, result.stderr
+        assert any("profile:show_cfg_test" in line for line in num_results_lines)
+
+    @patch("phentrieve.retrieval.query_orchestrator.orchestrate_query")
+    def test_flag_off_means_no_output(self, mock_orchestrate, app):
+        """Without the flag, the resolved-config table is not printed."""
+        mock_orchestrate.return_value = []
+        runner = CliRunner()
+        result = runner.invoke(app, ["query", "TEXT"])
+        assert result.exit_code == 0, result.output
+        assert "Resolved configuration" not in result.stderr
+        assert "Resolved configuration" not in result.stdout

--- a/tests/unit/cli/test_text_commands.py
+++ b/tests/unit/cli/test_text_commands.py
@@ -1043,3 +1043,238 @@ class TestProcessProfileResolution:
         # behaviour). Critically NOT hardcoded as "en" inside Typer signature.
         assert kwargs["language"] == DEFAULT_LANGUAGE
         assert kwargs["chunk_retrieval_threshold"] == 0.4
+
+
+class TestProcessAdaptiveRechunkingFlags:
+    """Plan B Phase 8: --adaptive-rechunking* flags on ``text process``.
+
+    Four flags map onto an ``AdaptiveRechunkingConfig`` resolved with the
+    precedence stack CLI > profile > YAML > defaults. The boolean
+    ``--adaptive-rechunking / --no-adaptive-rechunking`` only enters the
+    CLI tier when the user explicitly supplied it; otherwise profile and
+    YAML values pass through.
+    """
+
+    def setup_method(self) -> None:
+        _clear_yaml_cache()
+
+    def teardown_method(self) -> None:
+        _clear_yaml_cache()
+
+    @patch("phentrieve.cli.text_commands.run_full_text_service")
+    def test_disabled_by_default(self, mock_run, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _clear_yaml_cache()
+        mock_run.return_value = {
+            "meta": {},
+            "processed_chunks": [],
+            "aggregated_hpo_terms": [],
+        }
+        monkeypatch.setattr(
+            "phentrieve.cli.text_commands.resolve_chunking_pipeline_config",
+            lambda **kwargs: [{"type": "paragraph"}],
+        )
+
+        (tmp_path / "in.txt").write_text("text")
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["text", "process", "--input-file", str(tmp_path / "in.txt")]
+        )
+        assert result.exit_code == 0, result.output
+        cfg = mock_run.call_args.kwargs.get("adaptive_rechunking")
+        # When the flag isn't passed, the config is built with enabled=False
+        # (or absent - both acceptable).
+        if cfg is not None:
+            assert getattr(cfg, "enabled", False) is False
+
+    @patch("phentrieve.cli.text_commands.run_full_text_service")
+    def test_enabled_via_flag(self, mock_run, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _clear_yaml_cache()
+        mock_run.return_value = {
+            "meta": {},
+            "processed_chunks": [],
+            "aggregated_hpo_terms": [],
+        }
+        monkeypatch.setattr(
+            "phentrieve.cli.text_commands.resolve_chunking_pipeline_config",
+            lambda **kwargs: [{"type": "paragraph"}],
+        )
+
+        (tmp_path / "in.txt").write_text("text")
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "text",
+                "process",
+                "--input-file",
+                str(tmp_path / "in.txt"),
+                "--adaptive-rechunking",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        cfg = mock_run.call_args.kwargs["adaptive_rechunking"]
+        assert cfg.enabled is True
+
+    @patch("phentrieve.cli.text_commands.run_full_text_service")
+    def test_threshold_flags(self, mock_run, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _clear_yaml_cache()
+        mock_run.return_value = {
+            "meta": {},
+            "processed_chunks": [],
+            "aggregated_hpo_terms": [],
+        }
+        monkeypatch.setattr(
+            "phentrieve.cli.text_commands.resolve_chunking_pipeline_config",
+            lambda **kwargs: [{"type": "paragraph"}],
+        )
+
+        (tmp_path / "in.txt").write_text("text")
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "text",
+                "process",
+                "--input-file",
+                str(tmp_path / "in.txt"),
+                "--adaptive-rechunking",
+                "--adaptive-rechunking-quality-threshold",
+                "0.5",
+                "--adaptive-rechunking-margin-threshold",
+                "0.05",
+                "--adaptive-rechunking-max-depth",
+                "1",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        cfg = mock_run.call_args.kwargs["adaptive_rechunking"]
+        assert cfg.enabled is True
+        assert cfg.quality_threshold == 0.5
+        assert cfg.margin_threshold == 0.05
+        assert cfg.max_depth == 1
+
+    @patch("phentrieve.cli.text_commands.run_full_text_service")
+    def test_yaml_extraction_block_applies(self, mock_run, tmp_path, monkeypatch):
+        """YAML extraction.adaptive_rechunking propagates when no CLI flag."""
+        (tmp_path / "phentrieve.yaml").write_text(
+            "extraction:\n"
+            "  adaptive_rechunking:\n"
+            "    enabled: true\n"
+            "    quality_threshold: 0.42\n"
+        )
+        monkeypatch.chdir(tmp_path)
+        _clear_yaml_cache()
+        mock_run.return_value = {
+            "meta": {},
+            "processed_chunks": [],
+            "aggregated_hpo_terms": [],
+        }
+        monkeypatch.setattr(
+            "phentrieve.cli.text_commands.resolve_chunking_pipeline_config",
+            lambda **kwargs: [{"type": "paragraph"}],
+        )
+
+        (tmp_path / "in.txt").write_text("text")
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["text", "process", "--input-file", str(tmp_path / "in.txt")]
+        )
+        assert result.exit_code == 0, result.output
+        cfg = mock_run.call_args.kwargs["adaptive_rechunking"]
+        assert cfg.enabled is True
+        assert cfg.quality_threshold == 0.42
+
+    @patch("phentrieve.cli.text_commands.run_full_text_service")
+    def test_profile_block_applies(self, mock_run, tmp_path, monkeypatch):
+        """``Profile.adaptive_rechunking`` block flows through when no CLI flag."""
+        (tmp_path / "phentrieve.yaml").write_text(
+            "profiles:\n"
+            "  adaptive_demo:\n"
+            "    command: text process\n"
+            "    adaptive_rechunking:\n"
+            "      enabled: true\n"
+            "      quality_threshold: 0.6\n"
+            "      max_depth: 3\n"
+        )
+        monkeypatch.chdir(tmp_path)
+        _clear_yaml_cache()
+        mock_run.return_value = {
+            "meta": {},
+            "processed_chunks": [],
+            "aggregated_hpo_terms": [],
+        }
+        monkeypatch.setattr(
+            "phentrieve.cli.text_commands.resolve_chunking_pipeline_config",
+            lambda **kwargs: [{"type": "paragraph"}],
+        )
+
+        (tmp_path / "in.txt").write_text("text")
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "text",
+                "process",
+                "--input-file",
+                str(tmp_path / "in.txt"),
+                "--profile",
+                "adaptive_demo",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        cfg = mock_run.call_args.kwargs["adaptive_rechunking"]
+        assert cfg.enabled is True
+        assert cfg.quality_threshold == 0.6
+        assert cfg.max_depth == 3
+
+    @patch("phentrieve.cli.text_commands.run_full_text_service")
+    def test_explicit_flag_beats_profile(self, mock_run, tmp_path, monkeypatch):
+        """An explicit ``--adaptive-rechunking-*`` flag wins over profile values."""
+        (tmp_path / "phentrieve.yaml").write_text(
+            "profiles:\n"
+            "  adaptive_demo:\n"
+            "    command: text process\n"
+            "    adaptive_rechunking:\n"
+            "      enabled: true\n"
+            "      quality_threshold: 0.6\n"
+            "      max_depth: 3\n"
+        )
+        monkeypatch.chdir(tmp_path)
+        _clear_yaml_cache()
+        mock_run.return_value = {
+            "meta": {},
+            "processed_chunks": [],
+            "aggregated_hpo_terms": [],
+        }
+        monkeypatch.setattr(
+            "phentrieve.cli.text_commands.resolve_chunking_pipeline_config",
+            lambda **kwargs: [{"type": "paragraph"}],
+        )
+
+        (tmp_path / "in.txt").write_text("text")
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "text",
+                "process",
+                "--input-file",
+                str(tmp_path / "in.txt"),
+                "--profile",
+                "adaptive_demo",
+                "--adaptive-rechunking-quality-threshold",
+                "0.5",
+                "--adaptive-rechunking-max-depth",
+                "1",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        cfg = mock_run.call_args.kwargs["adaptive_rechunking"]
+        # Profile still supplies enabled=True (untouched).
+        assert cfg.enabled is True
+        # Explicit flags beat profile-supplied values.
+        assert cfg.quality_threshold == 0.5
+        assert cfg.max_depth == 1

--- a/tests/unit/cli/test_text_commands.py
+++ b/tests/unit/cli/test_text_commands.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 from typer.testing import CliRunner
@@ -845,3 +846,200 @@ def test_run_llm_backend_uses_default_model_when_not_explicitly_configured(
 
     assert calls["config"].model == "gemini-3.1-flash-lite-preview"
     assert result["meta"]["llm_model"] == "gemini-3.1-flash-lite-preview"
+
+
+def _clear_yaml_cache() -> None:
+    from phentrieve.config import _load_yaml_config
+    from phentrieve.utils import load_user_config
+
+    _load_yaml_config.cache_clear()
+    load_user_config.cache_clear()
+
+
+class TestProcessProfileResolution:
+    """Plan A Phase 5: ``phentrieve text process`` --profile resolution.
+
+    The four hardcoded literals (``language="en"``, ``num_results=10``,
+    ``chunk_confidence=0.2``, ``assertion_preference="dependency"``) get
+    replaced with ``None`` Typer defaults plus a value-or-constant body
+    fallback. Together with the eager ``--profile`` callback this lets the
+    precedence stack (explicit flag > profile > top-level YAML > constants)
+    work without a hardcoded literal short-circuiting it.
+    """
+
+    def setup_method(self) -> None:
+        _clear_yaml_cache()
+
+    def teardown_method(self) -> None:
+        _clear_yaml_cache()
+
+    @patch("phentrieve.cli.text_commands.run_full_text_service")
+    def test_default_profile_falls_through_to_config(
+        self, mock_run, monkeypatch, tmp_path
+    ):
+        from phentrieve.config import (
+            DEFAULT_CHUNK_RETRIEVAL_THRESHOLD,
+            DEFAULT_LANGUAGE,
+        )
+
+        monkeypatch.chdir(tmp_path)
+        _clear_yaml_cache()
+        mock_run.return_value = {
+            "meta": {},
+            "processed_chunks": [],
+            "aggregated_hpo_terms": [],
+        }
+        monkeypatch.setattr(
+            "phentrieve.cli.text_commands.resolve_chunking_pipeline_config",
+            lambda **kwargs: [{"type": "paragraph"}],
+        )
+
+        (tmp_path / "in.txt").write_text("Patient with seizures.")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["text", "process", "--input-file", str(tmp_path / "in.txt")],
+        )
+        assert result.exit_code == 0, result.output
+
+        kwargs = mock_run.call_args.kwargs
+        # No profile, no YAML override -> falls through to config constants.
+        assert kwargs["chunk_retrieval_threshold"] == DEFAULT_CHUNK_RETRIEVAL_THRESHOLD
+        # language: not hardcoded to "en"; either auto-detected or DEFAULT_LANGUAGE.
+        assert kwargs.get("language") in {None, DEFAULT_LANGUAGE}
+
+    @patch("phentrieve.cli.text_commands.run_full_text_service")
+    def test_profile_provides_defaults(self, mock_run, monkeypatch, tmp_path):
+        # User profile with overrides.
+        (tmp_path / "phentrieve.yaml").write_text(
+            "profiles:\n"
+            "  high_recall_german:\n"
+            "    command: text process\n"
+            "    language: de\n"
+            "    num_results: 5\n"
+            "    chunk_retrieval_threshold: 0.5\n"
+        )
+        monkeypatch.chdir(tmp_path)
+        _clear_yaml_cache()
+        mock_run.return_value = {
+            "meta": {},
+            "processed_chunks": [],
+            "aggregated_hpo_terms": [],
+        }
+        monkeypatch.setattr(
+            "phentrieve.cli.text_commands.resolve_chunking_pipeline_config",
+            lambda **kwargs: [{"type": "paragraph"}],
+        )
+
+        (tmp_path / "in.txt").write_text("Der Patient hat Anfaelle.")
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "text",
+                "process",
+                "--input-file",
+                str(tmp_path / "in.txt"),
+                "--profile",
+                "high_recall_german",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        kwargs = mock_run.call_args.kwargs
+        assert kwargs["language"] == "de"
+        assert kwargs["chunk_retrieval_threshold"] == 0.5
+        assert kwargs["num_results_per_chunk"] == 5
+
+    @patch("phentrieve.cli.text_commands.run_full_text_service")
+    def test_explicit_flag_overrides_profile(self, mock_run, monkeypatch, tmp_path):
+        (tmp_path / "phentrieve.yaml").write_text(
+            "profiles:\n"
+            "  custom:\n"
+            "    command: text process\n"
+            "    language: de\n"
+            "    num_results: 5\n"
+        )
+        monkeypatch.chdir(tmp_path)
+        _clear_yaml_cache()
+        mock_run.return_value = {
+            "meta": {},
+            "processed_chunks": [],
+            "aggregated_hpo_terms": [],
+        }
+        monkeypatch.setattr(
+            "phentrieve.cli.text_commands.resolve_chunking_pipeline_config",
+            lambda **kwargs: [{"type": "paragraph"}],
+        )
+
+        (tmp_path / "in.txt").write_text("Patient.")
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "text",
+                "process",
+                "--input-file",
+                str(tmp_path / "in.txt"),
+                "--profile",
+                "custom",
+                "--language",
+                "fr",
+                "--num-results",
+                "3",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        kwargs = mock_run.call_args.kwargs
+        # Explicit flags beat profile-supplied values.
+        assert kwargs["language"] == "fr"
+        assert kwargs["num_results_per_chunk"] == 3
+
+    @patch("phentrieve.cli.text_commands.run_full_text_service")
+    def test_language_auto_detect_when_not_in_profile(
+        self, mock_run, monkeypatch, tmp_path
+    ):
+        """When neither flag nor profile/YAML supply a language, the body
+        falls through to DEFAULT_LANGUAGE (or auto-detect). This guards that
+        ``language="en"`` is no longer hardcoded as a Typer default literal.
+        """
+        from phentrieve.config import DEFAULT_LANGUAGE
+
+        # Profile that DOES NOT set language.
+        (tmp_path / "phentrieve.yaml").write_text(
+            "profiles:\n"
+            "  recall_only:\n"
+            "    command: text process\n"
+            "    chunk_retrieval_threshold: 0.4\n"
+        )
+        monkeypatch.chdir(tmp_path)
+        _clear_yaml_cache()
+        mock_run.return_value = {
+            "meta": {},
+            "processed_chunks": [],
+            "aggregated_hpo_terms": [],
+        }
+        monkeypatch.setattr(
+            "phentrieve.cli.text_commands.resolve_chunking_pipeline_config",
+            lambda **kwargs: [{"type": "paragraph"}],
+        )
+
+        (tmp_path / "in.txt").write_text("Patient.")
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "text",
+                "process",
+                "--input-file",
+                str(tmp_path / "in.txt"),
+                "--profile",
+                "recall_only",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        kwargs = mock_run.call_args.kwargs
+        # Language is whatever DEFAULT_LANGUAGE resolves to (matches API
+        # behaviour). Critically NOT hardcoded as "en" inside Typer signature.
+        assert kwargs["language"] == DEFAULT_LANGUAGE
+        assert kwargs["chunk_retrieval_threshold"] == 0.4

--- a/tests/unit/cli/test_text_interactive_profile.py
+++ b/tests/unit/cli/test_text_interactive_profile.py
@@ -1,0 +1,214 @@
+"""Tests for ``phentrieve text interactive`` --profile resolution (Plan A
+Phase 4 / issue #171).
+
+The built-in ``interactive`` profile is auto-selected when ``--profile`` is
+not given on the commandline (the option default is ``"interactive"``).
+That profile sets the loose retrieval defaults
+(``chunk_retrieval_threshold=0.3``, ``aggregated_term_confidence=0.35``,
+``num_results=5``) so existing users see no behaviour change. Passing
+``--profile default`` switches to the empty built-in, falling through to
+the strict ``DEFAULT_*`` constants. Explicit flags always beat both.
+
+These tests assert the kwargs that ``orchestrate_hpo_extraction`` sees -
+that is the precise observable point where profile/YAML/flag resolution
+has finished and only one value can survive.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from phentrieve.cli.text_interactive import interactive_text_mode
+from phentrieve.config import _load_yaml_config
+
+
+def _clear_config_caches() -> None:
+    from phentrieve.utils import load_user_config
+
+    _load_yaml_config.cache_clear()
+    load_user_config.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_yaml(tmp_path, monkeypatch):
+    """Run from an empty cwd so phentrieve.yaml from the repo isn't picked up."""
+    monkeypatch.chdir(tmp_path)
+    _clear_config_caches()
+    yield
+    _clear_config_caches()
+
+
+def _install_pipeline_doubles(monkeypatch) -> dict[str, Any]:
+    """Install the minimal set of doubles to let interactive_text_mode reach
+    ``orchestrate_hpo_extraction`` and exit cleanly via the ``q`` prompt.
+
+    Returns a dict that gets populated with the orchestrator's kwargs once
+    the function under test calls it.
+    """
+    captured: dict[str, Any] = {}
+    prompt_inputs = iter(["Patient has seizures.", "q"])
+
+    class FakePipeline:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        def process(self, raw_text: str) -> list[dict[str, str]]:
+            return [{"text": raw_text, "status": "present"}]
+
+    class FakeRetriever:
+        pass
+
+    def _capture_orchestrator(**kwargs: Any) -> tuple[list, list]:
+        captured["called"] = True
+        captured["kwargs"] = kwargs
+        return ([], [])
+
+    monkeypatch.setattr(
+        "phentrieve.cli.text_interactive.resolve_chunking_pipeline_config",
+        lambda **kwargs: [],
+    )
+    monkeypatch.setattr(
+        "phentrieve.cli.text_interactive.TextProcessingPipeline",
+        FakePipeline,
+    )
+    monkeypatch.setattr(
+        "phentrieve.cli.text_interactive.DenseRetriever.from_model_name",
+        lambda **kwargs: FakeRetriever(),
+    )
+    monkeypatch.setattr(
+        "phentrieve.embeddings.load_embedding_model",
+        lambda **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        "phentrieve.cli.text_interactive.orchestrate_hpo_extraction",
+        _capture_orchestrator,
+    )
+    monkeypatch.setattr(
+        "phentrieve.cli.text_interactive._display_interactive_text_results",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "rich.prompt.Prompt.ask",
+        lambda *args, **kwargs: next(prompt_inputs),
+    )
+    monkeypatch.setattr(
+        "torch.cuda.is_available",
+        lambda: False,
+    )
+    return captured
+
+
+class TestTextInteractiveProfileResolution:
+    """The function-level invariant: when callers omit profileable args (or
+    pass them as None as Click would on default), the body resolves them
+    against the right precedence stack."""
+
+    def test_default_invocation_uses_interactive_profile_values(
+        self, monkeypatch
+    ) -> None:
+        """With no flags at all, all profileable args are None, so the body's
+        value-or-constant fallback returns the constants. The built-in
+        'interactive' profile sets the loose values via Click's default_map
+        when the eager callback runs - but we are calling the function
+        directly here, so the fallback receives None and uses the strict
+        constants. This test therefore guards a different invariant:
+        calling interactive_text_mode() with no kwargs MUST NOT raise and
+        MUST reach orchestrate_hpo_extraction with non-None values.
+        """
+        captured = _install_pipeline_doubles(monkeypatch)
+
+        interactive_text_mode()
+
+        assert captured.get("called") is True
+        kwargs = captured["kwargs"]
+        assert kwargs["chunk_retrieval_threshold"] is not None
+        assert kwargs["min_confidence_for_aggregated"] is not None
+        assert kwargs["num_results_per_chunk"] is not None
+
+    def test_profile_default_swaps_to_strict(self, monkeypatch) -> None:
+        """Pass-through: explicit None args trigger the body's fallback to
+        the DEFAULT_* constants - this is the path '--profile default' takes
+        once Click hands off, since the empty built-in 'default' profile
+        contributes no default_map entries.
+        """
+        from phentrieve.config import (
+            DEFAULT_CHUNK_RETRIEVAL_THRESHOLD,
+            DEFAULT_MIN_CONFIDENCE_AGGREGATED,
+            DEFAULT_TOP_K,
+        )
+
+        captured = _install_pipeline_doubles(monkeypatch)
+
+        interactive_text_mode(
+            chunk_retrieval_threshold=None,
+            aggregated_term_confidence=None,
+            num_results=None,
+        )
+
+        assert captured.get("called") is True
+        kwargs = captured["kwargs"]
+        assert kwargs["chunk_retrieval_threshold"] == DEFAULT_CHUNK_RETRIEVAL_THRESHOLD
+        assert (
+            kwargs["min_confidence_for_aggregated"] == DEFAULT_MIN_CONFIDENCE_AGGREGATED
+        )
+        assert kwargs["num_results_per_chunk"] == DEFAULT_TOP_K
+
+    def test_explicit_flag_overrides_profile(self, monkeypatch) -> None:
+        """Explicit non-None values reach the orchestrator unchanged, beating
+        any profile-injected default. This mirrors what happens when the
+        user passes --num-results 20 on the CLI: Click routes COMMANDLINE
+        through to the function with the explicit value, the body's
+        fallback is a no-op, and the orchestrator sees 20.
+        """
+        captured = _install_pipeline_doubles(monkeypatch)
+
+        interactive_text_mode(
+            language="fr",
+            num_results=20,
+            chunk_retrieval_threshold=0.42,
+            aggregated_term_confidence=0.7,
+        )
+
+        assert captured.get("called") is True
+        kwargs = captured["kwargs"]
+        assert kwargs["language"] == "fr"
+        assert kwargs["num_results_per_chunk"] == 20
+        assert kwargs["chunk_retrieval_threshold"] == 0.42
+        assert kwargs["min_confidence_for_aggregated"] == 0.7
+
+
+class TestProfileOptionRegistered:
+    """Smoke-test: the --profile option is wired with the eager callback."""
+
+    def test_profile_option_present_with_eager_callback(self) -> None:
+        import typer
+        from typer.main import get_command
+
+        from phentrieve.cli._profile import apply_profile_callback
+
+        # Build a tiny app that registers interactive_text_mode under a
+        # known name and inspect the resulting click.Group's subcommand.
+        app = typer.Typer()
+        app.command("interactive")(interactive_text_mode)
+        # Force a second command so Typer materializes a Group rather
+        # than collapsing to a single TyperCommand.
+        app.command("noop")(lambda: None)
+        click_cmd = get_command(app)
+        sub = click_cmd.commands["interactive"]  # type: ignore[attr-defined]
+
+        profile_param = next((p for p in sub.params if p.name == "profile"), None)
+        assert profile_param is not None, "--profile option not registered"
+        assert profile_param.is_eager is True
+        # xdist workers may import _profile in different processes - compare
+        # by qualified name rather than identity.
+        assert profile_param.callback is not None
+        assert profile_param.callback.__module__ == apply_profile_callback.__module__
+        assert (
+            profile_param.callback.__qualname__ == apply_profile_callback.__qualname__
+        )
+        # Built-in default per spec.
+        assert profile_param.default == "interactive"
+        # envvar wired per spec.
+        assert profile_param.envvar == "PHENTRIEVE_PROFILE"

--- a/tests/unit/cli/test_yaml_legacy_paths.py
+++ b/tests/unit/cli/test_yaml_legacy_paths.py
@@ -1,0 +1,81 @@
+"""Tests that legacy ``~/.phentrieve/`` YAML paths are still searched.
+
+Spec A Phase 7 Task 14: ``phentrieve.utils.get_config_paths()`` returns the
+legacy ``~/.phentrieve/phentrieve.yaml`` location after the local
+``./phentrieve.yaml``. A profile defined in the legacy file is loaded by
+``phentrieve.profiles.merged_profiles()`` when no local YAML exists; a local
+``./phentrieve.yaml`` shadows the legacy entry.
+"""
+
+from __future__ import annotations
+
+
+def _clear_yaml_cache() -> None:
+    from phentrieve.config import _load_yaml_config
+    from phentrieve.utils import load_user_config
+
+    _load_yaml_config.cache_clear()
+    load_user_config.cache_clear()
+
+
+def test_get_config_paths_includes_legacy_home(tmp_path, monkeypatch):
+    """``get_config_paths()`` lists ``~/.phentrieve/phentrieve.yaml``."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.chdir(tmp_path)
+
+    from phentrieve.utils import get_config_paths
+
+    paths = get_config_paths()
+    legacy = fake_home / ".phentrieve" / "phentrieve.yaml"
+    assert legacy in paths
+    # Local cwd path should appear before the legacy location.
+    local = (tmp_path / "phentrieve.yaml").resolve()
+    legacy_resolved = legacy.resolve()
+    resolved_paths = [p.resolve() for p in paths]
+    assert resolved_paths.index(local) < resolved_paths.index(legacy_resolved)
+
+
+def test_home_phentrieve_yaml_picked_up_when_no_local(tmp_path, monkeypatch):
+    """A ``phentrieve.yaml`` at ``~/.phentrieve/`` is searched when no local."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    (fake_home / ".phentrieve").mkdir()
+    (fake_home / ".phentrieve" / "phentrieve.yaml").write_text(
+        "profiles:\n  legacy_profile:\n    language: de\n"
+    )
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+    monkeypatch.setenv("HOME", str(fake_home))
+    _clear_yaml_cache()
+
+    from phentrieve.profiles import merged_profiles
+
+    profiles = merged_profiles()
+    assert "legacy_profile" in profiles
+    assert profiles["legacy_profile"].language == "de"
+    _clear_yaml_cache()
+
+
+def test_local_yaml_shadows_legacy_path(tmp_path, monkeypatch):
+    """``./phentrieve.yaml`` shadows ``~/.phentrieve/phentrieve.yaml``."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    (fake_home / ".phentrieve").mkdir()
+    (fake_home / ".phentrieve" / "phentrieve.yaml").write_text(
+        "profiles:\n  shared:\n    language: de\n"
+    )
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    (cwd / "phentrieve.yaml").write_text("profiles:\n  shared:\n    language: fr\n")
+    monkeypatch.chdir(cwd)
+    monkeypatch.setenv("HOME", str(fake_home))
+    _clear_yaml_cache()
+
+    from phentrieve.profiles import merged_profiles
+
+    profiles = merged_profiles()
+    assert profiles["shared"].language == "fr"
+    _clear_yaml_cache()

--- a/tests/unit/profiles/test_frontend_constant_parity.py
+++ b/tests/unit/profiles/test_frontend_constant_parity.py
@@ -1,0 +1,63 @@
+"""Cross-language parity check between frontend defaults and Python config."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FRONTEND_DEFAULTS = REPO_ROOT / "frontend" / "src" / "constants" / "defaults.js"
+
+
+# Map of frontend constant -> Python config attribute that should match.
+# Whitelist: DEFAULT_NUM_RESULTS_PER_CHUNK is intentional UI divergence (3 vs backend 10).
+PARITY_MAP: dict[str, str] = {
+    "DEFAULT_NUM_RESULTS": "DEFAULT_TOP_K",
+    "DEFAULT_SIMILARITY_THRESHOLD": "MIN_SIMILARITY_THRESHOLD",
+    "DEFAULT_SPLIT_THRESHOLD": "DEFAULT_SPLITTING_THRESHOLD",
+    "DEFAULT_CHUNK_RETRIEVAL_THRESHOLD": "DEFAULT_CHUNK_RETRIEVAL_THRESHOLD",
+    "DEFAULT_AGGREGATED_TERM_CONFIDENCE": "DEFAULT_MIN_CONFIDENCE_AGGREGATED",
+    "DEFAULT_WINDOW_SIZE": "DEFAULT_WINDOW_SIZE_TOKENS",
+    "DEFAULT_STEP_SIZE": "DEFAULT_STEP_SIZE_TOKENS",
+    "DEFAULT_MIN_SEGMENT_LENGTH": "DEFAULT_MIN_SEGMENT_LENGTH_WORDS",
+}
+
+# Intentional UI-specific divergences. Documented in docs/user-guide/configuration-profiles.md.
+INTENTIONAL_DIVERGENCES: set[str] = {"DEFAULT_NUM_RESULTS_PER_CHUNK"}
+
+
+def _extract_js_numeric_constants(text: str) -> dict[str, float]:
+    """Parse `export const NAME = NUMBER;` lines."""
+    pattern = re.compile(r"export\s+const\s+(\w+)\s*=\s*([\d.]+)\s*;")
+    return {name: float(value) for name, value in pattern.findall(text)}
+
+
+def test_frontend_defaults_file_exists():
+    assert FRONTEND_DEFAULTS.exists(), f"{FRONTEND_DEFAULTS} not found"
+
+
+@pytest.mark.parametrize("frontend_name,python_name", list(PARITY_MAP.items()))
+def test_constant_parity(frontend_name: str, python_name: str):
+    from phentrieve import config as phentrieve_config
+
+    js_constants = _extract_js_numeric_constants(FRONTEND_DEFAULTS.read_text())
+    assert frontend_name in js_constants, (
+        f"Frontend constant {frontend_name} missing from {FRONTEND_DEFAULTS}. "
+        f"Expected to match Python {python_name}."
+    )
+    python_value = getattr(phentrieve_config, python_name, None)
+    assert python_value is not None, f"Python config has no attribute {python_name}"
+    assert js_constants[frontend_name] == float(python_value), (
+        f"Parity mismatch: frontend {frontend_name} = {js_constants[frontend_name]}, "
+        f"Python {python_name} = {python_value}. "
+        f"Update one to match the other."
+    )
+
+
+def test_intentional_divergences_documented():
+    js_constants = _extract_js_numeric_constants(FRONTEND_DEFAULTS.read_text())
+    for name in INTENTIONAL_DIVERGENCES:
+        assert name in js_constants, (
+            f"Whitelisted-divergence {name} not found in frontend; "
+            f"remove from INTENTIONAL_DIVERGENCES if it was deleted."
+        )

--- a/tests/unit/profiles/test_profile_schema.py
+++ b/tests/unit/profiles/test_profile_schema.py
@@ -59,3 +59,29 @@ class TestProfilesFileSchema:
             {"profiles": {"x": {"language": "en"}}, "unrelated_top_level": 42}
         )
         assert "x" in f.profiles
+
+
+class TestBuiltInProfiles:
+    def test_builtin_default_exists(self):
+        from phentrieve.profiles import BUILTIN_PROFILES
+
+        assert "default" in BUILTIN_PROFILES
+        # All fields None - fall through to YAML / constants.
+        assert BUILTIN_PROFILES["default"].chunk_retrieval_threshold is None
+
+    def test_builtin_interactive_exists_and_loose(self):
+        from phentrieve.profiles import BUILTIN_PROFILES
+
+        interactive = BUILTIN_PROFILES["interactive"]
+        assert interactive.chunk_retrieval_threshold == 0.3
+        assert interactive.aggregated_term_confidence == 0.35
+        assert interactive.num_results == 5
+
+    def test_builtin_profiles_validate(self):
+        from phentrieve.profiles import BUILTIN_PROFILES
+
+        # Each is a real Profile instance, not a dict.
+        for name, p in BUILTIN_PROFILES.items():
+            assert isinstance(p, Profile), (
+                f"BUILTIN_PROFILES[{name!r}] is not a Profile"
+            )

--- a/tests/unit/profiles/test_profile_schema.py
+++ b/tests/unit/profiles/test_profile_schema.py
@@ -1,0 +1,61 @@
+"""Tests for Profile and ProfilesFile pydantic models."""
+
+import pytest
+from pydantic import ValidationError
+
+from phentrieve.profiles import Profile, ProfilesFile
+
+
+class TestProfileSchema:
+    def test_minimal_profile_all_fields_optional(self):
+        # Should not raise: every Profile field is optional.
+        profile = Profile()
+        assert profile.description is None
+        assert profile.command is None
+        assert profile.language is None
+
+    def test_profile_with_all_fields(self):
+        profile = Profile(
+            description="test",
+            command="text process",
+            language="de",
+            chunk_retrieval_threshold=0.6,
+            num_results=5,
+        )
+        assert profile.description == "test"
+        assert profile.command == "text process"
+        assert profile.language == "de"
+
+    def test_profile_extra_forbid_rejects_unknown_keys(self):
+        with pytest.raises(ValidationError) as exc_info:
+            Profile(unknown_field="value")
+        assert "unknown_field" in str(exc_info.value)
+
+    def test_profile_extra_forbid_rejects_typos(self):
+        # User typos like `chuck_retrieval_threshold` (chunk -> chuck) error.
+        with pytest.raises(ValidationError) as exc_info:
+            Profile(chuck_retrieval_threshold=0.5)
+        assert "chuck_retrieval_threshold" in str(exc_info.value)
+
+
+class TestProfilesFileSchema:
+    def test_empty_profiles_file_ok(self):
+        f = ProfilesFile()
+        assert f.profiles == {}
+
+    def test_profiles_dict_typed(self):
+        f = ProfilesFile(
+            profiles={
+                "fast_query": Profile(
+                    command="query", num_results=5, similarity_threshold=0.5
+                ),
+            }
+        )
+        assert f.profiles["fast_query"].num_results == 5
+
+    def test_profiles_file_ignores_unknown_top_level_keys(self):
+        # ProfilesFile uses extra="ignore" so other top-level YAML keys are fine.
+        f = ProfilesFile.model_validate(
+            {"profiles": {"x": {"language": "en"}}, "unrelated_top_level": 42}
+        )
+        assert "x" in f.profiles

--- a/tests/unit/profiles/test_resolver.py
+++ b/tests/unit/profiles/test_resolver.py
@@ -1,0 +1,115 @@
+"""Tests for resolve_profile_for_command."""
+
+import pytest
+import typer
+
+from phentrieve.profiles import (
+    BUILTIN_PROFILES,
+    Profile,
+    resolve_profile_for_command,
+)
+
+
+@pytest.fixture
+def known_profiles():
+    return {
+        **BUILTIN_PROFILES,
+        "fast_query": Profile(command="query", num_results=5, similarity_threshold=0.5),
+        "shared_german": Profile(
+            language="de", semantic_chunker_model="jinaai/jina-embeddings-v2-base-de"
+        ),
+    }
+
+
+class TestResolveProfileForCommand:
+    def test_none_returns_appropriate_builtin_for_text_interactive(
+        self, known_profiles
+    ):
+        profile, kwargs = resolve_profile_for_command(
+            None,
+            ("text", "interactive"),
+            accepted_keys=set(),
+            all_profiles=known_profiles,
+        )
+        assert profile is known_profiles["interactive"]
+
+    def test_none_returns_default_for_other_commands(self, known_profiles):
+        profile, _ = resolve_profile_for_command(
+            None,
+            ("text", "process"),
+            accepted_keys=set(),
+            all_profiles=known_profiles,
+        )
+        assert profile is known_profiles["default"]
+
+    def test_unknown_profile_raises_with_close_match(self, known_profiles):
+        with pytest.raises(typer.BadParameter) as exc_info:
+            resolve_profile_for_command(
+                "fast_quary",  # typo
+                ("query",),
+                accepted_keys=set(),
+                all_profiles=known_profiles,
+            )
+        # Echo + close-match suggestion.
+        msg = str(exc_info.value)
+        assert "fast_quary" in msg
+        assert "fast_query" in msg  # close-match hint
+
+    def test_unknown_profile_no_close_match(self, known_profiles):
+        # Use a name far enough from any known profile that difflib doesn't suggest.
+        with pytest.raises(typer.BadParameter) as exc_info:
+            resolve_profile_for_command(
+                "xyzzy",
+                ("query",),
+                accepted_keys=set(),
+                all_profiles=known_profiles,
+            )
+        msg = str(exc_info.value)
+        assert "xyzzy" in msg
+        # No "Did you mean" since no profile is close enough.
+        assert "Did you mean" not in msg or "fast_query" not in msg
+
+    def test_command_bound_profile_matches(self, known_profiles):
+        profile, kwargs = resolve_profile_for_command(
+            "fast_query",
+            ("query",),
+            accepted_keys={"num_results", "similarity_threshold"},
+            all_profiles=known_profiles,
+        )
+        assert profile is known_profiles["fast_query"]
+        assert kwargs == {"num_results": 5, "similarity_threshold": 0.5}
+
+    def test_command_bound_profile_mismatched_command_raises(self, known_profiles):
+        # fast_query is bound to "query" but invoked from text process.
+        with pytest.raises(typer.BadParameter) as exc_info:
+            resolve_profile_for_command(
+                "fast_query",
+                ("text", "process"),
+                accepted_keys={"num_results"},
+                all_profiles=known_profiles,
+            )
+        assert "query" in str(exc_info.value)  # mention the bound command
+
+    def test_unbound_profile_filters_to_accepted_keys(self, known_profiles):
+        # shared_german has language and semantic_chunker_model.
+        # If the command only accepts language, only language should land in kwargs.
+        profile, kwargs = resolve_profile_for_command(
+            "shared_german",
+            ("query",),
+            accepted_keys={"language"},
+            all_profiles=known_profiles,
+        )
+        assert kwargs == {"language": "de"}
+        # Not in accepted_keys -> filtered out.
+        assert "semantic_chunker_model" not in kwargs
+
+    def test_unbound_profile_skips_none_fields(self, known_profiles):
+        profile, kwargs = resolve_profile_for_command(
+            "shared_german",
+            ("query",),
+            accepted_keys={"language", "num_results"},
+            all_profiles=known_profiles,
+        )
+        # num_results is None on shared_german -> not included.
+        assert "num_results" not in kwargs
+        assert kwargs == {"language": "de"}

--- a/tests/unit/profiles/test_resolver.py
+++ b/tests/unit/profiles/test_resolver.py
@@ -113,3 +113,66 @@ class TestResolveProfileForCommand:
         # num_results is None on shared_german -> not included.
         assert "num_results" not in kwargs
         assert kwargs == {"language": "de"}
+
+
+class TestLoadProfilesFromYaml:
+    def test_no_profiles_section_returns_empty(self, tmp_path, monkeypatch):
+        from phentrieve.profiles import load_profiles_from_yaml
+
+        yaml_path = tmp_path / "phentrieve.yaml"
+        yaml_path.write_text("data_dir: data\ndefault_model: foo\n")
+        # Force phentrieve.yaml lookup to point at our tmp path.
+        monkeypatch.chdir(tmp_path)
+        # Clear caches from any prior test - both layers cache.
+        from phentrieve.config import _load_yaml_config
+        from phentrieve.utils import load_user_config
+
+        load_user_config.cache_clear()
+        _load_yaml_config.cache_clear()
+
+        profiles = load_profiles_from_yaml()
+        assert profiles == {}
+
+    def test_profiles_section_parses(self, tmp_path, monkeypatch):
+        from phentrieve.config import _load_yaml_config
+        from phentrieve.profiles import load_profiles_from_yaml
+
+        yaml_path = tmp_path / "phentrieve.yaml"
+        yaml_path.write_text(
+            "profiles:\n"
+            "  fast_query:\n"
+            "    command: query\n"
+            "    num_results: 5\n"
+            "    similarity_threshold: 0.5\n"
+        )
+        monkeypatch.chdir(tmp_path)
+        from phentrieve.utils import load_user_config
+
+        load_user_config.cache_clear()
+        _load_yaml_config.cache_clear()
+
+        profiles = load_profiles_from_yaml()
+        assert "fast_query" in profiles
+        assert profiles["fast_query"].num_results == 5
+
+    def test_invalid_profile_logs_warning_and_skips(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        from phentrieve.config import _load_yaml_config
+        from phentrieve.profiles import load_profiles_from_yaml
+
+        yaml_path = tmp_path / "phentrieve.yaml"
+        # Has an unknown key (extra=forbid -> validation error on this profile only).
+        yaml_path.write_text(
+            "profiles:\n  good:\n    language: en\n  bad:\n    unknown_field: value\n"
+        )
+        monkeypatch.chdir(tmp_path)
+        from phentrieve.utils import load_user_config
+
+        load_user_config.cache_clear()
+        _load_yaml_config.cache_clear()
+
+        profiles = load_profiles_from_yaml()
+        assert "good" in profiles
+        assert "bad" not in profiles  # Skipped due to validation error.
+        assert any("bad" in rec.message for rec in caplog.records)

--- a/tests/unit/retrieval/adaptive_rechunker/test_adaptive_config.py
+++ b/tests/unit/retrieval/adaptive_rechunker/test_adaptive_config.py
@@ -1,0 +1,109 @@
+"""Tests for AdaptiveRechunkingConfig and AdaptiveRechunkingProfileBlock."""
+
+import dataclasses
+
+import pytest
+
+
+def test_default_config_disabled():
+    from phentrieve.retrieval.adaptive_rechunker import AdaptiveRechunkingConfig
+
+    cfg = AdaptiveRechunkingConfig()
+    assert cfg.enabled is False  # opt-in
+    assert cfg.quality_threshold == 0.55
+    assert cfg.margin_threshold == 0.03
+    assert cfg.use_ontology_coherence is False
+    assert cfg.max_depth == 2
+    assert cfg.min_chunk_chars == 30
+    assert cfg.max_sentences_per_subchunk == 3
+    assert cfg.overlap_sentences == 1
+    assert cfg.score_improvement_gate == 0.05
+
+
+def test_config_is_frozen():
+    from phentrieve.retrieval.adaptive_rechunker import AdaptiveRechunkingConfig
+
+    cfg = AdaptiveRechunkingConfig(enabled=True)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        cfg.enabled = False  # type: ignore[misc]
+
+
+def test_profile_block_pydantic_extra_forbid():
+    from pydantic import ValidationError
+
+    from phentrieve.retrieval.adaptive_rechunker import AdaptiveRechunkingProfileBlock
+
+    with pytest.raises(ValidationError):
+        AdaptiveRechunkingProfileBlock(unknown_knob=123)
+
+
+def test_profile_block_optional_fields():
+    from phentrieve.retrieval.adaptive_rechunker import AdaptiveRechunkingProfileBlock
+
+    block = AdaptiveRechunkingProfileBlock(enabled=True)
+    assert block.enabled is True
+    assert block.quality_threshold is None  # optional
+    assert block.max_depth is None
+
+
+def test_profile_block_all_fields():
+    from phentrieve.retrieval.adaptive_rechunker import AdaptiveRechunkingProfileBlock
+
+    block = AdaptiveRechunkingProfileBlock(
+        enabled=True,
+        quality_threshold=0.6,
+        margin_threshold=0.02,
+        max_depth=1,
+        min_chunk_chars=40,
+        max_sentences_per_subchunk=2,
+        overlap_sentences=0,
+        score_improvement_gate=0.1,
+        use_ontology_coherence=False,
+    )
+    assert block.quality_threshold == 0.6
+    assert block.max_depth == 1
+
+
+def test_resolve_precedence_cli_over_profile_over_yaml_over_default():
+    from phentrieve.retrieval.adaptive_rechunker import (
+        AdaptiveRechunkingProfileBlock,
+        adaptive_config_from_profile_block,
+    )
+
+    block = AdaptiveRechunkingProfileBlock(
+        enabled=True, quality_threshold=0.7, margin_threshold=0.04
+    )
+    yaml_block = {
+        "quality_threshold": 0.5,  # masked by profile
+        "min_chunk_chars": 50,  # masked by no other source -> takes effect
+    }
+    cli_overrides = {"margin_threshold": 0.01}  # masks profile
+
+    cfg = adaptive_config_from_profile_block(
+        block=block,
+        yaml_block=yaml_block,
+        cli_overrides=cli_overrides,
+    )
+
+    # CLI wins
+    assert cfg.margin_threshold == 0.01
+    # Profile wins over YAML
+    assert cfg.quality_threshold == 0.7
+    assert cfg.enabled is True
+    # YAML wins over default
+    assert cfg.min_chunk_chars == 50
+    # Default for unset
+    assert cfg.max_depth == 2
+    assert cfg.score_improvement_gate == 0.05
+
+
+def test_resolve_with_no_inputs_returns_defaults():
+    from phentrieve.retrieval.adaptive_rechunker import (
+        AdaptiveRechunkingConfig,
+        adaptive_config_from_profile_block,
+    )
+
+    cfg = adaptive_config_from_profile_block(
+        block=None, yaml_block=None, cli_overrides=None
+    )
+    assert cfg == AdaptiveRechunkingConfig()

--- a/tests/unit/retrieval/adaptive_rechunker/test_quality_assessment.py
+++ b/tests/unit/retrieval/adaptive_rechunker/test_quality_assessment.py
@@ -1,0 +1,122 @@
+"""Tests for assess_chunk_quality.
+
+The trigger conjunction:
+    is_poor = top_1 < quality_threshold AND (margin < margin_threshold OR top_2 is None)
+"""
+
+import pytest
+
+from phentrieve.retrieval.adaptive_rechunker import (
+    AdaptiveRechunkingConfig,
+    ChunkQualitySignals,
+    assess_chunk_quality,
+)
+
+
+def make_raw_result(similarities: list[float]) -> dict:
+    """Helper to build a raw query_batch output entry."""
+    return {
+        "ids": [[f"HP:{i:07d}" for i in range(len(similarities))]],
+        "metadatas": [[{"id": f"HP:{i:07d}"} for i in range(len(similarities))]],
+        "similarities": [similarities],
+        "distances": [[1 - s for s in similarities]],
+        "documents": [[""] * len(similarities)],
+    }
+
+
+@pytest.fixture
+def config():
+    return AdaptiveRechunkingConfig(quality_threshold=0.55, margin_threshold=0.03)
+
+
+class TestAssessChunkQuality:
+    def test_empty_raw_results_is_poor_no_matches(self, config):
+        raw = make_raw_result([])
+        sig = assess_chunk_quality(
+            raw, chunk_idx=0, chunk_retrieval_threshold=0.7, config=config
+        )
+        assert sig.is_poor is True
+        assert sig.reason == "no_matches"
+        assert sig.top_1 is None
+
+    def test_single_match_above_threshold_is_ok(self, config):
+        raw = make_raw_result([0.9])
+        sig = assess_chunk_quality(
+            raw, chunk_idx=0, chunk_retrieval_threshold=0.7, config=config
+        )
+        # top_2 is None - but top_1 above quality_threshold means we trust it.
+        assert sig.is_poor is False
+        assert sig.reason == "ok"
+
+    def test_single_match_below_threshold_is_poor_low_score(self, config):
+        raw = make_raw_result([0.4])
+        sig = assess_chunk_quality(
+            raw, chunk_idx=0, chunk_retrieval_threshold=0.7, config=config
+        )
+        # top_1 < 0.55 AND top_2 is None -> poor.
+        assert sig.is_poor is True
+        assert sig.reason == "low_score"
+
+    def test_two_matches_above_threshold_with_low_margin_ok(self, config):
+        # top_1=0.9, top_2=0.89, margin=0.01 < 0.03.
+        # But top_1 >= quality_threshold so we trust the result regardless.
+        raw = make_raw_result([0.9, 0.89])
+        sig = assess_chunk_quality(
+            raw, chunk_idx=0, chunk_retrieval_threshold=0.7, config=config
+        )
+        assert sig.is_poor is False
+        assert sig.reason == "ok"
+
+    def test_two_matches_low_score_high_margin_ok(self, config):
+        # top_1=0.5, top_2=0.1, margin=0.4 >= 0.03.
+        # Conjunction: top_1 < 0.55 AND (margin < 0.03 OR top_2 is None).
+        # margin is high -> second condition false -> not poor.
+        raw = make_raw_result([0.5, 0.1])
+        sig = assess_chunk_quality(
+            raw, chunk_idx=0, chunk_retrieval_threshold=0.7, config=config
+        )
+        assert sig.is_poor is False
+        assert sig.reason == "ok"
+
+    def test_two_matches_low_score_low_margin_is_poor_low_margin(self, config):
+        # top_1=0.5, top_2=0.49, margin=0.01 < 0.03. Both bad -> poor.
+        raw = make_raw_result([0.5, 0.49])
+        sig = assess_chunk_quality(
+            raw, chunk_idx=0, chunk_retrieval_threshold=0.7, config=config
+        )
+        assert sig.is_poor is True
+        assert sig.reason == "low_margin"
+
+    def test_signals_record_top_1_top_2_margin(self, config):
+        raw = make_raw_result([0.4, 0.38, 0.35])
+        sig = assess_chunk_quality(
+            raw, chunk_idx=2, chunk_retrieval_threshold=0.7, config=config
+        )
+        assert sig.chunk_idx == 2
+        assert sig.top_1 == 0.4
+        assert sig.top_2 == 0.38
+        assert sig.margin == pytest.approx(0.02)
+
+    def test_n_matches_above_threshold_informational(self, config):
+        # chunk_retrieval_threshold filters chunk_results, but
+        # assess_chunk_quality reads raw - n_matches_above_threshold is informational.
+        raw = make_raw_result([0.9, 0.85, 0.5, 0.4])  # 2 above 0.7
+        sig = assess_chunk_quality(
+            raw, chunk_idx=0, chunk_retrieval_threshold=0.7, config=config
+        )
+        assert sig.n_matches_above_threshold == 2
+
+    def test_chunk_quality_signals_is_frozen(self):
+        from dataclasses import FrozenInstanceError
+
+        sig = ChunkQualitySignals(
+            chunk_idx=0,
+            top_1=0.5,
+            top_2=0.4,
+            margin=0.1,
+            n_matches_above_threshold=0,
+            is_poor=False,
+            reason="ok",
+        )
+        with pytest.raises(FrozenInstanceError):
+            sig.chunk_idx = 1  # type: ignore[misc]

--- a/tests/unit/retrieval/adaptive_rechunker/test_raw_score_access.py
+++ b/tests/unit/retrieval/adaptive_rechunker/test_raw_score_access.py
@@ -1,0 +1,63 @@
+"""Critical invariant: assess_chunk_quality reads from raw query_batch
+output, NOT from threshold-filtered chunk_results. Without this test, a
+regression to filtered input could silently break the trigger for the
+exact case adaptive rechunking is designed to handle."""
+
+import pytest
+
+from phentrieve.retrieval.adaptive_rechunker import (
+    AdaptiveRechunkingConfig,
+    assess_chunk_quality,
+)
+
+
+class TestRawScoreAccess:
+    def test_genuinely_poor_chunk_detectable(self):
+        """Simulates a chunk where every retrieval result was below
+        chunk_retrieval_threshold. orchestrate_hpo_extraction would put
+        an empty `matches` list into chunk_results - but raw_query_results
+        still has the (low) similarities."""
+        config = AdaptiveRechunkingConfig(quality_threshold=0.55, margin_threshold=0.03)
+
+        # All similarities below the standard chunk_retrieval_threshold of 0.7.
+        # The corresponding chunk_results entry would have matches=[].
+        raw = {
+            "ids": [["HP:0001", "HP:0002"]],
+            "metadatas": [[{"id": "HP:0001"}, {"id": "HP:0002"}]],
+            "similarities": [[0.4, 0.39]],  # Both below 0.55, low margin.
+            "distances": [[0.6, 0.61]],
+            "documents": [["", ""]],
+        }
+
+        sig = assess_chunk_quality(
+            raw_query_result=raw,
+            chunk_idx=0,
+            chunk_retrieval_threshold=0.7,  # all matches below this!
+            config=config,
+        )
+
+        # The trigger MUST fire - both score and margin are bad.
+        assert sig.is_poor is True
+        assert sig.reason == "low_margin"
+        # And n_matches_above_threshold reports the chunk_results filter result.
+        assert sig.n_matches_above_threshold == 0  # nothing above 0.7
+
+    def test_top_2_present_in_raw_even_if_filtered_out_of_chunk_results(self):
+        """When chunk_retrieval_threshold = 0.7 and similarities = [0.6, 0.5],
+        chunk_results[0]['matches'] is empty. But raw still has both scores.
+        """
+        config = AdaptiveRechunkingConfig(quality_threshold=0.55, margin_threshold=0.03)
+        raw = {
+            "ids": [["HP:0001", "HP:0002"]],
+            "metadatas": [[{"id": "HP:0001"}, {"id": "HP:0002"}]],
+            "similarities": [[0.6, 0.5]],
+            "distances": [[0.4, 0.5]],
+            "documents": [["", ""]],
+        }
+        sig = assess_chunk_quality(
+            raw, chunk_idx=0, chunk_retrieval_threshold=0.7, config=config
+        )
+        # top_1=0.6 >= quality_threshold 0.55, so we trust it.
+        assert sig.is_poor is False
+        assert sig.top_2 == 0.5
+        assert sig.margin == pytest.approx(0.1)

--- a/tests/unit/retrieval/adaptive_rechunker/test_run_adaptive_rechunking.py
+++ b/tests/unit/retrieval/adaptive_rechunker/test_run_adaptive_rechunking.py
@@ -1,0 +1,292 @@
+"""Tests for the top-level run_adaptive_rechunking orchestration."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from phentrieve.retrieval.adaptive_rechunker import (
+    AdaptiveRechunkingConfig,
+    AdaptiveRechunkingResult,
+    run_adaptive_rechunking,
+)
+
+
+def make_raw(similarities: list[float]) -> dict:
+    return {
+        "ids": [[f"HP:{i:07d}" for i in range(len(similarities))]],
+        "metadatas": [
+            [{"id": f"HP:{i:07d}", "label": "x"} for i in range(len(similarities))]
+        ],
+        "similarities": [similarities],
+        "distances": [[1 - s for s in similarities]],
+        "documents": [[""] * len(similarities)],
+    }
+
+
+@pytest.fixture
+def mock_retriever():
+    return MagicMock()
+
+
+@pytest.fixture
+def basic_inputs():
+    """One good chunk + one poor chunk for happy-path tests."""
+    processed_chunks = [
+        {
+            "text": "Good chunk.",
+            "status": "AFFIRMED",
+            "start_char": 0,
+            "end_char": 11,
+            "source_indices": {"processing_stages": ["sentence"]},
+        },
+        {
+            "text": (
+                "Poor multi-finding sentence one. "
+                "Poor multi-finding sentence two. "
+                "Poor multi-finding sentence three."
+            ),
+            "status": "AFFIRMED",
+            "start_char": 12,
+            "end_char": 113,
+            "source_indices": {"processing_stages": ["sentence"]},
+        },
+    ]
+    chunk_results = [
+        {
+            "chunk_idx": 0,
+            "chunk_text": processed_chunks[0]["text"],
+            "matches": [{"id": "HP:0001", "name": "Good", "score": 0.9}],
+        },
+        {
+            "chunk_idx": 1,
+            "chunk_text": processed_chunks[1]["text"],
+            "matches": [],
+        },  # below threshold
+    ]
+    raw_query_results = [
+        make_raw([0.9, 0.8]),  # good chunk
+        make_raw([0.4, 0.39]),  # poor chunk: low score AND low margin
+    ]
+    return processed_chunks, chunk_results, raw_query_results
+
+
+class TestRunAdaptiveRechunking:
+    def test_disabled_returns_inputs_unchanged(self, mock_retriever, basic_inputs):
+        chunks, results, raw = basic_inputs
+        config = AdaptiveRechunkingConfig(enabled=False)
+        out = run_adaptive_rechunking(
+            processed_chunks=chunks,
+            chunk_results=results,
+            raw_query_results=raw,
+            retriever=mock_retriever,
+            language="en",
+            config=config,
+            num_results_per_chunk=10,
+            chunk_retrieval_threshold=0.7,
+            min_confidence_for_aggregated=0.0,
+            include_details=False,
+        )
+        assert isinstance(out, AdaptiveRechunkingResult)
+        assert out.processed_chunks == chunks
+        assert out.chunk_results == results
+        assert out.meta["enabled"] is False
+        # No retrieval calls were made.
+        assert mock_retriever.query_batch.call_count == 0
+
+    def test_no_poor_chunks_no_op(self, mock_retriever):
+        """All chunks are fine - no subdivision, no extra query_batch calls."""
+        processed = [
+            {
+                "text": "Good chunk one.",
+                "status": "AFFIRMED",
+                "start_char": 0,
+                "end_char": 15,
+                "source_indices": {"processing_stages": ["sentence"]},
+            },
+        ]
+        results = [
+            {
+                "chunk_idx": 0,
+                "chunk_text": processed[0]["text"],
+                "matches": [{"id": "HP:0001", "name": "x", "score": 0.9}],
+            }
+        ]
+        raw = [make_raw([0.95, 0.85])]
+        config = AdaptiveRechunkingConfig(enabled=True)
+
+        out = run_adaptive_rechunking(
+            processed_chunks=processed,
+            chunk_results=results,
+            raw_query_results=raw,
+            retriever=mock_retriever,
+            language="en",
+            config=config,
+            num_results_per_chunk=10,
+            chunk_retrieval_threshold=0.7,
+            min_confidence_for_aggregated=0.0,
+            include_details=False,
+        )
+        assert mock_retriever.query_batch.call_count == 0
+        assert out.meta["trigger_count"] == 0
+        assert out.meta["subdivided_count"] == 0
+
+    def test_one_poor_chunk_subdivided_with_improving_children(self, mock_retriever):
+        """One poor chunk subdivided into children that improve via the gate."""
+        processed = [
+            {
+                "text": "First sentence here. Second sentence here. Third sentence here.",
+                "status": "AFFIRMED",
+                "start_char": 0,
+                "end_char": 64,
+                "source_indices": {"processing_stages": ["sentence"]},
+            },
+        ]
+        results = [{"chunk_idx": 0, "chunk_text": processed[0]["text"], "matches": []}]
+        raw = [make_raw([0.4, 0.39])]  # poor: low score, low margin
+
+        # Mock retriever returns improved scores for children. We expect 1
+        # query_batch call (the children) at depth 1. With max_sentences=3 and
+        # overlap=0 the parent (3 sentences) yields a single child window; with
+        # overlap=1 it yields multiple windows. We don't pin child count here
+        # except via the side_effect length below.
+        # Children improve enough to pass the gate. Oversize the side_effect
+        # so we don't depend on the exact number of windows the chunker
+        # emits for our 3-sentence parent.
+        mock_retriever.query_batch.return_value = [
+            make_raw([0.9, 0.5]),  # top_1 = 0.9 > 0.4 + 0.05 -> improves!
+        ] * 5
+
+        config = AdaptiveRechunkingConfig(
+            enabled=True,
+            quality_threshold=0.55,
+            margin_threshold=0.03,
+            score_improvement_gate=0.05,
+            max_depth=1,
+            max_sentences_per_subchunk=2,
+            overlap_sentences=0,
+            min_chunk_chars=10,
+        )
+
+        out = run_adaptive_rechunking(
+            processed_chunks=processed,
+            chunk_results=results,
+            raw_query_results=raw,
+            retriever=mock_retriever,
+            language="en",
+            config=config,
+            num_results_per_chunk=10,
+            chunk_retrieval_threshold=0.7,
+            min_confidence_for_aggregated=0.0,
+            include_details=False,
+        )
+
+        # Exactly one query_batch call for the children at this single
+        # recursion level.
+        assert mock_retriever.query_batch.call_count == 1
+        assert out.meta["enabled"] is True
+        assert out.meta["trigger_count"] == 1
+        assert out.meta["subdivided_count"] == 1
+        assert out.meta["reverted_count"] == 0
+        # The parent chunk was replaced by one or more children in the
+        # final flat list; children carry the depth-1 stage marker.
+        assert all(
+            "adaptive_rechunker_depth_1"
+            in c.get("source_indices", {}).get("processing_stages", [])
+            for c in out.processed_chunks
+        )
+
+    def test_call_count_invariant_at_max_depth_2(self, mock_retriever):
+        """The hard cost-model contract: 1 call per recursion level."""
+        processed = [
+            {
+                "text": "Sentence one. Sentence two. Sentence three.",
+                "status": "AFFIRMED",
+                "start_char": 0,
+                "end_char": 44,
+                "source_indices": {"processing_stages": ["sentence"]},
+            },
+        ]
+        results = [{"chunk_idx": 0, "chunk_text": processed[0]["text"], "matches": []}]
+        raw = [make_raw([0.4, 0.39])]
+
+        # Children always also "poor" so recursion continues.
+        # Children improve enough to pass the gate, then still flag at depth 2.
+        # Worst case: each level produces 2 children, so we return enough raw
+        # results for any number of children we might emit.
+        depth_1_child = make_raw([0.6, 0.59])  # improves over 0.4 -> keeps
+        depth_2_child = make_raw([0.9, 0.5])  # improves further over 0.6
+
+        mock_retriever.query_batch.side_effect = [
+            [depth_1_child] * 5,  # depth 1 query (oversize is fine)
+            [depth_2_child] * 5,  # depth 2 query
+        ]
+
+        config = AdaptiveRechunkingConfig(
+            enabled=True,
+            quality_threshold=0.7,  # higher to keep flagging
+            margin_threshold=0.03,
+            score_improvement_gate=0.05,
+            max_depth=2,
+            max_sentences_per_subchunk=2,
+            overlap_sentences=0,
+            min_chunk_chars=5,
+        )
+
+        run_adaptive_rechunking(
+            processed_chunks=processed,
+            chunk_results=results,
+            raw_query_results=raw,
+            retriever=mock_retriever,
+            language="en",
+            config=config,
+            num_results_per_chunk=10,
+            chunk_retrieval_threshold=0.7,
+            min_confidence_for_aggregated=0.0,
+            include_details=False,
+        )
+
+        # AT MOST 2 query_batch calls (depth 1 + depth 2). Hard invariant.
+        assert mock_retriever.query_batch.call_count <= 2
+
+    def test_recursion_respects_max_depth(self, mock_retriever):
+        """max_depth=1 means: subdivide once, do not recurse further."""
+        processed = [
+            {
+                "text": "Sentence one. Sentence two. Sentence three.",
+                "status": "AFFIRMED",
+                "start_char": 0,
+                "end_char": 44,
+                "source_indices": {"processing_stages": ["sentence"]},
+            },
+        ]
+        results = [{"chunk_idx": 0, "chunk_text": processed[0]["text"], "matches": []}]
+        raw = [make_raw([0.4, 0.39])]
+        # Children also flag as poor - at max_depth=1 we should not recurse.
+        mock_retriever.query_batch.return_value = [make_raw([0.6, 0.59])] * 5
+
+        config = AdaptiveRechunkingConfig(
+            enabled=True,
+            max_depth=1,
+            quality_threshold=0.7,
+            margin_threshold=0.03,
+            score_improvement_gate=0.05,
+            max_sentences_per_subchunk=2,
+            overlap_sentences=0,
+            min_chunk_chars=5,
+        )
+
+        out = run_adaptive_rechunking(
+            processed_chunks=processed,
+            chunk_results=results,
+            raw_query_results=raw,
+            retriever=mock_retriever,
+            language="en",
+            config=config,
+            num_results_per_chunk=10,
+            chunk_retrieval_threshold=0.7,
+            min_confidence_for_aggregated=0.0,
+            include_details=False,
+        )
+
+        assert mock_retriever.query_batch.call_count == 1
+        assert out.meta["max_depth_reached"] == 1

--- a/tests/unit/retrieval/adaptive_rechunker/test_score_improvement_gate.py
+++ b/tests/unit/retrieval/adaptive_rechunker/test_score_improvement_gate.py
@@ -1,0 +1,91 @@
+"""Tests for apply_score_improvement_gate."""
+
+from phentrieve.retrieval.adaptive_rechunker import (
+    AdaptiveRechunkingConfig,
+    apply_score_improvement_gate,
+)
+
+
+def test_all_children_below_gate_revert():
+    config = AdaptiveRechunkingConfig(score_improvement_gate=0.05)
+    parent_top_1 = {0: 0.5}  # parent_idx 0 had top_1 = 0.5
+    child_top_1 = {1: 0.51, 2: 0.49}  # neither beats parent + 0.05 = 0.55
+
+    revert, keep = apply_score_improvement_gate(
+        parent_to_children={0: [1, 2]},
+        parent_top_1=parent_top_1,
+        child_top_1=child_top_1,
+        config=config,
+    )
+    assert revert == {0}
+    assert keep == set()
+
+
+def test_one_child_above_gate_keep():
+    config = AdaptiveRechunkingConfig(score_improvement_gate=0.05)
+    parent_top_1 = {0: 0.5}
+    child_top_1 = {1: 0.4, 2: 0.7}  # child 2 beats 0.5 + 0.05 = 0.55
+
+    revert, keep = apply_score_improvement_gate(
+        parent_to_children={0: [1, 2]},
+        parent_top_1=parent_top_1,
+        child_top_1=child_top_1,
+        config=config,
+    )
+    assert revert == set()
+    assert keep == {0}
+
+
+def test_multiple_parents_mixed_outcome():
+    config = AdaptiveRechunkingConfig(score_improvement_gate=0.05)
+    parent_top_1 = {0: 0.5, 1: 0.6}
+    child_top_1 = {2: 0.45, 3: 0.46, 4: 0.7, 5: 0.71}
+    # Parent 0 (children 2,3): max(0.46) < 0.55 -> revert.
+    # Parent 1 (children 4,5): max(0.71) > 0.65 -> keep.
+    revert, keep = apply_score_improvement_gate(
+        parent_to_children={0: [2, 3], 1: [4, 5]},
+        parent_top_1=parent_top_1,
+        child_top_1=child_top_1,
+        config=config,
+    )
+    assert revert == {0}
+    assert keep == {1}
+
+
+def test_parent_with_no_children_skipped():
+    config = AdaptiveRechunkingConfig(score_improvement_gate=0.05)
+    revert, keep = apply_score_improvement_gate(
+        parent_to_children={0: []},
+        parent_top_1={0: 0.5},
+        child_top_1={},
+        config=config,
+    )
+    # No children -> no decision, parent stays as-is.
+    assert revert == set()
+    assert keep == set()
+
+
+def test_parent_missing_top_1_skipped():
+    """Defensive: if a parent index has no recorded top_1, skip it."""
+    config = AdaptiveRechunkingConfig(score_improvement_gate=0.05)
+    revert, keep = apply_score_improvement_gate(
+        parent_to_children={0: [1]},
+        parent_top_1={},  # parent 0 has no entry
+        child_top_1={1: 0.9},
+        config=config,
+    )
+    assert revert == set()
+    assert keep == set()
+
+
+def test_children_missing_scores_revert():
+    """If child top_1 entries are missing, treat as revert (no improvement)."""
+    config = AdaptiveRechunkingConfig(score_improvement_gate=0.05)
+    revert, keep = apply_score_improvement_gate(
+        parent_to_children={0: [1, 2]},
+        parent_top_1={0: 0.5},
+        child_top_1={},  # no scores for any child
+        config=config,
+    )
+    assert revert == {0}
+    assert keep == set()

--- a/tests/unit/retrieval/adaptive_rechunker/test_subdivide_parent_chunk.py
+++ b/tests/unit/retrieval/adaptive_rechunker/test_subdivide_parent_chunk.py
@@ -1,0 +1,100 @@
+"""Tests for subdivide_parent_chunk."""
+
+import pytest
+
+from phentrieve.retrieval.adaptive_rechunker import (
+    AdaptiveRechunkingConfig,
+    subdivide_parent_chunk,
+)
+
+
+@pytest.fixture
+def config():
+    return AdaptiveRechunkingConfig(
+        min_chunk_chars=20, max_sentences_per_subchunk=3, overlap_sentences=1
+    )
+
+
+def make_parent(text: str, start_char: int = 0) -> dict:
+    return {
+        "text": text,
+        "status": "AFFIRMED",
+        "assertion_details": {"trigger": "default"},
+        "source_indices": {"processing_stages": ["paragraph", "sentence"]},
+        "start_char": start_char,
+        "end_char": start_char + len(text),
+    }
+
+
+class TestSubdivideParentChunk:
+    def test_multi_sentence_parent_produces_subchunks(self, config):
+        text = (
+            "Patient has severe intellectual disability. "
+            "He shows recurrent seizures since age 3. "
+            "Brain MRI revealed cortical atrophy. "
+            "Family history is unremarkable."
+        )
+        parent = make_parent(text)
+        children = subdivide_parent_chunk(
+            parent_chunk=parent, language="en", config=config, depth=1
+        )
+        assert len(children) >= 1
+        # Every child preserves assertion_status.
+        for child in children:
+            assert child["status"] == "AFFIRMED"
+            assert child["assertion_details"] == {"trigger": "default"}
+
+    def test_single_sentence_parent_returns_empty(self, config):
+        parent = make_parent("Patient has severe intellectual disability.")
+        children = subdivide_parent_chunk(
+            parent_chunk=parent, language="en", config=config, depth=1
+        )
+        # Either 0 (no useful split) or 1 (a single child equal to the
+        # parent - filtered out).
+        assert children == []
+
+    def test_subchunks_track_depth_in_processing_stages(self, config):
+        text = "First sentence here. Second sentence here. Third sentence."
+        parent = make_parent(text)
+        children = subdivide_parent_chunk(
+            parent_chunk=parent, language="en", config=config, depth=2
+        )
+        for child in children:
+            stages = child.get("source_indices", {}).get("processing_stages", [])
+            assert any("adaptive_rechunker_depth_2" in s for s in stages)
+
+    def test_subchunks_offset_by_parent_start_char(self, config):
+        text = (
+            "Patient has severe intellectual disability. "
+            "He shows recurrent seizures since age 3. "
+            "Brain MRI revealed cortical atrophy. "
+            "Family history is unremarkable."
+        )
+        parent = make_parent(text, start_char=100)
+        children = subdivide_parent_chunk(
+            parent_chunk=parent, language="en", config=config, depth=1
+        )
+        assert len(children) >= 1
+        for child in children:
+            assert child["start_char"] >= 100
+            assert child["end_char"] <= 100 + len(text)
+
+    def test_short_subchunks_below_min_chunk_chars_dropped(self):
+        config = AdaptiveRechunkingConfig(
+            min_chunk_chars=80, max_sentences_per_subchunk=1, overlap_sentences=0
+        )
+        text = "Short. Tiny. Brief sentence. " + "x" * 100 + "."
+        parent = make_parent(text)
+        children = subdivide_parent_chunk(
+            parent_chunk=parent, language="en", config=config, depth=1
+        )
+        # Sentences shorter than min_chunk_chars (80) should be dropped.
+        for child in children:
+            assert len(child["text"]) >= 80
+
+    def test_empty_parent_text_returns_empty(self, config):
+        parent = make_parent("")
+        children = subdivide_parent_chunk(
+            parent_chunk=parent, language="en", config=config, depth=1
+        )
+        assert children == []

--- a/tests/unit/test_config_constants.py
+++ b/tests/unit/test_config_constants.py
@@ -1,0 +1,27 @@
+"""Tests for new config constants added by Plan A."""
+
+import pytest
+
+from phentrieve import config as phentrieve_config
+
+pytestmark = pytest.mark.unit
+
+
+def test_default_num_results_exists_and_aliases_top_k():
+    assert phentrieve_config.DEFAULT_NUM_RESULTS == phentrieve_config.DEFAULT_TOP_K
+
+
+def test_default_chunk_confidence_default_value():
+    assert phentrieve_config.DEFAULT_CHUNK_CONFIDENCE == 0.2
+
+
+def test_default_assertion_preference_default_value():
+    assert phentrieve_config.DEFAULT_ASSERTION_PREFERENCE == "dependency"
+
+
+def test_default_output_format_query_default_value():
+    assert phentrieve_config.DEFAULT_OUTPUT_FORMAT_QUERY == "text"
+
+
+def test_default_output_format_process_default_value():
+    assert phentrieve_config.DEFAULT_OUTPUT_FORMAT_PROCESS == "json_lines"

--- a/tests/unit/text_processing/test_adapt_standard_response_extra_meta.py
+++ b/tests/unit/text_processing/test_adapt_standard_response_extra_meta.py
@@ -1,0 +1,42 @@
+"""Tests for adapt_standard_response.extra_meta merging."""
+
+from phentrieve.text_processing.full_text_service import adapt_standard_response
+
+
+def test_extra_meta_none_preserves_existing_shape():
+    response = adapt_standard_response(
+        pipeline_result=[],
+        extraction_result=([], []),
+        extra_meta=None,
+    )
+    assert "meta" in response
+    assert response["meta"]["extraction_backend"] == "standard"
+    # No new keys introduced.
+    assert "adaptive_rechunking" not in response["meta"]
+
+
+def test_extra_meta_dict_merges_into_meta():
+    extra = {"adaptive_rechunking": {"enabled": True, "trigger_count": 3}}
+    response = adapt_standard_response(
+        pipeline_result=[],
+        extraction_result=([], []),
+        extra_meta=extra,
+    )
+    assert response["meta"]["adaptive_rechunking"] == {
+        "enabled": True,
+        "trigger_count": 3,
+    }
+    # Existing meta keys preserved.
+    assert response["meta"]["extraction_backend"] == "standard"
+
+
+def test_extra_meta_does_not_overwrite_extraction_backend():
+    """If extra_meta accidentally includes extraction_backend, the canonical
+    value from the response wins (we set extraction_backend last)."""
+    extra = {"extraction_backend": "wrong"}
+    response = adapt_standard_response(
+        pipeline_result=[],
+        extraction_result=([], []),
+        extra_meta=extra,
+    )
+    assert response["meta"]["extraction_backend"] == "standard"

--- a/tests/unit/text_processing/test_full_text_service.py
+++ b/tests/unit/text_processing/test_full_text_service.py
@@ -14,6 +14,7 @@ from phentrieve.text_processing.full_text_service import (
     adapt_standard_response,
     preprocess_grounded_document,
     run_llm_backend,
+    run_standard_backend,
 )
 
 
@@ -1085,3 +1086,173 @@ def test_run_llm_backend_surfaces_phase2_routing_counts(mocker) -> None:
     assert result["meta"]["observability"]["phase2b_local_accept_count"] == 3
     assert result["meta"]["observability"]["phase2b_deferred_count"] == 2
     assert result["meta"]["observability"]["phase2b_no_candidate_skip_count"] == 1
+
+
+def _make_orchestration_result(
+    aggregated: list[dict] | None = None,
+    chunks: list[dict] | None = None,
+    raw: list[dict] | None = None,
+):
+    from phentrieve.text_processing.orchestration_result import OrchestrationResult
+
+    return OrchestrationResult(
+        aggregated_results=list(aggregated or []),
+        chunk_results=list(chunks or []),
+        raw_query_results=list(raw or []),
+    )
+
+
+def test_run_standard_backend_skips_adaptive_when_disabled(mocker):
+    """When adaptive_rechunking config is absent, no rechunker call is made
+    and meta.adaptive_rechunking is not surfaced.
+    """
+    text_pipeline = mocker.Mock()
+    text_pipeline.process.return_value = [
+        {"text": "chunk one", "status": "AFFIRMED", "start_char": 0, "end_char": 9},
+    ]
+    retriever = mocker.Mock()
+
+    raw = [{"similarities": [[0.9, 0.7]], "ids": [["HP:0001"]], "metadatas": [[{}]]}]
+    mocker.patch(
+        "phentrieve.text_processing.hpo_extraction_orchestrator.orchestrate_hpo_extraction",
+        return_value=_make_orchestration_result(
+            aggregated=[{"id": "HP:0001", "name": "X", "score": 0.9}],
+            chunks=[{"chunk_idx": 0, "matches": []}],
+            raw=raw,
+        ),
+    )
+    rechunker_spy = mocker.patch(
+        "phentrieve.retrieval.adaptive_rechunker.run_adaptive_rechunking"
+    )
+
+    result = run_standard_backend(
+        text="some clinical text",
+        text_pipeline=text_pipeline,
+        retriever=retriever,
+    )
+
+    rechunker_spy.assert_not_called()
+    assert "adaptive_rechunking" not in result["meta"]
+    assert result["meta"]["extraction_backend"] == "standard"
+
+
+def test_run_standard_backend_skips_adaptive_when_config_disabled(mocker):
+    """An AdaptiveRechunkingConfig with enabled=False is treated as no-op."""
+    from phentrieve.retrieval.adaptive_rechunker import AdaptiveRechunkingConfig
+
+    text_pipeline = mocker.Mock()
+    text_pipeline.process.return_value = [
+        {"text": "chunk one", "status": "AFFIRMED", "start_char": 0, "end_char": 9},
+    ]
+    retriever = mocker.Mock()
+    mocker.patch(
+        "phentrieve.text_processing.hpo_extraction_orchestrator.orchestrate_hpo_extraction",
+        return_value=_make_orchestration_result(),
+    )
+    rechunker_spy = mocker.patch(
+        "phentrieve.retrieval.adaptive_rechunker.run_adaptive_rechunking"
+    )
+
+    result = run_standard_backend(
+        text="some clinical text",
+        text_pipeline=text_pipeline,
+        retriever=retriever,
+        adaptive_rechunking=AdaptiveRechunkingConfig(enabled=False),
+    )
+
+    rechunker_spy.assert_not_called()
+    assert "adaptive_rechunking" not in result["meta"]
+
+
+def test_run_standard_backend_invokes_adaptive_when_enabled(mocker):
+    """When adaptive_rechunking is enabled, the rechunker is called and its
+    meta is surfaced under meta.adaptive_rechunking. The post-rechunk
+    processed_chunks / aggregated_results / chunk_results replace the
+    initial pass outputs.
+    """
+    from phentrieve.retrieval.adaptive_rechunker import (
+        AdaptiveRechunkingConfig,
+        AdaptiveRechunkingResult,
+    )
+
+    initial_processed = [
+        {
+            "text": "weak parent chunk",
+            "status": "AFFIRMED",
+            "start_char": 0,
+            "end_char": 17,
+        },
+    ]
+    text_pipeline = mocker.Mock()
+    text_pipeline.process.return_value = initial_processed
+    retriever = mocker.Mock()
+
+    initial_raw = [{"similarities": [[0.4]], "ids": [["HP:0001"]], "metadatas": [[{}]]}]
+    initial_orchestration = _make_orchestration_result(
+        aggregated=[{"id": "HP:0001", "name": "Weak", "score": 0.4}],
+        chunks=[{"chunk_idx": 0, "matches": []}],
+        raw=initial_raw,
+    )
+    mocker.patch(
+        "phentrieve.text_processing.hpo_extraction_orchestrator.orchestrate_hpo_extraction",
+        return_value=initial_orchestration,
+    )
+
+    post_processed = [
+        {"text": "child a", "status": "AFFIRMED", "start_char": 0, "end_char": 7},
+        {"text": "child b", "status": "AFFIRMED", "start_char": 8, "end_char": 15},
+    ]
+    post_aggregated = [
+        {"id": "HP:0002", "name": "Better", "score": 0.85, "chunks": [0]},
+    ]
+    post_chunks = [
+        {"chunk_idx": 0, "matches": []},
+        {"chunk_idx": 1, "matches": []},
+    ]
+    adaptive_meta = {
+        "enabled": True,
+        "trigger_count": 1,
+        "subdivided_count": 1,
+        "reverted_count": 0,
+        "max_depth_reached": 1,
+        "extra_chunks_added": 1,
+    }
+    rechunker_spy = mocker.patch(
+        "phentrieve.retrieval.adaptive_rechunker.run_adaptive_rechunking",
+        return_value=AdaptiveRechunkingResult(
+            processed_chunks=post_processed,
+            aggregated_results=post_aggregated,
+            chunk_results=post_chunks,
+            meta=adaptive_meta,
+        ),
+    )
+
+    cfg = AdaptiveRechunkingConfig(enabled=True)
+    result = run_standard_backend(
+        text="some clinical text",
+        text_pipeline=text_pipeline,
+        retriever=retriever,
+        adaptive_rechunking=cfg,
+        num_results_per_chunk=10,
+        chunk_retrieval_threshold=0.3,
+        min_confidence_for_aggregated=0.4,
+        include_details=False,
+    )
+
+    rechunker_spy.assert_called_once()
+    call_kwargs = rechunker_spy.call_args.kwargs
+    assert call_kwargs["processed_chunks"] == initial_processed
+    assert call_kwargs["chunk_results"] == initial_orchestration.chunk_results
+    assert call_kwargs["raw_query_results"] == initial_orchestration.raw_query_results
+    assert call_kwargs["retriever"] is retriever
+    assert call_kwargs["config"] is cfg
+    assert call_kwargs["num_results_per_chunk"] == 10
+    assert call_kwargs["chunk_retrieval_threshold"] == 0.3
+    assert call_kwargs["min_confidence_for_aggregated"] == 0.4
+    assert call_kwargs["include_details"] is False
+
+    assert result["meta"]["adaptive_rechunking"] == adaptive_meta
+    assert result["meta"]["num_processed_chunks"] == 2
+    assert result["meta"]["num_aggregated_hpo_terms"] == 1
+    # The aggregated terms come from the rechunker output, not the initial pass.
+    assert [t["id"] for t in result["aggregated_hpo_terms"]] == ["HP:0002"]

--- a/tests/unit/text_processing/test_orchestrate_with_precomputed.py
+++ b/tests/unit/text_processing/test_orchestrate_with_precomputed.py
@@ -1,0 +1,94 @@
+"""Tests for the new precomputed_query_results parameter and
+OrchestrationResult return type on orchestrate_hpo_extraction."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from phentrieve.text_processing.hpo_extraction_orchestrator import (
+    orchestrate_hpo_extraction,
+)
+from phentrieve.text_processing.orchestration_result import OrchestrationResult
+
+
+@pytest.fixture
+def mock_retriever():
+    r = MagicMock()
+    # Standard query_batch return shape.
+    r.query_batch.return_value = [
+        {
+            "ids": [["HP:0001250"]],
+            "metadatas": [[{"id": "HP:0001250", "label": "Seizure"}]],
+            "similarities": [[0.85]],
+            "distances": [[0.15]],
+            "documents": [[""]],
+        }
+    ]
+    return r
+
+
+def test_returns_orchestration_result(mock_retriever):
+    result = orchestrate_hpo_extraction(
+        text_chunks=["seizures"],
+        retriever=mock_retriever,
+        num_results_per_chunk=1,
+    )
+    assert isinstance(result, OrchestrationResult)
+    assert result.aggregated_results
+    assert result.chunk_results
+    assert result.raw_query_results  # populated from query_batch
+
+
+def test_legacy_unpack_still_works(mock_retriever):
+    aggregated, chunks = orchestrate_hpo_extraction(
+        text_chunks=["seizures"],
+        retriever=mock_retriever,
+        num_results_per_chunk=1,
+    )
+    assert isinstance(aggregated, list)
+    assert isinstance(chunks, list)
+
+
+def test_precomputed_skips_retrieval(mock_retriever):
+    raw = [
+        {
+            "ids": [["HP:0001"]],
+            "metadatas": [[{"id": "HP:0001", "label": "Foo"}]],
+            "similarities": [[0.9]],
+            "distances": [[0.1]],
+            "documents": [[""]],
+        }
+    ]
+    result = orchestrate_hpo_extraction(
+        text_chunks=["any text"],
+        retriever=mock_retriever,
+        num_results_per_chunk=1,
+        precomputed_query_results=raw,
+    )
+    # query_batch should NOT have been called.
+    assert mock_retriever.query_batch.call_count == 0
+    assert result.raw_query_results == raw
+    assert any(t["id"] == "HP:0001" for t in result.aggregated_results)
+
+
+def test_precomputed_value_drives_aggregation(mock_retriever):
+    raw = [
+        {
+            "ids": [["HP:0002"]],
+            "metadatas": [[{"id": "HP:0002", "label": "Bar"}]],
+            "similarities": [[0.95]],
+            "distances": [[0.05]],
+            "documents": [[""]],
+        }
+    ]
+    # mock_retriever would have returned HP:0001250 (from fixture) if called,
+    # but precomputed should drive aggregation entirely.
+    result = orchestrate_hpo_extraction(
+        text_chunks=["unused"],
+        retriever=mock_retriever,
+        num_results_per_chunk=1,
+        precomputed_query_results=raw,
+    )
+    ids = [t["id"] for t in result.aggregated_results]
+    assert "HP:0002" in ids
+    assert "HP:0001250" not in ids  # precomputed wins

--- a/tests/unit/text_processing/test_orchestration_result_legacy_unpack.py
+++ b/tests/unit/text_processing/test_orchestration_result_legacy_unpack.py
@@ -1,0 +1,67 @@
+"""Tests that OrchestrationResult supports both legacy 2-tuple unpacking
+and modern attribute access. Legacy unpacking is what keeps existing call
+sites working."""
+
+import pytest
+
+
+class TestOrchestrationResult:
+    def test_legacy_2_tuple_unpack_works(self):
+        from phentrieve.text_processing.orchestration_result import (
+            OrchestrationResult,
+        )
+
+        result = OrchestrationResult(
+            aggregated_results=[{"id": "HP:0001"}],
+            chunk_results=[{"chunk_idx": 0}],
+            raw_query_results=[{"similarities": [[0.9]]}],
+        )
+        # The legacy call sites do this:
+        agg, chunks = result
+        assert agg == [{"id": "HP:0001"}]
+        assert chunks == [{"chunk_idx": 0}]
+
+    def test_attribute_access_works(self):
+        from phentrieve.text_processing.orchestration_result import (
+            OrchestrationResult,
+        )
+
+        result = OrchestrationResult(
+            aggregated_results=[],
+            chunk_results=[],
+            raw_query_results=[{"similarities": [[]]}],
+        )
+        assert result.aggregated_results == []
+        assert result.chunk_results == []
+        assert result.raw_query_results == [{"similarities": [[]]}]
+
+    def test_indexing_returns_legacy_2_tuple_elements(self):
+        from phentrieve.text_processing.orchestration_result import (
+            OrchestrationResult,
+        )
+
+        result = OrchestrationResult(
+            aggregated_results=[1, 2],
+            chunk_results=[3, 4],
+            raw_query_results=[5, 6],
+        )
+        # Some call sites may index instead of unpack.
+        assert result[0] == [1, 2]
+        assert result[1] == [3, 4]
+
+    def test_iteration_yields_2_tuple(self):
+        from phentrieve.text_processing.orchestration_result import (
+            OrchestrationResult,
+        )
+
+        result = OrchestrationResult([1], [2], [3])
+        assert list(result) == [[1], [2]]
+
+    def test_immutable(self):
+        from phentrieve.text_processing.orchestration_result import (
+            OrchestrationResult,
+        )
+
+        result = OrchestrationResult([], [], [])
+        with pytest.raises(AttributeError):
+            result.aggregated_results = []  # frozen=True


### PR DESCRIPTION
## Summary

Implements two coordinated specs in one branch:

- **Spec/Plan A** — `.planning/specs/2026-04-25-cli-profiles-default-resolution-spec.md`. CLI profiles + interactive defaults fix. Closes **#28** and **#171**.
- **Spec/Plan B** — `.planning/specs/2026-04-25-adaptive-rechunking-spec.md`. Opt-in adaptive re-chunking for poor-quality retrieval. Closes **#148**.

44 atomic commits, TDD-driven, executed via subagent-driven-development per `.planning/active/EXECUTION-HANDOFF.md`.

### Spec A — CLI profiles
- New `--profile NAME` flag on `query`, `text process`, `text interactive`. Both root (`phentrieve --profile X cmd`) and per-command placement work; subcommand wins on conflict. `PHENTRIEVE_PROFILE` env var equivalent.
- New `phentrieve config` subcommand group (`list-profiles`, `show`, `validate`, `path`).
- New `--show-resolved-config` debug flag (stderr) on every command.
- New `phentrieve.yaml` sections: `profiles:`, `extraction:`, `output:`. Built-in `default` and `interactive` profiles ship in code.
- Architecture: Click's native `default_map` populated by an eager `--profile` callback before option resolution. Profileable Typer defaults move from literals to `None`; bodies fall back to `phentrieve.config` constants. Sidecar `ctx.obj["resolved_sources"]` provides fine-grained source labels (profile/yaml/const/commandline).
- Fixes #171: `phentrieve text interactive` defaults are now config-driven (no more divergent hardcoded literals).
- Frontend `DEFAULT_SIMILARITY_THRESHOLD` aligned with API: 0.5 → 0.3. Cross-language parity test guards against future drift.

### Spec B — Adaptive re-chunking
- Opt-in `--adaptive-rechunking` on `phentrieve text process` plus three threshold flags (`--adaptive-rechunking-quality-threshold`, `--adaptive-rechunking-margin-threshold`, `--adaptive-rechunking-max-depth`). Disabled by default — no behavior change for existing users.
- Detects per-chunk retrieval quality from raw `query_batch` top-K (not threshold-filtered), subdivides poor parents into sentence-window children via `SentenceChunker`, re-queries once per recursion level, applies score-improvement gate, re-aggregates without re-querying via the new `precomputed_query_results` parameter on `orchestrate_hpo_extraction`.
- Hard cost invariant tested: `query_batch.call_count == 1 + N` at recursion depth N (max 3 calls at `max_depth=2`).
- API parity: `TextProcessingRequest.adaptive_rechunking` field; `meta.adaptive_rechunking` response block. Frontend forwards the field when supplied (no UI in v1, deferred).
- Aggregator unchanged — the `max_score`-filter switch from earlier drafts moved to Future work to preserve the opt-in invariant.

### Refactor — `OrchestrationResult` (Spec B preflight)
- `orchestrate_hpo_extraction` now returns an `OrchestrationResult` dataclass instead of a 2-tuple. Backward compatible via `__iter__` for all 5 known legacy unpacking call sites. New `raw_query_results` attribute exposes unfiltered top-K.

### Companion issues spawned during planning (tracked separately, not in this PR)
- #234 — `phentrieve config calibrate-thresholds` subcommand.
- #235 — Aggregator `max_score` confidence filter.

## Acceptance gates run

- `make check && make typecheck-fast && make test` — 1491 passed, 44 skipped, 71% coverage.
- `make frontend-test-ci` — 239/239 passed.
- `make frontend-build-ci` — built in 2.6s.
- `make ci-local` and `make precommit` — pass.
- Cross-spec test `tests/integration/test_specA_specB_interaction.py` — passes.
- Documented-YAML test `tests/integration/test_documented_yaml.py` — every YAML snippet in `docs/user-guide/configuration-profiles.md` and `docs/user-guide/adaptive-rechunking.md` parses + resolves cleanly.

## Test plan

- [ ] CI green (lint, typecheck, unit + integration tests, frontend).
- [ ] Manual smoke: `phentrieve config list-profiles` (built-ins shown), `phentrieve --profile X query "hpo term"` (profile applied), `phentrieve text process file.txt --adaptive-rechunking --show-resolved-config` (adaptive enabled, resolved config printed to stderr).
- [ ] Verify `phentrieve text interactive` no longer diverges from `text process` defaults (#171).
- [ ] Frontend smoke: query with new 0.3 threshold default, results unchanged shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)