### PR TITLE
[codex] Add research-use compliance guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Phentrieve is an advanced AI-powered research system for mapping phenotype descriptions to Human Phenotype Ontology (HPO) terms using a Retrieval-Augmented Generation (RAG) approach. It supports multiple languages and offers robust tools for benchmarking, text processing, and HPO term retrieval.
 
-**Research use only:** Phentrieve is not a medical device and must not be used for diagnosis, treatment selection, patient triage, or other clinical decision-making. See the [Research Use Only guide](docs/compliance/research-use.md).
+**Research use only:** Phentrieve is not a medical device and must not be used for diagnosis, treatment selection, patient triage, or other clinical decision-making. See the [Research Use Only guide](docs/compliance/research-use.md) and [Privacy and LLM Processing](docs/compliance/privacy-and-llm-processing.md).
 
 **For comprehensive documentation, please visit the [Phentrieve Documentation Site](https://berntpopp.github.io/phentrieve/).**
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ![Phentrieve Logo](docs/assets/phentrieve-logo.svg)
 
-Phentrieve is an advanced AI-powered system for mapping clinical text to Human Phenotype Ontology (HPO) terms using a Retrieval-Augmented Generation (RAG) approach. It supports multiple languages and offers robust tools for benchmarking, text processing, and HPO term retrieval.
+Phentrieve is an advanced AI-powered research system for mapping phenotype descriptions to Human Phenotype Ontology (HPO) terms using a Retrieval-Augmented Generation (RAG) approach. It supports multiple languages and offers robust tools for benchmarking, text processing, and HPO term retrieval.
+
+**Research use only:** Phentrieve is not a medical device and must not be used for diagnosis, treatment selection, patient triage, or other clinical decision-making. See the [Research Use Only guide](docs/compliance/research-use.md).
 
 **For comprehensive documentation, please visit the [Phentrieve Documentation Site](https://berntpopp.github.io/phentrieve/).**
 
@@ -41,8 +43,8 @@ For detailed setup and usage instructions, including Docker deployment, please s
 # Launch interactive query mode
 phentrieve query --interactive
 
-# Process clinical text to extract HPO terms
-phentrieve text process "The patient exhibits microcephaly and frequent seizures."
+# Process research text to extract HPO terms
+phentrieve text process "The research note mentions microcephaly and frequent seizures."
 ```
 
 Discover more commands and options in the [User Guide](https://berntpopp.github.io/phentrieve/user-guide/).
@@ -67,7 +69,7 @@ See [docs/user-guide/configuration-profiles.md](docs/user-guide/configuration-pr
 
 ## Docker Deployment
 
-Deploy Phentrieve using Docker Compose for production environments:
+Deploy Phentrieve using Docker Compose for self-hosted research environments:
 
 ```bash
 # Linux: Setup volume permissions (required)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,3 +36,4 @@ Scans run on every push/PR and weekly.
 - Public-hosted research deployments should set `PHENTRIEVE_PUBLIC_HOSTED_MODE=true`
 - Do not submit PHI/PII unless you have an appropriate legal basis, privacy controls, and operational safeguards
 - No PHI/PII stored by default
+- For LLM extraction, publish which external provider is configured and avoid raw-text logging

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,5 +32,7 @@ Scans run on every push/PR and weekly.
 ## Considerations
 
 - ML models loaded from Hugging Face Hub (verify checksums when possible)
-- Configure rate limiting in production
+- Configure rate limiting for hosted deployments
+- Public-hosted research deployments should set `PHENTRIEVE_PUBLIC_HOSTED_MODE=true`
+- Do not submit PHI/PII unless you have an appropriate legal basis, privacy controls, and operational safeguards
 - No PHI/PII stored by default

--- a/api/README.md
+++ b/api/README.md
@@ -6,7 +6,7 @@ This directory contains the FastAPI implementation for the Phentrieve project, p
 
 The Phentrieve API provides a set of endpoints to interact with the Human Phenotype Ontology (HPO) data for:
 
-- Querying clinical text to retrieve relevant HPO terms
+- Querying research phenotype text to retrieve relevant HPO terms
 - Calculating semantic similarity between HPO terms
 - Retrieving configuration and model information
 - Health check endpoint for monitoring

--- a/api/config.py
+++ b/api/config.py
@@ -30,6 +30,8 @@ __all__ = [
     "PHENTRIEVE_TRUSTED_PROXY_CIDRS",
     "PHENTRIEVE_LLM_DAILY_LIMIT",
     "PHENTRIEVE_LLM_QUOTA_DB_PATH",
+    "PHENTRIEVE_PUBLIC_HOSTED_MODE",
+    "PHENTRIEVE_REQUIRE_RESEARCH_ACK",
     "get_api_config_value",
 ]
 
@@ -49,6 +51,14 @@ _DEFAULT_CORS_METHODS = ["*"]
 _DEFAULT_CORS_HEADERS = ["*"]
 
 _DEFAULT_DATA_ROOT_DIR = "../data"
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    """Parse a boolean environment variable with a conservative default."""
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    return raw_value.strip().lower() in {"1", "true", "yes", "on"}
 
 
 @functools.lru_cache(maxsize=1)
@@ -234,4 +244,8 @@ PHENTRIEVE_LLM_DAILY_LIMIT: int = int(os.getenv("PHENTRIEVE_LLM_DAILY_LIMIT", "5
 PHENTRIEVE_LLM_QUOTA_DB_PATH: str = os.getenv(
     "PHENTRIEVE_LLM_QUOTA_DB_PATH",
     "../data/app/llm_quota.db",
+)
+PHENTRIEVE_PUBLIC_HOSTED_MODE: bool = _env_bool("PHENTRIEVE_PUBLIC_HOSTED_MODE", False)
+PHENTRIEVE_REQUIRE_RESEARCH_ACK: bool = _env_bool(
+    "PHENTRIEVE_REQUIRE_RESEARCH_ACK", False
 )

--- a/api/main.py
+++ b/api/main.py
@@ -259,22 +259,22 @@ def create_app() -> FastAPI:
             "description": "API for Human Phenotype Ontology (HPO) term retrieval and semantic similarity calculation",
             "endpoints": {
                 "HPO Term Query": {
-                    "description": "Query HPO terms based on clinical text",
+                    "description": "Query HPO terms based on research phenotype text",
                     "endpoints": [
                         {
                             "path": "/api/v1/query/",
                             "methods": ["GET", "POST"],
-                            "description": "Retrieve relevant HPO terms for clinical text",
+                            "description": "Retrieve relevant HPO terms for research phenotype text",
                         }
                     ],
                 },
                 "Text Processing": {
-                    "description": "Process clinical text to extract HPO terms with advanced configuration",
+                    "description": "Process research phenotype text to extract HPO terms with advanced configuration",
                     "endpoints": [
                         {
                             "path": "/api/v1/text/process",
                             "methods": ["POST"],
-                            "description": "Process raw clinical text with customizable chunking and assertion detection settings",
+                            "description": "Process raw research phenotype text with customizable chunking and assertion detection settings",
                         }
                     ],
                 },

--- a/api/mcp/config.py
+++ b/api/mcp/config.py
@@ -39,7 +39,11 @@ class MCPSettings(BaseSettings):
         description="MCP server name shown to clients",
     )
     description: str = Field(
-        default="Extract HPO (Human Phenotype Ontology) terms from clinical text",
+        default=(
+            "Research use only: map research text to Human Phenotype "
+            "Ontology (HPO) terms. Not for diagnosis, treatment, triage, "
+            "or other clinical decision-making."
+        ),
         description="MCP server description shown to clients",
     )
 

--- a/api/research_use.py
+++ b/api/research_use.py
@@ -13,6 +13,23 @@ RESEARCH_USE_LIMITATION = (
 )
 
 
+def research_ack_openapi_parameter() -> dict[str, object]:
+    """Return the OpenAPI parameter for research-use acknowledgement."""
+    return {
+        "name": RESEARCH_ACK_HEADER_DISPLAY,
+        "in": "header",
+        "required": False,
+        "schema": {
+            "type": "string",
+            "enum": ["true"],
+        },
+        "description": (
+            "Required when public-hosted or research-ack mode is enabled. "
+            "Set to `true` after presenting the research-use limitation."
+        ),
+    }
+
+
 def is_research_ack_required() -> bool:
     """Return whether text-bearing endpoints require acknowledgement."""
     return bool(

--- a/api/research_use.py
+++ b/api/research_use.py
@@ -1,0 +1,44 @@
+"""Research-use guardrails shared by API routers."""
+
+from fastapi import HTTPException, Request, status
+
+import api.config as api_config
+
+RESEARCH_ACK_HEADER = "x-phentrieve-research-use-acknowledged"
+RESEARCH_ACK_HEADER_DISPLAY = "X-Phentrieve-Research-Use-Acknowledged"
+RESEARCH_USE_LIMITATION = (
+    "Research use only. Phentrieve maps text to HPO terms for research, "
+    "education, and knowledge discovery. It must not be used for diagnosis, "
+    "treatment selection, patient triage, or other clinical decision-making."
+)
+
+
+def is_research_ack_required() -> bool:
+    """Return whether text-bearing endpoints require acknowledgement."""
+    return bool(
+        api_config.PHENTRIEVE_PUBLIC_HOSTED_MODE
+        or api_config.PHENTRIEVE_REQUIRE_RESEARCH_ACK
+    )
+
+
+def require_research_use_acknowledgement(request: Request) -> None:
+    """Require a research-use acknowledgement header when configured."""
+    if not is_research_ack_required():
+        return
+
+    if request.headers.get(RESEARCH_ACK_HEADER, "").lower() == "true":
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_428_PRECONDITION_REQUIRED,
+        detail={
+            "error_code": "research_use_ack_required",
+            "message": (
+                "This endpoint is available for research use only. Send "
+                f"{RESEARCH_ACK_HEADER_DISPLAY}: true after presenting the "
+                "research-use limitation to the user."
+            ),
+            "required_header": RESEARCH_ACK_HEADER_DISPLAY,
+            "intended_use": RESEARCH_USE_LIMITATION,
+        },
+    )

--- a/api/routers/phenopacket_router.py
+++ b/api/routers/phenopacket_router.py
@@ -1,8 +1,12 @@
 import json
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 
+from api.research_use import (
+    RESEARCH_USE_LIMITATION,
+    require_research_use_acknowledgement,
+)
 from api.schemas.phenopacket_schemas import (
     ExportPhenotypeRequest,
     ExportTextAttributionRequest,
@@ -116,6 +120,12 @@ def _apply_request_metadata_to_bundle(
 
     meta = phenopacket_payload.setdefault("metaData", {})
     external_references = meta.setdefault("externalReferences", [])
+    external_references.append(
+        {
+            "id": "phentrieve:intended_use",
+            "description": RESEARCH_USE_LIMITATION,
+        }
+    )
     if request.case_label:
         external_references.append(
             {
@@ -143,8 +153,11 @@ def _apply_request_metadata_to_bundle(
 
 @router.post("/export", response_model=PhenopacketExportResponse)
 def export_phenopacket(
+    http_request: Request,
     request: PhenopacketExportRequest,
 ) -> PhenopacketExportResponse:
+    require_research_use_acknowledgement(http_request)
+
     aggregated_results = [
         _map_phenotype_for_export(phenotype) for phenotype in request.phenotypes
     ]

--- a/api/routers/phenopacket_router.py
+++ b/api/routers/phenopacket_router.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Request
 from api.research_use import (
     RESEARCH_USE_LIMITATION,
     require_research_use_acknowledgement,
+    research_ack_openapi_parameter,
 )
 from api.schemas.phenopacket_schemas import (
     ExportPhenotypeRequest,
@@ -151,7 +152,11 @@ def _apply_request_metadata_to_bundle(
     return bundle
 
 
-@router.post("/export", response_model=PhenopacketExportResponse)
+@router.post(
+    "/export",
+    response_model=PhenopacketExportResponse,
+    openapi_extra={"parameters": [research_ack_openapi_parameter()]},
+)
 def export_phenopacket(
     http_request: Request,
     request: PhenopacketExportRequest,

--- a/api/routers/query_router.py
+++ b/api/routers/query_router.py
@@ -1,9 +1,13 @@
 import logging
 from typing import Literal, cast
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 
 from api.dependencies import get_dense_retriever_dependency
+from api.research_use import (
+    RESEARCH_USE_LIMITATION,
+    require_research_use_acknowledgement,
+)
 from api.schemas.query_schemas import QueryRequest, QueryResponse
 from phentrieve.config import (
     DEFAULT_AGGREGATION_STRATEGY,
@@ -85,10 +89,14 @@ async def get_retriever_for_get_params(
     "/",
     response_model=QueryResponse,
     operation_id="query_hpo_terms",
-    summary="Query HPO terms from clinical text",
-    description="Extract relevant HPO terms from clinical text using semantic search.",
+    summary="Query HPO terms from research text",
+    description=(
+        f"{RESEARCH_USE_LIMITATION} Extract relevant HPO terms from research "
+        "text using semantic search."
+    ),
 )
 async def run_hpo_query_get(
+    http_request: Request,
     text: str,
     model_name: str | None = DEFAULT_MODEL,
     language: str | None = None,  # Will auto-detect if not provided
@@ -134,7 +142,11 @@ async def run_hpo_query_get(
     )
 
     # Reuse the POST endpoint logic
-    return await run_hpo_query(request=request, retriever=retriever)
+    return await run_hpo_query(
+        request=request,
+        http_request=http_request,
+        retriever=retriever,
+    )
 
 
 @router.post(
@@ -142,10 +154,14 @@ async def run_hpo_query_get(
     response_model=QueryResponse,
     operation_id="query_hpo_terms_advanced",
     summary="Advanced HPO term query with full configuration",
-    description="Execute HPO term query with full control over retrieval parameters.",
+    description=(
+        f"{RESEARCH_USE_LIMITATION} Execute HPO term query with full control "
+        "over retrieval parameters."
+    ),
 )
 async def run_hpo_query(
     request: QueryRequest,
+    http_request: Request,
     retriever: DenseRetriever = Depends(get_retriever_for_request),
 ):
     """Execute an HPO term query with full control over parameters.
@@ -153,6 +169,8 @@ async def run_hpo_query(
     This endpoint accepts a JSON body with various options for fine-tuning the query.
     For a simpler interface, use the GET endpoint.
     """
+    require_research_use_acknowledgement(http_request)
+
     sbert_model_to_use_for_retrieval = (
         request.model_name or DEFAULT_MODEL
     )  # Use requested or default for retrieval SBERT

--- a/api/routers/query_router.py
+++ b/api/routers/query_router.py
@@ -7,6 +7,7 @@ from api.dependencies import get_dense_retriever_dependency
 from api.research_use import (
     RESEARCH_USE_LIMITATION,
     require_research_use_acknowledgement,
+    research_ack_openapi_parameter,
 )
 from api.schemas.query_schemas import QueryRequest, QueryResponse
 from phentrieve.config import (
@@ -94,6 +95,7 @@ async def get_retriever_for_get_params(
         f"{RESEARCH_USE_LIMITATION} Extract relevant HPO terms from research "
         "text using semantic search."
     ),
+    openapi_extra={"parameters": [research_ack_openapi_parameter()]},
 )
 async def run_hpo_query_get(
     http_request: Request,
@@ -158,6 +160,7 @@ async def run_hpo_query_get(
         f"{RESEARCH_USE_LIMITATION} Execute HPO term query with full control "
         "over retrieval parameters."
     ),
+    openapi_extra={"parameters": [research_ack_openapi_parameter()]},
 )
 async def run_hpo_query(
     request: QueryRequest,

--- a/api/routers/text_processing_router.py
+++ b/api/routers/text_processing_router.py
@@ -488,7 +488,7 @@ def _adapt_shared_service_response_to_api(
     "/process",
     response_model=TextProcessingResponseAPI,
     operation_id="process_clinical_text",
-    summary="Process clinical text to extract HPO terms",
+    summary="Process research phenotype text to extract HPO terms",
     description=(
         f"{RESEARCH_USE_LIMITATION} Process text with chunking, assertion "
         "detection, and HPO term extraction. When LLM extraction is selected "
@@ -535,10 +535,10 @@ async def process_text_extract_hpo(
     request: TextProcessingRequest,
 ):
     """
-    Process clinical text to extract Human Phenotype Ontology (HPO) terms.
+    Process research phenotype text to extract Human Phenotype Ontology (HPO) terms.
 
     This endpoint replicates the functionality of the `phentrieve text process` CLI command,
-    accepting raw clinical text input along with various processing configurations.
+    accepting raw research phenotype text input along with various processing configurations.
     It returns processed text chunks with assertion statuses and aggregated HPO terms.
 
     Heavy NLP operations are executed asynchronously to prevent blocking the API server.

--- a/api/routers/text_processing_router.py
+++ b/api/routers/text_processing_router.py
@@ -21,9 +21,9 @@ from api.llm_quota import (
     resolve_subject_ip,
 )
 from api.research_use import (
-    RESEARCH_ACK_HEADER_DISPLAY,
     RESEARCH_USE_LIMITATION,
     require_research_use_acknowledgement,
+    research_ack_openapi_parameter,
 )
 from api.schemas.text_processing_schemas import (
     AggregatedHPOTermAPI,
@@ -513,20 +513,7 @@ def _adapt_shared_service_response_to_api(
                     "`429 Too Many Requests`."
                 ),
             },
-            {
-                "name": RESEARCH_ACK_HEADER_DISPLAY,
-                "in": "header",
-                "required": False,
-                "schema": {
-                    "type": "string",
-                    "enum": ["true"],
-                },
-                "description": (
-                    "Required when public-hosted or research-ack mode is "
-                    "enabled. Confirms the user has accepted the research-use "
-                    "limitation."
-                ),
-            },
+            research_ack_openapi_parameter(),
         ]
     },
 )

--- a/api/routers/text_processing_router.py
+++ b/api/routers/text_processing_router.py
@@ -20,6 +20,11 @@ from api.llm_quota import (
     quota_reset_at_iso,
     resolve_subject_ip,
 )
+from api.research_use import (
+    RESEARCH_ACK_HEADER_DISPLAY,
+    RESEARCH_USE_LIMITATION,
+    require_research_use_acknowledgement,
+)
 from api.schemas.text_processing_schemas import (
     AggregatedHPOTermAPI,
     HPOMatchInChunkAPI,
@@ -485,8 +490,9 @@ def _adapt_shared_service_response_to_api(
     operation_id="process_clinical_text",
     summary="Process clinical text to extract HPO terms",
     description=(
-        "Process clinical text with chunking, assertion detection, and HPO "
-        "term extraction. When LLM extraction is selected in production, "
+        f"{RESEARCH_USE_LIMITATION} Process text with chunking, assertion "
+        "detection, and HPO term extraction. When LLM extraction is selected "
+        "in production, "
         "clients can opt into automatic fallback to the standard backend by "
         "sending `X-Phentrieve-Allow-Standard-Fallback: true`."
     ),
@@ -506,7 +512,21 @@ def _adapt_shared_service_response_to_api(
                     "the standard extraction backend instead of returning "
                     "`429 Too Many Requests`."
                 ),
-            }
+            },
+            {
+                "name": RESEARCH_ACK_HEADER_DISPLAY,
+                "in": "header",
+                "required": False,
+                "schema": {
+                    "type": "string",
+                    "enum": ["true"],
+                },
+                "description": (
+                    "Required when public-hosted or research-ack mode is "
+                    "enabled. Confirms the user has accepted the research-use "
+                    "limitation."
+                ),
+            },
         ]
     },
 )
@@ -525,6 +545,8 @@ async def process_text_extract_hpo(
 
     Includes adaptive timeout based on text length to prevent frontend disconnects.
     """
+    require_research_use_acknowledgement(http_request)
+
     logger.info(
         "API: Received request to process text. Language: %s, Strategy: %s",
         _sanitize(request.language),

--- a/api/schemas/query_schemas.py
+++ b/api/schemas/query_schemas.py
@@ -9,7 +9,9 @@ from phentrieve.config import DEFAULT_MULTI_VECTOR
 
 class QueryRequest(BaseModel):
     text: str = Field(
-        ..., min_length=1, description="Clinical text to query for HPO terms."
+        ...,
+        min_length=1,
+        description="Research phenotype text to query for HPO terms.",
     )
     model_name: str | None = Field(
         None,

--- a/api/schemas/text_processing_schemas.py
+++ b/api/schemas/text_processing_schemas.py
@@ -21,7 +21,7 @@ class TextProcessingRequest(BaseModel):
     text: str = Field(
         ...,
         validation_alias=AliasChoices("text", "text_content"),
-        description="The raw clinical text to process.",
+        description="The raw research phenotype text to process.",
     )
     extraction_backend: Literal["standard", "llm"] = "standard"
     llm_model: str | None = None

--- a/docs/DOCKER-DEPLOYMENT.md
+++ b/docs/DOCKER-DEPLOYMENT.md
@@ -379,7 +379,7 @@ healthcheck:
 
 ---
 
-## Production Deployment
+## Hosted Research Deployment
 
 ### Reverse Proxy Integration (Nginx Proxy Manager)
 

--- a/docs/DOCKER-DEPLOYMENT.md
+++ b/docs/DOCKER-DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Docker Deployment Guide
 
-This guide covers deploying Phentrieve using Docker and Docker Compose for production environments.
+This guide covers deploying Phentrieve using Docker and Docker Compose for self-hosted research environments.
 
 ## Table of Contents
 
@@ -10,7 +10,7 @@ This guide covers deploying Phentrieve using Docker and Docker Compose for produ
 - [Pre-built Data Bundles](#pre-built-data-bundles)
 - [Volume Permissions (Linux Only)](#volume-permissions-linux-only)
 - [Configuration](#configuration)
-- [Production Deployment](#production-deployment)
+- [Hosted Research Deployment](#hosted-research-deployment)
 - [Troubleshooting](#troubleshooting)
 - [Security Considerations](#security-considerations)
 - [Upgrading from Previous Versions](#upgrading-from-previous-versions)
@@ -19,7 +19,7 @@ This guide covers deploying Phentrieve using Docker and Docker Compose for produ
 
 ## Overview
 
-Phentrieve provides production-ready Docker images with comprehensive security hardening:
+Phentrieve provides Docker images with comprehensive security hardening for hosted research deployments:
 
 - ✅ **Non-root execution** - API runs as UID 10001, frontend as UID 101
 - ✅ **Resource limits** - CPU and memory constraints prevent resource exhaustion

--- a/docs/advanced-topics/algorithms-and-packages.md
+++ b/docs/advanced-topics/algorithms-and-packages.md
@@ -4,7 +4,7 @@ This document provides a comprehensive reference of the algorithms, packages, me
 
 ## Overview
 
-Phentrieve implements a multi-stage pipeline combining natural language processing, vector embeddings, and information retrieval to map clinical text to HPO terms. This reference documents the technical implementation details.
+Phentrieve implements a multi-stage pipeline combining natural language processing, vector embeddings, and information retrieval to map research phenotype text to HPO terms. This reference documents the technical implementation details.
 
 ## Core Algorithms
 

--- a/docs/advanced-topics/benchmarking-framework.md
+++ b/docs/advanced-topics/benchmarking-framework.md
@@ -4,7 +4,7 @@ Phentrieve includes a comprehensive benchmarking framework for evaluating and co
 
 ## Overview
 
-The benchmarking framework tests how well different models map clinical text to the correct HPO terms. It uses a set of test cases with ground truth HPO terms and measures various metrics to evaluate performance.
+The benchmarking framework tests how well different models map research phenotype text to the correct HPO terms. It uses a set of test cases with ground truth HPO terms and measures various metrics to evaluate performance.
 
 ## Running Benchmarks
 
@@ -159,7 +159,7 @@ class CustomMetric(BaseMetric):
 
 ## Extraction Benchmarking
 
-The extraction benchmark evaluates document-level HPO extraction from clinical text against gold-standard annotations.
+The extraction benchmark evaluates document-level HPO extraction from research phenotype text against gold-standard annotations.
 
 ### Overview
 

--- a/docs/advanced-topics/index.md
+++ b/docs/advanced-topics/index.md
@@ -8,7 +8,7 @@ Phentrieve leverages state-of-the-art algorithms from machine learning, NLP, and
 
 ## Text Processing Pipeline
 
-Phentrieve's text processing pipeline is highly configurable and can be adapted to different clinical text formats and languages. The [Text Processing Pipeline](text-processing-pipeline.md) page explains the internal architecture and customization options.
+Phentrieve's text processing pipeline is highly configurable and can be adapted to different research phenotype text formats and languages. The [Text Processing Pipeline](text-processing-pipeline.md) page explains the internal architecture and customization options.
 
 ## Benchmarking Framework
 

--- a/docs/advanced-topics/text-processing-pipeline.md
+++ b/docs/advanced-topics/text-processing-pipeline.md
@@ -1,6 +1,6 @@
 # Text Processing Pipeline
 
-Phentrieve utilizes a sophisticated, configurable pipeline to transform raw clinical text into analyzable semantic units. This document explains the architecture, implementation details, and customization options.
+Phentrieve utilizes a sophisticated, configurable pipeline to transform raw research phenotype text into analyzable semantic units. This document explains the architecture, implementation details, and customization options.
 
 ## Architecture Overview
 
@@ -345,7 +345,7 @@ pipeline = TextProcessingPipeline(
 )
 
 # Process text
-chunks = pipeline.chunk_text("Your clinical text here...")
+chunks = pipeline.chunk_text("Your research phenotype text here...")
 ```
 
 ## Language Support

--- a/docs/compliance/privacy-and-llm-processing.md
+++ b/docs/compliance/privacy-and-llm-processing.md
@@ -1,0 +1,72 @@
+# Privacy and LLM Processing
+
+This page describes the intended privacy posture for a public Phentrieve
+research service, including deployments such as `phentrieve.kidney-genetics.org`.
+
+Phentrieve can process text through two backend modes:
+
+- **Standard extraction** uses local retrieval and text-processing components.
+- **LLM extraction** may send submitted text to the external LLM provider
+  configured by the service operator.
+
+## Public Hosted Mode
+
+Public deployments should enable:
+
+```bash
+PHENTRIEVE_PUBLIC_HOSTED_MODE=true
+PHENTRIEVE_REQUIRE_RESEARCH_ACK=true
+```
+
+This keeps LLM functionality available while requiring clients to acknowledge
+the research-use limitation before text-bearing requests are accepted.
+
+## External LLM Disclosure
+
+When LLM extraction is enabled, the operator should disclose:
+
+- which LLM provider or provider category is used;
+- that submitted text may be transmitted to that provider for processing;
+- whether provider-side logging, retention, or model-training use is disabled;
+- whether text is stored by the Phentrieve service itself;
+- how long application logs are retained;
+- who to contact for privacy or data-removal questions.
+
+The frontend displays an LLM-specific notice when the LLM extraction backend is
+selected. Operators should keep the deployment privacy notice consistent with
+the configured LLM provider and data processing terms.
+
+## User Data Guidance
+
+Users should submit research text only. They should not submit names, contact
+details, record numbers, addresses, dates that directly identify a person, or
+other directly identifying information.
+
+Research text may still contain health-related information. Operators remain
+responsible for assessing whether their deployment has an appropriate legal
+basis, privacy notice, data processing agreement, cross-border transfer basis,
+and security controls for the data they accept.
+
+## Logging and Storage
+
+The public research service should avoid logging raw submitted text. Logs should
+prefer metadata such as request size, selected backend, status code, latency,
+and quota state.
+
+Phentrieve does not need to store submitted text for normal query and text
+processing requests. Phenopacket exports intentionally include source text in
+the returned artifact when the user chooses to export it; exported artifacts are
+the user's responsibility after download or downstream transfer.
+
+## Operator Checklist
+
+Before enabling a public hosted research deployment with LLM extraction:
+
+- publish a privacy notice that names the service operator;
+- document the configured LLM provider and data handling terms;
+- keep raw-text logging disabled;
+- require the research-use acknowledgement;
+- keep clinical decision-making claims out of the UI and documentation;
+- provide a contact route for privacy and security reports;
+- review whether GDPR, institutional review, data processing, or transfer
+  requirements apply to the deployment.

--- a/docs/compliance/research-use.md
+++ b/docs/compliance/research-use.md
@@ -52,5 +52,9 @@ text that you are not authorized to process. The CLI prints a research-use
 notice for text-bearing commands, the web app requires the current disclaimer to
 be acknowledged, and the frontend avoids logging raw submitted text.
 
+See [Privacy and LLM Processing](privacy-and-llm-processing.md) for the
+recommended public-service posture when LLM extraction sends text to an external
+AI provider.
+
 Phenopacket exports include a Phentrieve intended-use metadata reference so
 exported artifacts carry the research-use limitation with them.

--- a/docs/compliance/research-use.md
+++ b/docs/compliance/research-use.md
@@ -1,0 +1,56 @@
+# Research Use Only
+
+Phentrieve is provided for research, education, benchmarking, and knowledge
+discovery. It maps input text to Human Phenotype Ontology (HPO) terms and may
+return incomplete, incorrect, or contextually inappropriate results.
+
+Phentrieve is not a medical device and must not be used for diagnosis,
+treatment selection, patient triage, emergency workflows, or any other clinical
+decision-making. Human review and separate clinical validation are required
+before any downstream clinical or operational use.
+
+## EU AI Act Positioning
+
+This project is intended to remain outside clinical high-risk use by keeping the
+public service research-only and by avoiding claims that it performs diagnosis,
+patient management, or therapeutic decision support.
+
+Operators who deploy Phentrieve in a different context are responsible for their
+own legal assessment. A deployment used for clinical decision support, patient
+care workflows, or automated decision-making may require obligations that are
+not covered by this research-use configuration.
+
+## Public Service Guardrails
+
+Text-bearing API endpoints can require explicit acknowledgement by setting:
+
+```bash
+PHENTRIEVE_PUBLIC_HOSTED_MODE=true
+```
+
+or:
+
+```bash
+PHENTRIEVE_REQUIRE_RESEARCH_ACK=true
+```
+
+Clients must then send:
+
+```http
+X-Phentrieve-Research-Use-Acknowledged: true
+```
+
+LLM extraction remains available in public-hosted research deployments. If an
+external LLM provider is configured, operators should maintain a separate
+privacy, data processing, logging, and vendor-transfer assessment and disclose
+that submitted text may be processed by an external AI provider.
+
+## Data Handling
+
+Do not submit protected health information, directly identifying information, or
+text that you are not authorized to process. The CLI prints a research-use
+notice for text-bearing commands, the web app requires the current disclaimer to
+be acknowledged, and the frontend avoids logging raw submitted text.
+
+Phenopacket exports include a Phentrieve intended-use metadata reference so
+exported artifacts carry the research-use limitation with them.

--- a/docs/core-concepts/index.md
+++ b/docs/core-concepts/index.md
@@ -4,7 +4,7 @@ This section explains the key concepts and technologies behind Phentrieve's appr
 
 ## Multilingual Retrieval Augmented Generation (RAG)
 
-Phentrieve uses a Retrieval Augmented Generation (RAG) approach to map clinical text to Human Phenotype Ontology (HPO) terms. The key innovation is doing this in a multilingual context without requiring translation.
+Phentrieve uses a Retrieval Augmented Generation (RAG) approach to map research phenotype text to Human Phenotype Ontology (HPO) terms. The key innovation is doing this in a multilingual context without requiring translation.
 
 ## Key Components
 
@@ -24,7 +24,7 @@ These documents are converted into vector embeddings and stored in a vector data
 
 ### Semantic Similarity
 
-When clinical text is processed, it's embedded using the same model and compared to the stored HPO term vectors using semantic similarity. This allows direct matching between clinical descriptions in any language and English-based HPO terminology.
+When research phenotype text is processed, it is embedded using the same model and compared to the stored HPO term vectors using semantic similarity. This allows direct matching between phenotype descriptions in any language and English-based HPO terminology.
 
 ## Section Contents
 

--- a/docs/core-concepts/multilingual-embeddings.md
+++ b/docs/core-concepts/multilingual-embeddings.md
@@ -1,6 +1,6 @@
 # Multilingual Embeddings
 
-Multilingual embedding models are at the core of Phentrieve's ability to map clinical text in different languages to HPO terms without requiring translation.
+Multilingual embedding models are at the core of Phentrieve's ability to map research phenotype text in different languages to HPO terms without requiring translation.
 
 ## How Multilingual Embeddings Work
 
@@ -9,7 +9,7 @@ Multilingual embedding models are trained on text from multiple languages simult
 For example, the words "headache" (English), "Kopfschmerzen" (German), and "céphalée" (French) all refer to the same medical concept. A well-trained multilingual model will place these terms close together in the embedding space despite their different languages.
 
 This property enables Phentrieve to:
-1. Embed clinical text in any supported language
+1. Embed research phenotype text in any supported language
 2. Embed HPO terms (primarily in English)
 3. Find matches based on semantic similarity in the shared embedding space
 
@@ -23,7 +23,7 @@ Phentrieve supports several multilingual embedding models, each with different s
 
 ### Language-Specific Models
 
-- **jinaai/jina-embeddings-v2-base-de**: Optimized for German language understanding, this model performs well for German clinical text but lacks the cross-lingual capabilities of other models.
+- **jinaai/jina-embeddings-v2-base-de**: Optimized for German language understanding, this model performs well for German phenotype text but lacks the cross-lingual capabilities of other models.
 
 ### General Multilingual Models
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,15 +4,15 @@
 
 ### What is Phentrieve?
 
-Phentrieve is a comprehensive system for mapping clinical text in multiple languages to Human Phenotype Ontology (HPO) terms using a Retrieval-Augmented Generation (RAG) approach. It supports multilingual text processing, benchmarking across various embedding models, and provides flexible interfaces through a Python package, API, and web frontend.
+Phentrieve is a comprehensive research system for mapping phenotype text in multiple languages to Human Phenotype Ontology (HPO) terms using a Retrieval-Augmented Generation (RAG) approach. It supports multilingual text processing, benchmarking across various embedding models, and provides flexible interfaces through a Python package, API, and web frontend.
 
 ### What languages does Phentrieve support?
 
 Phentrieve supports multiple languages through its multilingual embedding models. The exact language coverage depends on the specific model being used. Domain-specific models like BioLORD support major languages for biomedical text, while general multilingual models like BGE-M3 support dozens of languages.
 
-### Do I need to translate my clinical text?
+### Do I need to translate my research phenotype text?
 
-No, that's the core innovation of Phentrieve! The system uses multilingual embedding models that can map clinical text in various languages directly to HPO terms without requiring translation.
+No, that's the core innovation of Phentrieve. The system uses multilingual embedding models that can map research phenotype text in various languages directly to HPO terms without requiring translation.
 
 ## Technical Questions
 
@@ -38,11 +38,11 @@ For the most accurate decision, run a benchmark on a representative sample of yo
 
 ### What is the difference between chunking strategies?
 
-Phentrieve offers different text chunking strategies for processing clinical text:
+Phentrieve offers different text chunking strategies for processing research phenotype text:
 
 - **Simple**: Basic chunking that splits text into paragraphs and then sentences. Good for well-structured notes.
 - **Semantic**: More advanced chunking that uses semantic similarity to create meaningful chunks. Good for complex sentences.
-- **Detailed**: The most fine-grained chunking that splits by punctuation and then applies semantic splitting. Best for dense clinical text.
+- **Detailed**: The most fine-grained chunking that splits by punctuation and then applies semantic splitting. Best for dense research phenotype text.
 - **Sliding Window**: Most configurable strategy with parameters for window size, step size, etc. Good when you need precise control.
 
 Choose based on your text structure and specific needs.

--- a/docs/getting-started/initial-setup.md
+++ b/docs/getting-started/initial-setup.md
@@ -97,7 +97,7 @@ Phentrieve supports several multilingual embedding models optimized for differen
 
 - **`jinaai/jina-embeddings-v2-base-de`**
   - German language specialization
-  - High precision for German clinical text
+  - High precision for German phenotype text
 
 ### General Multilingual Models
 
@@ -184,7 +184,7 @@ If everything is working, you should see HPO term suggestions like:
 Once you've completed the initial setup:
 
 1. Try [Interactive Querying](../user-guide/cli-usage.md#interactive-querying) to test your setup
-2. Explore the [Text Processing Guide](../user-guide/text-processing-guide.md) to learn how to process clinical text
+2. Explore the [Text Processing Guide](../user-guide/text-processing-guide.md) to learn how to process research phenotype text
 3. Check out the [Benchmarking Guide](../user-guide/benchmarking-guide.md) to evaluate model performance
 
 ## Troubleshooting

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,18 +1,21 @@
 # Welcome to Phentrieve
 
-Phentrieve is a comprehensive system for mapping clinical text in multiple languages to Human Phenotype Ontology (HPO) terms via a Retrieval-Augmented Generation (RAG) approach. The system supports multilingual text processing, benchmarking across various embedding models, and provides flexible interfaces through a Python package, API, and web frontend.
+Phentrieve is a comprehensive research system for mapping phenotype descriptions in multiple languages to Human Phenotype Ontology (HPO) terms via a Retrieval-Augmented Generation (RAG) approach. The system supports multilingual text processing, benchmarking across various embedding models, and provides flexible interfaces through a Python package, API, and web frontend.
+
+!!! warning "Research use only"
+    Phentrieve is not a medical device and must not be used for diagnosis, treatment selection, patient triage, or other clinical decision-making.
 
 ## Key Features
 
-* **Multilingual HPO Term Mapping**: Map clinical text to HPO terms in multiple languages without translation
-* **Advanced Text Processing**: Process clinical text with semantic chunking and assertion detection
+* **Multilingual HPO Term Mapping**: Map phenotype research text to HPO terms in multiple languages without translation
+* **Advanced Text Processing**: Process research text with semantic chunking and assertion detection
 * **Multiple Embedding Models**: Support for domain-specific, language-specific, and general multilingual models
 * **Comprehensive Benchmarking**: Evaluate and compare model performance with detailed metrics
 * **Multiple Interfaces**: Command-line tools, FastAPI backend, and Vue.js frontend
 
 ## Core Concept
 
-In clinical genomics and rare disease diagnosis, identifying phenotypic abnormalities in patient descriptions is a critical step. Traditional approaches often require translation when descriptions are in languages other than English, which can introduce inaccuracies.
+In rare disease research and phenotype curation, identifying phenotypic abnormalities in text descriptions is a common step. Traditional approaches often require translation when descriptions are in languages other than English, which can introduce inaccuracies.
 
 Phentrieve implements a novel approach using **multilingual embedding models** that map semantically similar concepts from different languages to nearby points in the embedding space. This allows direct matching between non-English clinical descriptions and English-based HPO terminology.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ Phentrieve is a comprehensive research system for mapping phenotype descriptions
 
 In rare disease research and phenotype curation, identifying phenotypic abnormalities in text descriptions is a common step. Traditional approaches often require translation when descriptions are in languages other than English, which can introduce inaccuracies.
 
-Phentrieve implements a novel approach using **multilingual embedding models** that map semantically similar concepts from different languages to nearby points in the embedding space. This allows direct matching between non-English clinical descriptions and English-based HPO terminology.
+Phentrieve implements a novel approach using **multilingual embedding models** that map semantically similar concepts from different languages to nearby points in the embedding space. This allows direct matching between non-English phenotype descriptions and English-based HPO terminology.
 
 ## Dive Deeper
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -14,7 +14,7 @@ Phentrieve supports the [Model Context Protocol (MCP)](https://modelcontextproto
 
 | Tool | Description |
 |------|-------------|
-| `query_hpo_terms` | Search HPO terms by semantic similarity to clinical text |
+| `query_hpo_terms` | Search HPO terms by semantic similarity to research phenotype text |
 | `process_clinical_text` | Extract HPO terms from clinical notes with chunking and assertion detection |
 | `calculate_term_similarity` | Calculate semantic similarity between two HPO terms |
 

--- a/docs/user-guide/cli-usage.md
+++ b/docs/user-guide/cli-usage.md
@@ -77,11 +77,11 @@ given; pass `--profile default` to swap to strict thresholds.
 
 ### Text Processing
 
-Process clinical text to extract HPO terms with advanced pipeline:
+Process research phenotype text to extract HPO terms with advanced pipeline:
 
 ```bash
 # Basic processing with default strategy
-phentrieve text process "Patient has arachnodactyly but no scoliosis"
+phentrieve text process "The research note mentions arachnodactyly but no scoliosis"
 
 # Process with specific chunking strategy
 phentrieve text process "..." --strategy sliding_window_punct_conj_cleaned

--- a/docs/user-guide/frontend-usage.md
+++ b/docs/user-guide/frontend-usage.md
@@ -16,7 +16,7 @@ phentrieve text process --extraction-backend llm note.txt
 
 1. Start the API with your LLM environment configured.
 2. Open the frontend at `http://localhost:5734`.
-3. Paste clinical text into the main input.
+3. Paste research phenotype text into the main input.
 4. Open Advanced Options.
 5. Select the `llm` extraction backend.
 6. The shared default model is `gemini-3.1-flash-lite-preview`; override it only for targeted experiments.

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -18,11 +18,11 @@ Phentrieve provides several key functionalities:
 
 ### HPO Term Retrieval
 
-Map clinical text to relevant HPO terms using multilingual embedding models. This works across languages without requiring translation.
+Map research phenotype text to relevant HPO terms using multilingual embedding models. This works across languages without requiring translation.
 
 ### Text Processing
 
-Process clinical text with advanced features:
+Process research phenotype text with advanced features:
 - Semantic chunking
 - Assertion detection (negated, normal, uncertain)
 - Evidence aggregation
@@ -41,8 +41,8 @@ Calculate semantic similarity between HPO terms using the ontology graph structu
 This User Guide section contains the following pages:
 
 - [CLI Usage](cli-usage.md): Detailed guide on using the Phentrieve command-line interface
-- [Text Processing Guide](text-processing-guide.md): How to process clinical text to extract HPO terms
-- [Adaptive Re-Chunking](adaptive-rechunking.md): Opt-in retrieval-quality-driven sub-chunking for multi-concept clinical sentences
+- [Text Processing Guide](text-processing-guide.md): How to process research phenotype text to extract HPO terms
+- [Adaptive Re-Chunking](adaptive-rechunking.md): Opt-in retrieval-quality-driven sub-chunking for multi-concept phenotype sentences
 - [Benchmarking Guide](benchmarking-guide.md): Running and interpreting benchmarks
 - [Configuration Profiles](configuration-profiles.md): Configuring Phentrieve for different use cases
 - [API Usage](api-usage.md): Using the Phentrieve API

--- a/docs/user-guide/text-processing-guide.md
+++ b/docs/user-guide/text-processing-guide.md
@@ -1,6 +1,6 @@
 # Text Processing Guide
 
-Phentrieve includes robust text processing capabilities for extracting HPO terms from clinical text. This guide explains how to use these features and customize the text processing pipeline.
+Phentrieve includes robust text processing capabilities for extracting HPO terms from research phenotype text. This guide explains how to use these features and customize the text processing pipeline.
 
 ## Text Processing Overview
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -30,7 +30,7 @@
                 <v-icon>mdi-scale-balance</v-icon>
               </v-btn>
               <v-tooltip
-                v-if="disclaimerStore.isAcknowledged"
+                v-if="disclaimerStore.isCurrentVersionAcknowledged"
                 location="top"
                 :text="
                   $t('app.footer.disclaimerAcknowledgedTooltip', {
@@ -370,11 +370,12 @@ export default {
     // Store state is automatically hydrated by pinia-plugin-persistedstate
     logService.debug('Disclaimer store state', {
       isAcknowledged: this.disclaimerStore.isAcknowledged,
+      acknowledgedVersion: this.disclaimerStore.acknowledgedVersion,
       timestamp: this.disclaimerStore.acknowledgmentTimestamp,
     });
 
     // Show the disclaimer dialog if it has not been acknowledged
-    if (!this.disclaimerStore.isAcknowledged) {
+    if (!this.disclaimerStore.isCurrentVersionAcknowledged) {
       this.disclaimerDialogVisible = true;
       logService.info('Showing initial disclaimer dialog');
     }

--- a/frontend/src/components/AdvancedOptionsPanel.vue
+++ b/frontend/src/components/AdvancedOptionsPanel.vue
@@ -282,6 +282,15 @@
             </v-select>
           </v-col>
         </v-row>
+        <v-alert
+          v-if="textProcessOptions.extractionBackend === 'llm'"
+          type="warning"
+          variant="tonal"
+          density="compact"
+          class="my-2"
+        >
+          {{ $t('queryInterface.advancedOptions.llmDisclosure') }}
+        </v-alert>
 
         <div v-if="textProcessOptions.extractionBackend === 'standard'">
           <v-row dense>

--- a/frontend/src/config/faqConfig.json
+++ b/frontend/src/config/faqConfig.json
@@ -11,7 +11,7 @@
         },
         {
           "question": "How does Phentrieve work?",
-          "answer": "<p>Phentrieve uses a sophisticated pipeline of AI models and algorithms to process clinical text:</p><ol><li><strong>Text Analysis:</strong> The system analyzes the input text using specialized biomedical language models</li><li><strong>Term Matching:</strong> It identifies potential HPO terms using semantic search and context-aware matching</li><li><strong>Ranking:</strong> The matches are ranked by relevance</li><li><strong>Results:</strong> The most relevant HPO terms are presented to the user</li></ol><p>This process ensures high-quality matches while maintaining efficiency.</p>"
+          "answer": "<p>Phentrieve uses a sophisticated pipeline of AI models and algorithms to process research phenotype text:</p><ol><li><strong>Text Analysis:</strong> The system analyzes the input text using specialized biomedical language models</li><li><strong>Term Matching:</strong> It identifies potential HPO terms using semantic search and context-aware matching</li><li><strong>Ranking:</strong> The matches are ranked by relevance</li><li><strong>Results:</strong> The most relevant HPO terms are presented to the user</li></ol><p>This process ensures high-quality matches while maintaining efficiency.</p>"
         },
         {
           "question": "Who can use Phentrieve?",

--- a/frontend/src/config/faqConfig.json
+++ b/frontend/src/config/faqConfig.json
@@ -7,7 +7,7 @@
       "questions": [
         {
           "question": "What is Phentrieve?",
-          "answer": "<p>Phentrieve is an advanced AI-powered tool that automatically maps clinical descriptions to standardized Human Phenotype Ontology (HPO) terms. It streamlines the process of phenotype annotation for both research and clinical diagnostics, making it faster and more accurate.</p><p>Key features include:</p><ul><li>Automatic mapping of clinical text to HPO terms</li><li>High accuracy through state-of-the-art AI models</li><li>Support for multiple languages</li><li>User-friendly interface</li></ul>"
+          "answer": "<p>Phentrieve is an advanced AI-powered research tool that maps phenotype descriptions to standardized Human Phenotype Ontology (HPO) terms. It supports phenotype annotation for research, education, benchmarking, and knowledge discovery.</p><p>Key features include:</p><ul><li>Mapping research text to HPO terms</li><li>Semantic retrieval with state-of-the-art AI models</li><li>Support for multiple languages</li><li>User-friendly interface</li></ul>"
         },
         {
           "question": "How does Phentrieve work?",
@@ -15,7 +15,7 @@
         },
         {
           "question": "Who can use Phentrieve?",
-          "answer": "<p>Phentrieve is designed for:</p><ul><li><strong>Clinical Geneticists:</strong> For efficient patient phenotyping</li><li><strong>Researchers:</strong> For standardizing phenotype descriptions in studies</li><li><strong>Healthcare Professionals:</strong> For consistent phenotype documentation</li><li><strong>Bioinformaticians:</strong> For automated phenotype analysis</li></ul><p>The tool is free to use and accessible through a web browser.</p>"
+          "answer": "<p><strong>Phentrieve is for research and informational purposes only.</strong> It is not a clinical diagnostic tool.</p><p>Designed for:</p><ul><li><strong>Researchers:</strong> Standardizing phenotype descriptions in studies</li><li><strong>Bioinformaticians:</strong> Automated phenotype analysis in research datasets</li><li><strong>Educators and students:</strong> Learning HPO annotation concepts</li><li><strong>Curators:</strong> Literature review and research documentation</li></ul><p>The public service must not be used for diagnosis, treatment, triage, or other clinical decision-making.</p>"
         }
       ]
     },

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -153,6 +153,7 @@
       "llmModes": {
         "twoPhase": "Zweistufige Extraktion"
       },
+      "llmDisclosure": "Die LLM-Extraktion kann eingegebenen Text mit einem vom Betreiber konfigurierten externen KI-Anbieter verarbeiten. Verwenden Sie nur Forschungstext; geben Sie keine direkt identifizierenden Informationen ein.",
       "chunkingStrategy": "Aufteilungsstrategie",
       "windowSize": "Fenstergröße (Tokens)",
       "stepSize": "Schrittgröße",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -53,12 +53,12 @@
   "disclaimerDialog": {
     "title": "Research Use Disclaimer",
     "mainHeader": "Phentrieve is intended for research and informational purposes only.",
-    "description": "This tool is designed to map clinical text to standardized Human Phenotype Ontology (HPO) terms to aid in research and knowledge discovery.",
+    "description": "This tool is designed to map research text to standardized Human Phenotype Ontology (HPO) terms to aid in research and knowledge discovery.",
     "limitationsTitle": "Important Limitations:",
     "limitations": {
       "item1": "Phentrieve is NOT a clinical diagnostic tool and should not replace professional medical advice, diagnosis, or treatment.",
       "item2": "The AI models and HPO mapping may contain inaccuracies, errors, or limitations.",
-      "item3": "Results should be verified by qualified medical professionals before being used in any clinical context.",
+      "item3": "Results require independent review before any downstream use and must not be used for clinical decision-making.",
       "item4": "The tool does not establish a doctor-patient relationship and is not a substitute for consulting with healthcare providers."
     },
     "responsibilityTitle": "User Responsibility:",
@@ -67,22 +67,22 @@
   },
   "queryInterface": {
     "title": "Phentrieve",
-    "subtitle": "HPO Term Mapping for Clinical Phenotype Descriptions",
-    "welcomeText": "Phentrieve is an AI-powered tool that accurately maps clinical text to standardized Human Phenotype Ontology (HPO) terms, streamlining phenotype annotation for research and diagnostics.",
+    "subtitle": "HPO Term Mapping for Research Phenotype Descriptions",
+    "welcomeText": "Phentrieve is an AI-powered research tool that maps phenotype text to standardized Human Phenotype Ontology (HPO) terms for research annotation and knowledge discovery.",
     "queryModeLabel": "Query Mode",
     "documentModeLabel": "Document Mode",
     "modeSwitch": {
-      "autoFullTextNotice": "Switched to Full Text for longer clinical text"
+      "autoFullTextNotice": "Switched to Full Text for longer research text"
     },
-    "inputLabel": "Enter clinical text description",
+    "inputLabel": "Enter research text description",
     "examples": {
       "title": "Examples",
       "loadExample": "Load example",
-      "example1": "The patient presents with short stature, recurrent fractures, and blue sclerae, suggesting osteogenesis imperfecta.",
-      "example2": "The child exhibits facial dysmorphism with hypertelorism, downslanting palpebral fissures, and low-set ears, along with congenital heart defects and developmental delay."
+      "example1": "The research note describes short stature, recurrent fractures, and blue sclerae.",
+      "example2": "The research summary mentions facial dysmorphism with hypertelorism, downslanting palpebral fissures, low-set ears, congenital heart defects, and developmental delay."
     },
-    "formLabel": "Patient Information (Optional)",
-    "idLabel": "Patient ID",
+    "formLabel": "Research Subject Metadata (Optional)",
+    "idLabel": "Subject ID",
     "sexLabel": "Sex",
     "dobLabel": "Date of Birth",
     "sexOptions": {
@@ -153,6 +153,7 @@
       "llmModes": {
         "twoPhase": "Two-phase extraction"
       },
+      "llmDisclosure": "LLM extraction may process submitted text with an external AI provider configured by the service operator. Use research text only; do not submit directly identifying information.",
       "chunkingStrategy": "Chunking Strategy",
       "windowSize": "Window Size (tokens)",
       "stepSize": "Step Size",
@@ -331,7 +332,7 @@
     },
     "step2": {
       "title": "Enter Clinical Text",
-      "content": "Type or paste your clinical description here. You can describe patient symptoms, phenotypes, or any medical observations you want to map to HPO terms."
+      "content": "Type or paste your research description here. You can describe phenotypes or research observations you want to map to HPO terms."
     },
     "step3": {
       "title": "Search for HPO Terms",
@@ -378,7 +379,7 @@
         "questions": {
           "whatIsPhentrieve": {
             "question": "What is Phentrieve?",
-            "answer": "<p>Phentrieve is an advanced AI-powered tool that automatically maps clinical descriptions to standardized Human Phenotype Ontology (HPO) terms. It streamlines the process of phenotype annotation for both research and clinical diagnostics, making it faster and more accurate.</p><p>Key features include:</p><ul><li>Automatic mapping of clinical text to HPO terms</li><li>High accuracy through state-of-the-art AI models</li><li>Support for multiple languages</li><li>User-friendly interface</li></ul>"
+            "answer": "<p>Phentrieve is an advanced AI-powered research tool that maps phenotype descriptions to standardized Human Phenotype Ontology (HPO) terms. It supports phenotype annotation for research, education, benchmarking, and knowledge discovery.</p><p>Key features include:</p><ul><li>Mapping research text to HPO terms</li><li>Semantic retrieval with state-of-the-art AI models</li><li>Support for multiple languages</li><li>User-friendly interface</li></ul>"
           },
           "howItWorks": {
             "question": "How does Phentrieve work?",
@@ -386,7 +387,7 @@
           },
           "whoCanUse": {
             "question": "Who can use Phentrieve?",
-            "answer": "<p><strong>Phentrieve is for research and informational purposes only.</strong> It is NOT a clinical diagnostic tool.</p><p>Designed for:</p><ul><li><strong>Researchers:</strong> Standardizing phenotype descriptions in research studies</li><li><strong>Clinical Geneticists:</strong> Research phenotyping and literature review (NOT for patient diagnosis)</li><li><strong>Bioinformaticians:</strong> Automated phenotype analysis in research datasets</li><li><strong>Healthcare Professionals:</strong> Educational purposes and research documentation</li></ul><p><strong>Important:</strong> Results must be verified by qualified medical professionals before any clinical application. See the disclaimer for complete terms of use.</p>"
+            "answer": "<p><strong>Phentrieve is for research and informational purposes only.</strong> It is NOT a clinical diagnostic tool.</p><p>Designed for:</p><ul><li><strong>Researchers:</strong> Standardizing phenotype descriptions in research studies</li><li><strong>Bioinformaticians:</strong> Automated phenotype analysis in research datasets</li><li><strong>Educators and students:</strong> Learning about HPO-based phenotype annotation</li><li><strong>Curators:</strong> Literature review and research documentation</li></ul><p><strong>Important:</strong> Results must not be used for diagnosis, treatment, triage, or other clinical decision-making.</p>"
           }
         }
       },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -182,9 +182,9 @@
     },
     "accessibility": {
       "textProcessInputLabel": "Clinical document input for text processing",
-      "textProcessInputDescription": "Enter longer clinical text for document processing.",
+      "textProcessInputDescription": "Enter longer research phenotype text for document processing.",
       "queryInputLabel": "Clinical text input field",
-      "queryInputDescription": "Enter clinical text to search for HPO terms.",
+      "queryInputDescription": "Enter research phenotype text to search for HPO terms.",
       "processingInProgress": "Processing in progress.",
       "searchInProgress": "Search in progress.",
       "openAdvancedOptions": "Open advanced options",
@@ -328,7 +328,7 @@
   "tutorial": {
     "step1": {
       "title": "Welcome to Phentrieve",
-      "content": "This is your starting point for mapping clinical text to HPO terms. Let's take a quick tour of the main features!"
+      "content": "This is your starting point for mapping research phenotype text to HPO terms. Let's take a quick tour of the main features!"
     },
     "step2": {
       "title": "Enter Clinical Text",
@@ -383,7 +383,7 @@
           },
           "howItWorks": {
             "question": "How does Phentrieve work?",
-            "answer": "<p>Phentrieve uses a sophisticated pipeline of AI models and algorithms to process clinical text:</p><ol><li><strong>Text Analysis:</strong> The system analyzes the input text using specialized biomedical language models</li><li><strong>Term Matching:</strong> It identifies potential HPO terms using semantic search and context-aware matching</li><li><strong>Ranking:</strong> The matches are ranked by relevance</li><li><strong>Results:</strong> The most relevant HPO terms are presented to the user</li></ol><p>This process ensures high-quality matches while maintaining efficiency.</p>"
+            "answer": "<p>Phentrieve uses a sophisticated pipeline of AI models and algorithms to process research phenotype text:</p><ol><li><strong>Text Analysis:</strong> The system analyzes the input text using specialized biomedical language models</li><li><strong>Term Matching:</strong> It identifies potential HPO terms using semantic search and context-aware matching</li><li><strong>Ranking:</strong> The matches are ranked by relevance</li><li><strong>Results:</strong> The most relevant HPO terms are presented to the user</li></ol><p>This process ensures high-quality matches while maintaining efficiency.</p>"
           },
           "whoCanUse": {
             "question": "Who can use Phentrieve?",
@@ -400,7 +400,7 @@
           },
           "similarityScore": {
             "question": "What do the similarity scores mean?",
-            "answer": "<p>Phentrieve uses cosine similarity to measure how closely your clinical text matches HPO terms. Scores range from 0.0 (no similarity) to 1.0 (perfect match).</p><h4>Score Ranges</h4><ul><li><strong>0.90 - 1.00:</strong> Excellent match - highly relevant</li><li><strong>0.75 - 0.89:</strong> High match - very relevant</li><li><strong>0.60 - 0.74:</strong> Moderate match - potentially relevant</li><li><strong>0.40 - 0.59:</strong> Low match - loosely related</li><li><strong>0.00 - 0.39:</strong> Poor match - not recommended</li></ul><h4>Technical Details</h4><p>Scores are calculated using cosine similarity between embedding vectors. A score of 1.0 indicates identical semantic meaning, while 0.0 indicates no similarity.</p><p><strong>Note:</strong> These scores represent semantic similarity in vector space, not clinical certainty. Always review results with clinical expertise.</p>"
+            "answer": "<p>Phentrieve uses cosine similarity to measure how closely your research phenotype text matches HPO terms. Scores range from 0.0 (no similarity) to 1.0 (perfect match).</p><h4>Score Ranges</h4><ul><li><strong>0.90 - 1.00:</strong> Excellent match - highly relevant</li><li><strong>0.75 - 0.89:</strong> High match - very relevant</li><li><strong>0.60 - 0.74:</strong> Moderate match - potentially relevant</li><li><strong>0.40 - 0.59:</strong> Low match - loosely related</li><li><strong>0.00 - 0.39:</strong> Poor match - not recommended</li></ul><h4>Technical Details</h4><p>Scores are calculated using cosine similarity between embedding vectors. A score of 1.0 indicates identical semantic meaning, while 0.0 indicates no similarity.</p><p><strong>Note:</strong> These scores represent semantic similarity in vector space, not clinical certainty.</p>"
           }
         }
       }

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -153,6 +153,7 @@
       "llmModes": {
         "twoPhase": "Extracción en dos fases"
       },
+      "llmDisclosure": "La extracción LLM puede procesar el texto enviado con un proveedor externo de IA configurado por el operador del servicio. Use solo texto de investigación; no envíe información directamente identificable.",
       "chunkingStrategy": "Estrategia de fragmentación",
       "windowSize": "Tamaño de ventana (tokens)",
       "stepSize": "Tamaño de paso",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -153,6 +153,7 @@
       "llmModes": {
         "twoPhase": "Extraction en deux phases"
       },
+      "llmDisclosure": "L'extraction LLM peut traiter le texte soumis avec un fournisseur d'IA externe configuré par l'opérateur du service. Utilisez uniquement du texte de recherche ; ne soumettez pas d'informations directement identifiantes.",
       "chunkingStrategy": "Stratégie de découpage",
       "windowSize": "Taille de fenêtre (tokens)",
       "stepSize": "Taille de pas",

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -153,6 +153,7 @@
       "llmModes": {
         "twoPhase": "Extractie in twee fasen"
       },
+      "llmDisclosure": "LLM-extractie kan ingediende tekst verwerken met een externe AI-aanbieder die door de servicebeheerder is geconfigureerd. Gebruik alleen onderzoekstekst; dien geen direct identificerende informatie in.",
       "chunkingStrategy": "Opdelingsstrategie",
       "windowSize": "Venstergrootte (tokens)",
       "stepSize": "Stapgrootte",

--- a/frontend/src/services/PhentrieveService.js
+++ b/frontend/src/services/PhentrieveService.js
@@ -10,14 +10,21 @@ import { logService } from './logService';
  * 3. Development fallback - localhost with port for local development
  */
 const API_URL = import.meta.env.VITE_API_URL || '/api/v1'; // Default to relative path for Nginx proxy
+const RESEARCH_USE_ACK_CONFIG = Object.freeze({
+  headers: { 'X-Phentrieve-Research-Use-Acknowledged': 'true' },
+});
 
 class PhentrieveService {
   async queryHpo(queryData) {
     // queryData should match QueryRequest schema from FastAPI
     // Example: { text: "...", model_name: "...", num_results: 10, ... }
     try {
-      logService.info('Querying HPO API', { query: queryData });
-      const response = await axios.post(`${API_URL}/query/`, queryData);
+      logService.info('Querying HPO API', {
+        textLength: queryData.text?.length || 0,
+        numResults: queryData.num_results ?? queryData.numResults,
+        model: queryData.model_name ?? queryData.modelName,
+      });
+      const response = await axios.post(`${API_URL}/query/`, queryData, RESEARCH_USE_ACK_CONFIG);
       logService.debug('HPO API response received', {
         status: response.status,
         data: response.data,
@@ -63,7 +70,11 @@ class PhentrieveService {
         model: normalizedPayload.llm_model || normalizedPayload.retrieval_model_name,
       });
 
-      const response = await axios.post(`${API_URL}/text/process`, normalizedPayload);
+      const response = await axios.post(
+        `${API_URL}/text/process`,
+        normalizedPayload,
+        RESEARCH_USE_ACK_CONFIG
+      );
 
       logService.debug('Text Processing API response received', {
         status: response.status,
@@ -107,7 +118,11 @@ class PhentrieveService {
 
   async exportPhenopacket(exportData) {
     try {
-      const response = await axios.post(`${API_URL}/phenopackets/export`, exportData);
+      const response = await axios.post(
+        `${API_URL}/phenopackets/export`,
+        exportData,
+        RESEARCH_USE_ACK_CONFIG
+      );
       return response.data;
     } catch (error) {
       throw this._createStandardizedError(error, 'exporting a phenopacket');

--- a/frontend/src/stores/disclaimer.js
+++ b/frontend/src/stores/disclaimer.js
@@ -11,6 +11,8 @@
 import { defineStore } from 'pinia';
 import { ref, computed } from 'vue';
 
+export const DISCLAIMER_VERSION = '2026-04-29-research-use';
+
 export const useDisclaimerStore = defineStore(
   'disclaimer',
   () => {
@@ -29,6 +31,7 @@ export const useDisclaimerStore = defineStore(
      * @type {import('vue').Ref<string|null>}
      */
     const acknowledgmentTimestamp = ref(null);
+    const acknowledgedVersion = ref(null);
 
     // ===========================
     // Computed Properties
@@ -50,6 +53,9 @@ export const useDisclaimerStore = defineStore(
         minute: '2-digit',
       });
     });
+    const isCurrentVersionAcknowledged = computed(
+      () => isAcknowledged.value && acknowledgedVersion.value === DISCLAIMER_VERSION
+    );
 
     // ===========================
     // Actions
@@ -61,6 +67,7 @@ export const useDisclaimerStore = defineStore(
      */
     function saveAcknowledgment() {
       isAcknowledged.value = true;
+      acknowledgedVersion.value = DISCLAIMER_VERSION;
       acknowledgmentTimestamp.value = new Date().toISOString();
       // No manual localStorage - plugin handles persistence automatically
     }
@@ -72,6 +79,7 @@ export const useDisclaimerStore = defineStore(
     function reset() {
       isAcknowledged.value = false;
       acknowledgmentTimestamp.value = null;
+      acknowledgedVersion.value = null;
       // No manual localStorage - plugin handles persistence automatically
     }
 
@@ -83,9 +91,12 @@ export const useDisclaimerStore = defineStore(
       // State
       isAcknowledged,
       acknowledgmentTimestamp,
+      acknowledgedVersion,
+      DISCLAIMER_VERSION,
 
       // Computed
       formattedAcknowledgmentDate,
+      isCurrentVersionAcknowledged,
 
       // Actions
       saveAcknowledgment,
@@ -97,7 +108,7 @@ export const useDisclaimerStore = defineStore(
     persist: {
       key: 'phentrieve-disclaimer',
       storage: localStorage,
-      pick: ['isAcknowledged', 'acknowledgmentTimestamp'],
+      pick: ['isAcknowledged', 'acknowledgmentTimestamp', 'acknowledgedVersion'],
     },
   }
 );

--- a/frontend/src/test/services/PhentrieveService.researchUse.test.js
+++ b/frontend/src/test/services/PhentrieveService.researchUse.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('axios', () => ({
+  default: {
+    post: vi.fn(),
+    get: vi.fn(),
+  },
+}));
+
+import axios from 'axios';
+import PhentrieveService from '../../services/PhentrieveService';
+
+describe('PhentrieveService research-use guardrails', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sends research-use acknowledgement on text-bearing API calls', async () => {
+    axios.post.mockResolvedValue({ data: { ok: true } });
+
+    await PhentrieveService.queryHpo({ text: 'Research note.', num_results: 5 });
+    await PhentrieveService.processText({ text: 'Research note.' });
+    await PhentrieveService.exportPhenopacket({
+      input_text: 'Research note.',
+      phenotypes: [],
+    });
+
+    expect(axios.post).toHaveBeenNthCalledWith(
+      1,
+      '/api/v1/query/',
+      expect.objectContaining({ text: 'Research note.' }),
+      expect.objectContaining({
+        headers: { 'X-Phentrieve-Research-Use-Acknowledged': 'true' },
+      })
+    );
+    expect(axios.post).toHaveBeenNthCalledWith(
+      2,
+      '/api/v1/text/process',
+      expect.objectContaining({ text: 'Research note.' }),
+      expect.objectContaining({
+        headers: { 'X-Phentrieve-Research-Use-Acknowledged': 'true' },
+      })
+    );
+    expect(axios.post).toHaveBeenNthCalledWith(
+      3,
+      '/api/v1/phenopackets/export',
+      expect.objectContaining({ input_text: 'Research note.' }),
+      expect.objectContaining({
+        headers: { 'X-Phentrieve-Research-Use-Acknowledged': 'true' },
+      })
+    );
+  });
+});

--- a/frontend/src/test/services/PhentrieveService.test.js
+++ b/frontend/src/test/services/PhentrieveService.test.js
@@ -27,7 +27,8 @@ describe('PhentrieveService', () => {
 
     expect(axios.post).toHaveBeenCalledWith(
       '/api/v1/text/process',
-      expect.objectContaining({ extraction_backend: 'llm' })
+      expect.objectContaining({ extraction_backend: 'llm' }),
+      expect.any(Object)
     );
   });
 
@@ -194,7 +195,8 @@ describe('PhentrieveService', () => {
       '/api/v1/text/process',
       expect.objectContaining({
         top_term_per_chunk_for_aggregation: true,
-      })
+      }),
+      expect.any(Object)
     );
     expect(axios.post.mock.calls[0][1]).not.toHaveProperty('top_term_per_chunk');
   });
@@ -286,9 +288,13 @@ describe('PhentrieveService', () => {
       phenotypes: [],
     });
 
-    expect(axios.post).toHaveBeenCalledWith('/api/v1/phenopackets/export', {
-      case_id: 'case-1',
-      phenotypes: [],
-    });
+    expect(axios.post).toHaveBeenCalledWith(
+      '/api/v1/phenopackets/export',
+      {
+        case_id: 'case-1',
+        phenotypes: [],
+      },
+      expect.any(Object)
+    );
   });
 });

--- a/frontend/src/test/stores/disclaimer.test.js
+++ b/frontend/src/test/stores/disclaimer.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+
+import { useDisclaimerStore } from '../../stores/disclaimer';
+
+describe('disclaimer store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('tracks the disclaimer version acknowledged by the user', () => {
+    const store = useDisclaimerStore();
+
+    expect(store.isCurrentVersionAcknowledged).toBe(false);
+
+    store.saveAcknowledgment();
+
+    expect(store.isAcknowledged).toBe(true);
+    expect(store.acknowledgedVersion).toBe(store.DISCLAIMER_VERSION);
+    expect(store.isCurrentVersionAcknowledged).toBe(true);
+  });
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,8 @@ nav:
     - 'Local Docker': 'deployment/local-docker.md'
     - 'Data Management': 'deployment/data-management.md'
     - 'Security': 'deployment/security.md'
+  - 'Compliance':
+    - 'Research Use Only': 'compliance/research-use.md'
   - 'Development':
     - 'Overview': 'development/index.md'
     - 'Project Structure': 'development/project-structure.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
     - 'Security': 'deployment/security.md'
   - 'Compliance':
     - 'Research Use Only': 'compliance/research-use.md'
+    - 'Privacy and LLM Processing': 'compliance/privacy-and-llm-processing.md'
   - 'Development':
     - 'Overview': 'development/index.md'
     - 'Project Structure': 'development/project-structure.md'

--- a/phentrieve/cli/__init__.py
+++ b/phentrieve/cli/__init__.py
@@ -82,7 +82,7 @@ class _LazyRootGroup(TyperGroup):
             "text",
             _LazyTyperProxy(
                 import_path="phentrieve.cli.text_commands:app",
-                help_text="Process and analyze clinical text.",
+                help_text="Process and analyze research phenotype text.",
             ),
         ),
         (
@@ -220,7 +220,9 @@ def main_callback(
 # Register command groups
 app.add_typer(typer.Typer(), name="data", help="Manage HPO data.")
 app.add_typer(index_commands.app, name="index", help="Manage vector indexes.")
-app.add_typer(typer.Typer(), name="text", help="Process and analyze clinical text.")
+app.add_typer(
+    typer.Typer(), name="text", help="Process and analyze research phenotype text."
+)
 app.add_typer(
     benchmark_commands.app, name="benchmark", help="Run and manage benchmarks."
 )

--- a/phentrieve/cli/mcp_commands.py
+++ b/phentrieve/cli/mcp_commands.py
@@ -111,7 +111,7 @@ def mcp_info() -> None:
     tool_info = {
         "query_hpo_terms": (
             "GET /api/v1/query/",
-            "Extract HPO terms from clinical text",
+            "Extract HPO terms from research phenotype text",
         ),
         "process_clinical_text": (
             "POST /api/v1/text/process",

--- a/phentrieve/cli/query_commands.py
+++ b/phentrieve/cli/query_commands.py
@@ -10,6 +10,7 @@ from typing import Annotated, Any
 import typer
 
 from phentrieve.cli._profile import apply_profile_callback
+from phentrieve.cli.utils import emit_research_use_notice
 from phentrieve.config import (
     DEFAULT_AGGREGATION_STRATEGY,
     DEFAULT_MODEL,
@@ -263,6 +264,7 @@ def query_hpo(
 
     # Set up logging
     setup_logging_cli(debug=debug)
+    emit_research_use_notice()
 
     # Optional: print resolved configuration to stderr for debugging.
     import click as _click
@@ -309,7 +311,7 @@ def query_hpo(
     if interactive:
         # Display welcome message for interactive mode
         typer.echo("\n===== Phentrieve HPO RAG Query Tool =====")
-        typer.echo("Enter clinical descriptions to find matching HPO terms.")
+        typer.echo("Enter research text to find matching HPO terms.")
         typer.echo("Type 'exit', 'quit', or 'q' to exit the program.\n")
 
         # Initialize the retriever once for all queries
@@ -460,7 +462,7 @@ def query_hpo(
             )
             raise typer.Exit(code=1)
 
-        typer.echo(f"Querying for HPO terms with text: '{text}'")
+        typer.echo(f"Querying for HPO terms with input length: {len(text)} characters")
 
         # Call the orchestrator for a single query
         all_query_results = orchestrate_query(

--- a/phentrieve/cli/query_commands.py
+++ b/phentrieve/cli/query_commands.py
@@ -249,10 +249,10 @@ def query_hpo(
         ),
     ] = None,
 ):
-    """Query HPO terms with natural language clinical descriptions.
+    """Query HPO terms with natural language research phenotype descriptions.
 
-    This command allows querying the HPO term index with clinical text descriptions
-    to find matching HPO terms. It supports various embedding models.
+    This command allows querying the HPO term index with research phenotype text
+    descriptions to find matching HPO terms. It supports various embedding models.
 
     Results can be printed to the console or saved to a file in various formats:
     - text: Human-readable text output (default)

--- a/phentrieve/cli/text_commands.py
+++ b/phentrieve/cli/text_commands.py
@@ -18,7 +18,11 @@ import typer
 # only happen when commands actually need ML models, not for --help or --version.
 # The import is done inside command functions where the model is actually used.
 from phentrieve.cli._profile import apply_profile_callback
-from phentrieve.cli.utils import load_text_from_input, resolve_chunking_pipeline_config
+from phentrieve.cli.utils import (
+    emit_research_use_notice,
+    load_text_from_input,
+    resolve_chunking_pipeline_config,
+)
 from phentrieve.config import (
     DEFAULT_ASSERTION_PREFERENCE,
     DEFAULT_CHUNK_RETRIEVAL_THRESHOLD,
@@ -561,6 +565,7 @@ def process_text_for_hpo_command(
     logger = logging.getLogger(__name__)
     start_time = time.time()
     setup_logging_cli(debug=debug)
+    emit_research_use_notice()
 
     # Optional: print resolved configuration to stderr for debugging.
     import click as _click

--- a/phentrieve/cli/text_commands.py
+++ b/phentrieve/cli/text_commands.py
@@ -238,6 +238,7 @@ def interactive(
     """
     from phentrieve.cli.text_interactive import interactive_text_mode
 
+    emit_research_use_notice()
     interactive_text_mode(
         language=language,
         strategy=strategy,
@@ -276,6 +277,7 @@ def main_callback(
             # Call interactive mode directly
             from phentrieve.cli.text_interactive import interactive_text_mode
 
+            emit_research_use_notice()
             interactive_text_mode()
         else:
             # Show help if no subcommand and not interactive

--- a/phentrieve/cli/text_commands.py
+++ b/phentrieve/cli/text_commands.py
@@ -226,7 +226,7 @@ def interactive(
 ) -> None:
     """Interactive text processing mode for HPO term extraction.
 
-    This command enables an interactive session where you can enter clinical text
+    This command enables an interactive session where you can enter research phenotype text
     and see the chunking, annotations, and HPO term matches displayed with rich
     formatting. Each chunk is highlighted with its annotations shown in a box
     below the chunk text.
@@ -270,7 +270,7 @@ def main_callback(
         ),
     ] = False,
 ):
-    """Text processing commands for clinical text analysis."""
+    """Text processing commands for research phenotype text analysis."""
     if ctx.invoked_subcommand is None:
         if interactive:
             # Call interactive mode directly
@@ -546,11 +546,11 @@ def process_text_for_hpo_command(
         ),
     ] = None,
 ) -> None:
-    """Process clinical text to extract HPO terms.
+    """Process research phenotype text to extract HPO terms.
 
-    This command processes clinical texts through a chunking pipeline and assertion
-    detection, then extracts HPO terms from each chunk. Results are aggregated to provide
-    a comprehensive set of terms with evidence.
+    This command processes research phenotype texts through a chunking pipeline and
+    assertion detection, then extracts HPO terms from each chunk. Results are
+    aggregated to provide a comprehensive set of terms with evidence.
 
     Example usage:
     - Process direct text input: phentrieve text process "Patient has severe headaches"

--- a/phentrieve/cli/text_interactive.py
+++ b/phentrieve/cli/text_interactive.py
@@ -294,7 +294,7 @@ def interactive_text_mode(
 ) -> None:
     """Interactive text processing mode for HPO term extraction.
 
-    This command enables an interactive session where you can enter clinical text
+    This command enables an interactive session where you can enter research phenotype text
     and see the chunking, annotations, and HPO term matches displayed with rich
     formatting. Each chunk is highlighted with its annotations shown in a box
     below the chunk text.
@@ -345,7 +345,7 @@ def interactive_text_mode(
     console.print(
         Panel.fit(
             "[bold cyan]Phentrieve Interactive Text Analysis[/bold cyan]\n\n"
-            "Enter clinical text to analyze for HPO terms.\n"
+            "Enter research phenotype text to analyze for HPO terms.\n"
             "Each chunk will be displayed with its HPO annotations.\n\n"
             "[dim]Commands:[/dim]\n"
             "  • Type your text and press Enter to analyze\n"

--- a/phentrieve/cli/utils.py
+++ b/phentrieve/cli/utils.py
@@ -15,6 +15,17 @@ from phentrieve.config import (
     DEFAULT_WINDOW_SIZE_TOKENS,
 )
 
+RESEARCH_USE_NOTICE = (
+    "Research use only: Phentrieve maps text to HPO terms for research, "
+    "education, and knowledge discovery. Do not use results for diagnosis, "
+    "treatment, triage, or other clinical decision-making."
+)
+
+
+def emit_research_use_notice() -> None:
+    """Print the research-use limitation to stderr for text-bearing commands."""
+    typer.secho(RESEARCH_USE_NOTICE, fg=typer.colors.YELLOW, err=True)
+
 
 def load_text_from_input(text_arg: str | None, file_arg: Path | None) -> str:
     """Load text from command line argument, file, or stdin.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -274,6 +274,8 @@ dev = [
     # Security scanning
     "pip-audit>=2.9.0",  # Python dependency vulnerability scanner
     "bandit[toml,sarif]>=1.9.0",  # Python SAST with TOML config and SARIF output
+    "mkdocs-glightbox>=0.5.2",
+    "mkdocs-material>=9.7.6",
 ]
 
 [tool.semantic_release]

--- a/tests/unit/api/test_research_use_guard.py
+++ b/tests/unit/api/test_research_use_guard.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from api.main import app
+from api.research_use import RESEARCH_ACK_HEADER_DISPLAY
 from api.schemas.text_processing_schemas import TextProcessingResponseAPI
 
 pytestmark = pytest.mark.unit
@@ -105,3 +106,22 @@ def test_public_hosted_mode_allows_llm_after_research_ack(client, monkeypatch):
 
     assert response.status_code == 200
     assert response.json()["meta"]["extraction_backend"] == "llm"
+
+
+def test_text_bearing_routes_document_research_ack_header_in_openapi(client):
+    schema = client.get("/openapi.json").json()
+    operations = [
+        schema["paths"]["/api/v1/query/"]["get"],
+        schema["paths"]["/api/v1/query/"]["post"],
+        schema["paths"]["/api/v1/text/process"]["post"],
+        schema["paths"]["/api/v1/phenopackets/export"]["post"],
+    ]
+
+    for operation in operations:
+        header = next(
+            parameter
+            for parameter in operation["parameters"]
+            if parameter["name"] == RESEARCH_ACK_HEADER_DISPLAY
+        )
+        assert header["in"] == "header"
+        assert header["schema"]["enum"] == ["true"]

--- a/tests/unit/api/test_research_use_guard.py
+++ b/tests/unit/api/test_research_use_guard.py
@@ -1,0 +1,107 @@
+"""Tests for research-use guardrails on text-bearing API endpoints."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.schemas.text_processing_schemas import TextProcessingResponseAPI
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def client():
+    with TestClient(app, raise_server_exceptions=False) as test_client:
+        yield test_client
+
+
+def _empty_text_response() -> TextProcessingResponseAPI:
+    return TextProcessingResponseAPI.model_validate(
+        {
+            "meta": {"extraction_backend": "standard"},
+            "processed_chunks": [],
+            "aggregated_hpo_terms": [],
+        }
+    )
+
+
+def test_text_processing_requires_research_ack_in_public_hosted_mode(
+    client, monkeypatch
+):
+    monkeypatch.setattr("api.config.PHENTRIEVE_PUBLIC_HOSTED_MODE", True, raising=False)
+    monkeypatch.setattr(
+        "api.config.PHENTRIEVE_REQUIRE_RESEARCH_ACK", False, raising=False
+    )
+
+    response = client.post(
+        "/api/v1/text/process",
+        json={
+            "text": "Research note mentions recurrent seizures.",
+            "extraction_backend": "standard",
+        },
+    )
+
+    assert response.status_code == 428
+    assert response.json()["detail"]["error_code"] == "research_use_ack_required"
+
+
+def test_text_processing_accepts_research_ack_in_public_hosted_mode(
+    client, monkeypatch
+):
+    monkeypatch.setattr("api.config.PHENTRIEVE_PUBLIC_HOSTED_MODE", True, raising=False)
+    monkeypatch.setattr(
+        "api.config.PHENTRIEVE_REQUIRE_RESEARCH_ACK", False, raising=False
+    )
+    monkeypatch.setattr(
+        "api.routers.text_processing_router._process_text_via_shared_service",
+        AsyncMock(return_value=_empty_text_response()),
+    )
+
+    response = client.post(
+        "/api/v1/text/process",
+        headers={"X-Phentrieve-Research-Use-Acknowledged": "true"},
+        json={
+            "text": "Research note mentions recurrent seizures.",
+            "extraction_backend": "standard",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["meta"]["extraction_backend"] == "standard"
+
+
+def test_public_hosted_mode_allows_llm_after_research_ack(client, monkeypatch):
+    monkeypatch.setattr("api.config.PHENTRIEVE_PUBLIC_HOSTED_MODE", True, raising=False)
+    monkeypatch.setattr(
+        "api.config.PHENTRIEVE_REQUIRE_RESEARCH_ACK", False, raising=False
+    )
+    monkeypatch.setattr(
+        "api.routers.text_processing_router._process_text_via_shared_service",
+        AsyncMock(
+            return_value=TextProcessingResponseAPI.model_validate(
+                {
+                    "meta": {
+                        "extraction_backend": "llm",
+                        "llm_model": "gpt-5.4-mini",
+                    },
+                    "processed_chunks": [],
+                    "aggregated_hpo_terms": [],
+                }
+            )
+        ),
+    )
+
+    response = client.post(
+        "/api/v1/text/process",
+        headers={"X-Phentrieve-Research-Use-Acknowledged": "true"},
+        json={
+            "text": "Research note mentions recurrent seizures.",
+            "extraction_backend": "llm",
+            "llm_model": "gpt-5.4-mini",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["meta"]["extraction_backend"] == "llm"

--- a/tests/unit/cli/test_research_use_notice.py
+++ b/tests/unit/cli/test_research_use_notice.py
@@ -48,3 +48,29 @@ def test_text_process_command_shows_research_notice(monkeypatch):
 
     assert result.exit_code == 0
     assert "Research use only" in result.stderr
+
+
+def test_text_interactive_command_shows_research_notice(monkeypatch):
+    runner = CliRunner()
+    monkeypatch.setattr(
+        "phentrieve.cli.text_interactive.interactive_text_mode",
+        lambda **_kwargs: None,
+    )
+
+    result = runner.invoke(app, ["text", "interactive"])
+
+    assert result.exit_code == 0
+    assert "Research use only" in result.stderr
+
+
+def test_text_group_interactive_option_shows_research_notice(monkeypatch):
+    runner = CliRunner()
+    monkeypatch.setattr(
+        "phentrieve.cli.text_interactive.interactive_text_mode",
+        lambda **_kwargs: None,
+    )
+
+    result = runner.invoke(app, ["text", "--interactive"])
+
+    assert result.exit_code == 0
+    assert "Research use only" in result.stderr

--- a/tests/unit/cli/test_research_use_notice.py
+++ b/tests/unit/cli/test_research_use_notice.py
@@ -1,0 +1,50 @@
+"""CLI tests for research-use notices and text privacy."""
+
+from typer.testing import CliRunner
+
+from phentrieve.cli import app
+
+
+def test_query_command_shows_research_notice_without_echoing_raw_text(monkeypatch):
+    runner = CliRunner()
+    monkeypatch.setattr(
+        "phentrieve.retrieval.query_orchestrator.orchestrate_query",
+        lambda **_kwargs: [],
+    )
+
+    result = runner.invoke(
+        app,
+        ["query", "Research note mentions recurrent seizures."],
+    )
+
+    assert result.exit_code == 0
+    assert "Research use only" in result.stderr
+    assert "Research note mentions recurrent seizures" not in result.stdout
+
+
+def test_text_process_command_shows_research_notice(monkeypatch):
+    runner = CliRunner()
+    monkeypatch.setattr(
+        "phentrieve.cli.text_commands.run_full_text_service",
+        lambda **_kwargs: {
+            "meta": {"extraction_backend": "llm"},
+            "processed_chunks": [],
+            "aggregated_hpo_terms": [],
+        },
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "text",
+            "process",
+            "Research note mentions recurrent seizures.",
+            "--extraction-backend",
+            "llm",
+            "--llm-model",
+            "gpt-5.4-mini",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Research use only" in result.stderr

--- a/uv.lock
+++ b/uv.lock
@@ -98,6 +98,28 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "backrefs"
+version = "7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/a7dd63622beef68cc0d3c3c36d472e143dd95443d5ebf14cd1a5b4dfbf11/backrefs-7.0.tar.gz", hash = "sha256:4989bb9e1e99eb23647c7160ed51fb21d0b41b5d200f2d3017da41e023097e82", size = 7012453, upload-time = "2026-04-28T16:28:04.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/39/39a31d7eae729ea14ed10c3ccef79371197177b9355a86cb3525709e8502/backrefs-7.0-py310-none-any.whl", hash = "sha256:b57cd227ea556b0aed3dc9b8da4628db4eabc0402c6d7fcfc69283a93955f7e9", size = 380824, upload-time = "2026-04-28T16:27:55.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b5/9302644225ba7dfa934a2ff2b9c7bb85701313a90dddb3dfaf693fa5bae2/backrefs-7.0-py311-none-any.whl", hash = "sha256:a0fa7360c63509e9e077e174ef4e6d3c21c8db94189b9d957289ae6d794b9475", size = 392626, upload-time = "2026-04-28T16:27:57.42Z" },
+    { url = "https://files.pythonhosted.org/packages/36/da/87912ddec6e06feffbaa3d7aa18fc6352bee2e8f1fee185d7d1690f8f4e8/backrefs-7.0-py312-none-any.whl", hash = "sha256:ca42ce6a49ace3d75684dfa9937f3373902a63284ecb385ce36d15e5dcb41c12", size = 398537, upload-time = "2026-04-28T16:27:58.913Z" },
+    { url = "https://files.pythonhosted.org/packages/00/bb/90ba423612b6aa0adccc6b1874bcd4a9b44b660c0c16f346611e00f64ac3/backrefs-7.0-py313-none-any.whl", hash = "sha256:f2c52955d631b9e1ac4cd56209f0a3a946d592b98e7790e77699339ae01c102a", size = 400491, upload-time = "2026-04-28T16:28:00.928Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/5c/fb93d3092640a24dfb7bd7727a24016d7c01774ca013e60efd3f683c8002/backrefs-7.0-py314-none-any.whl", hash = "sha256:a6448b28180e3ca01134c9cf09dcebafad8531072e09903c5451748a05f24bc9", size = 412349, upload-time = "2026-04-28T16:28:02.412Z" },
+]
+
+[[package]]
 name = "bandit"
 version = "1.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1147,6 +1169,18 @@ wheels = [
 ]
 
 [[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
 name = "google-auth"
 version = "2.49.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1822,6 +1856,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2003,6 +2046,96 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocs-glightbox"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "selectolax" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/26/c793459622da8e31f954c6f5fb51e8f098143fdfc147b1e3c25bf686f4aa/mkdocs_glightbox-0.5.2.tar.gz", hash = "sha256:c7622799347c32310878e01ccf14f70648445561010911c80590cec0353370ac", size = 510586, upload-time = "2025-10-23T14:55:18.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/ca/03624e017e5ee2d7ce8a08d89f81c1e535eb3c30d7b2dc4a435ea3fbbeae/mkdocs_glightbox-0.5.2-py3-none-any.whl", hash = "sha256:23a431ea802b60b1030c73323db2eed6ba859df1a0822ce575afa43e0ea3f47e", size = 26458, upload-time = "2025-10-23T14:55:17.43Z" },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
 ]
 
 [[package]]
@@ -2823,6 +2956,15 @@ wheels = [
 ]
 
 [[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
+]
+
+[[package]]
 name = "pandas"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2980,6 +3122,8 @@ phenopackets = [
 dev = [
     { name = "bandit", extra = ["sarif"] },
     { name = "docker" },
+    { name = "mkdocs-glightbox" },
+    { name = "mkdocs-material" },
     { name = "mypy" },
     { name = "pip-audit" },
     { name = "pytest" },
@@ -3041,6 +3185,8 @@ provides-extras = ["api", "mcp", "llm", "benchmarks", "phenopackets", "energy", 
 dev = [
     { name = "bandit", extras = ["toml", "sarif"], specifier = ">=1.9.0" },
     { name = "docker", specifier = ">=7.0.0" },
+    { name = "mkdocs-glightbox", specifier = ">=0.5.2" },
+    { name = "mkdocs-material", specifier = ">=9.7.6" },
     { name = "mypy", specifier = ">=1.20.1" },
     { name = "pip-audit", specifier = ">=2.9.0" },
     { name = "pytest", specifier = ">=8.0.0" },
@@ -3707,6 +3853,19 @@ crypto = [
 ]
 
 [[package]]
+name = "pymdown-extensions"
+version = "10.21.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+]
+
+[[package]]
 name = "pynndescent"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3952,6 +4111,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
 ]
 
 [[package]]
@@ -4505,6 +4676,59 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/86/59/a451d7420a77ab0b98f7affa3a1d78a313d2f7281a57afb1a34bae8ab412/seaborn-0.13.2.tar.gz", hash = "sha256:93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7", size = 1457696, upload-time = "2024-01-25T13:21:52.551Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl", hash = "sha256:636f8336facf092165e27924f223d3c62ca560b1f2bb5dff7ab7fad265361987", size = 294914, upload-time = "2024-01-25T13:21:49.598Z" },
+]
+
+[[package]]
+name = "selectolax"
+version = "0.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/5c/bf049c4aec4c102977abcac68a90dfb1031edc225e9a754fe2c7e624a2d2/selectolax-0.4.7.tar.gz", hash = "sha256:17f7ba5a21714d450b4eea0451608a36be2bba8d327990ddbda812eb3f36fa51", size = 4822635, upload-time = "2026-03-06T09:25:15.411Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/6b/3409a8fd1d217f3449742e86fffe6e29d3f5f9a969a8a6121b1002f377fb/selectolax-0.4.7-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:48d95f3bbe37caa6fe341992ac7b4fb5b7efad1ed8bd939af67b6be0ccd5634e", size = 2062822, upload-time = "2026-03-06T09:23:50.634Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b3/ea286b3e89b56d55995927f8fa01cc01b985a14bb7f0c572f06db051c33e/selectolax-0.4.7-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f222827fef20c142131f1948bc08ebf1c9f3294c79bca8fa9c0a71e234be7b2f", size = 2059566, upload-time = "2026-03-06T09:23:52.274Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e0/8014f221b5ae3a3b1dbd915318cb01ee37e31f29a4cce088b39baab4a59d/selectolax-0.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4cc5c190277ff34f2e42be473ec5947ad5d87c07a072e25d0701c03b7ceb5b12", size = 2253634, upload-time = "2026-03-06T09:23:53.959Z" },
+    { url = "https://files.pythonhosted.org/packages/17/f8/3c15c68b5cd2126cdadb9c47dd8931330d0ef40d64533fed3460feb8a9e8/selectolax-0.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:26e24768ce86d376b50d311c1bdf54c5445139ac90cc5d955a7703402d2e2f7c", size = 2289548, upload-time = "2026-03-06T09:23:55.295Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/da/6d068419854eff6a83247804e358ef3abaa62815adac61f329583a992ab3/selectolax-0.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:50a668ede8d3f2dbe872c2713a28348e9e3e154a49118b898568243bfb356c96", size = 2265394, upload-time = "2026-03-06T09:23:56.916Z" },
+    { url = "https://files.pythonhosted.org/packages/94/cb/8dbecbacf55d55dd5cfe046a4d943ae1df979a96a7a407ee7d8c277976d5/selectolax-0.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fb1c01d39570f0990e8e2a2037e3f0cf8d193da6ea9ca1936d5818d5cf6a260", size = 2296276, upload-time = "2026-03-06T09:23:58.689Z" },
+    { url = "https://files.pythonhosted.org/packages/53/09/6dff1dcf77f762f3b088b63d6bc6ce15ce649066019e508031c140d483af/selectolax-0.4.7-cp311-cp311-win32.whl", hash = "sha256:8ca0af7156315d9193fac699e8e4c3281ea6dccc6262eed33b32001a633e57a9", size = 1740823, upload-time = "2026-03-06T09:24:00.367Z" },
+    { url = "https://files.pythonhosted.org/packages/93/d8/2b8ff4f2cef4236ffc3bdf1c500517fddf9b0cf9d4db20d1d01a6c49a128/selectolax-0.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:d322e725e0c575cacc8ba2f0041fb8405dc3932bff9073a563f568c6ef3a217b", size = 1836333, upload-time = "2026-03-06T09:24:02.066Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/cd/6a1989b9866430ad358865020e82e5aeb16a813df92455d4fd8608e27cae/selectolax-0.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:3e3dac7de3864701a18cd6c4806d07944a5a48d1db2f107a0ce8531f72881462", size = 1791761, upload-time = "2026-03-06T09:24:03.546Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/1d/8d3db7dcc053f7f4088a826f9089324c7b37617f9caaf6a03f0ff5854bbd/selectolax-0.4.7-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8fa541a520cc6213d754ec747ebbff12fdcc5b9f6bb7615784486e18697209fb", size = 2059304, upload-time = "2026-03-06T09:24:04.861Z" },
+    { url = "https://files.pythonhosted.org/packages/42/64/de442c5056aa4f42d140556a8093bfadee72545919384cf38d6f651b75b0/selectolax-0.4.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2a0e9b1e3b1d091a0133b44b3967c79db8de73d99efe38af85bab615775aa4e8", size = 2057450, upload-time = "2026-03-06T09:24:06.25Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/42/969e084f59c845fbb304d55f8e3899ffe823f3cd78d85d083edffe772766/selectolax-0.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7134b119c011e18d1e914d5adbb8f953e391649b4af734fcec61dad691a16f59", size = 2251180, upload-time = "2026-03-06T09:24:07.536Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/1b/d8f84cb6385637cd793aad3a53618d3ee1b4329e0feb0f4db7a7f81af4da/selectolax-0.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3840b79f5f39744b95dc80e3b428cf4e49b86d8c6e9cbb3e7df3e702bf240cce", size = 2292532, upload-time = "2026-03-06T09:24:08.896Z" },
+    { url = "https://files.pythonhosted.org/packages/85/54/15c3b5d94cf969748ffcca7289245d477ef69ce30a359c5a764b0bc2226e/selectolax-0.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:eb6faf15e6cc6a7c61c04e15c3490e3f6693c98f732e531941687093de36db81", size = 2263969, upload-time = "2026-03-06T09:24:10.556Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4f/fa4125a9a92b2a15a3b332592270e003e9092bb97c3d6c3a7f2714b4c507/selectolax-0.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3799b39d60266f7d4c48f322fac8eaecc6dec38f4342d6d3b17085d11815bcb4", size = 2298497, upload-time = "2026-03-06T09:24:11.919Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9d/fef3b7d4f8da87762574ea20ff9612485639d6b0a9b7d3839738d8ced105/selectolax-0.4.7-cp312-cp312-win32.whl", hash = "sha256:88344c8764f3a2fbcae2fd2353201c330920943c2da34a16e9b063f918deb7d6", size = 1735965, upload-time = "2026-03-06T09:24:13.407Z" },
+    { url = "https://files.pythonhosted.org/packages/31/25/5b893677a0acfc579d9ccb3f01204c4554ba533db5c144cc3b18e33e347b/selectolax-0.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:00953c3c6a7e4dfd990a5651315b713d50131706c239c1f1c5b6d4a75a11975a", size = 1833805, upload-time = "2026-03-06T09:24:14.726Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ad/bb94f409f33871b6d9b3b4d56fb82d14d9b2fd2e7657f32c25a35167187e/selectolax-0.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:e6b8d0f7cbdc6ca5cbf52dbd37f70c170184040499ac59a23409724724276784", size = 1783620, upload-time = "2026-03-06T09:24:16.062Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/6b/238c03a1be1aa73c5392026ae4efbcf9f8356bb5a07dda1134f07d33e78c/selectolax-0.4.7-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fb8f169511f037b662dac1a0e27cff30f4317f9aa30af2e37c8a37c3ca8c7e3c", size = 2058636, upload-time = "2026-03-06T09:24:17.787Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/44/22e433b7dc31ff83574051dd9951175bcd0e36b56c0e25cb277929e77ecb/selectolax-0.4.7-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:feaea6ac95da2fa137abad3c1ae13596bffed44c8e2bfa7802f89a37a1e5e39a", size = 2056263, upload-time = "2026-03-06T09:24:19.51Z" },
+    { url = "https://files.pythonhosted.org/packages/af/95/05f264c622d0f0839954d0f197d420cffe5723354521b6ce543d32b272a1/selectolax-0.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fdc5ec34ccce3a691e1664a14bf0f40ad6a41117e5de88e85d8ac8e68a7ea8bd", size = 2247850, upload-time = "2026-03-06T09:24:21.28Z" },
+    { url = "https://files.pythonhosted.org/packages/59/24/324a271f7ef49786d7bed5674e23718504fe996866e23c75f91ac06c3bfa/selectolax-0.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a7016db9c55ae541f1669a3433aee03fc0a1111d70c84aa5636a5a6b9499854", size = 2287889, upload-time = "2026-03-06T09:24:23.948Z" },
+    { url = "https://files.pythonhosted.org/packages/91/b0/779ab6c428be5cf53ebae1bc2539ebe9df9d8b76e2f9810f107a0338800e/selectolax-0.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d3da9e1609cefc9bb403f62c2b03d2f5622cbe3057c2f06e308a29fad8ae5654", size = 2261143, upload-time = "2026-03-06T09:24:25.552Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/c2/34b132d14922b7d8dbb50d0b487d22aeb7af8a47421baaf05f2cc1cc2dbd/selectolax-0.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9c70be8f4154a80b8d435bcc3217c04a82f928849fa2f6acd554d24c5b911db6", size = 2293796, upload-time = "2026-03-06T09:24:26.974Z" },
+    { url = "https://files.pythonhosted.org/packages/24/67/6ba2b7140d7e92a3a0f815ac6c8001171973248a9f27206b339019e0b288/selectolax-0.4.7-cp313-cp313-win32.whl", hash = "sha256:df8a8db519484c868839f1d36be720feeb228c8f75cf7b745e325db183b319c6", size = 1735965, upload-time = "2026-03-06T09:24:28.463Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/1c/d22cbd6c5828a59addd42626c22b2afb3422bfce59cf88d15095da05243f/selectolax-0.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:5a613760d2b890d7befd2e585a37dd0bdae9e23eee0cacb15d24adb83232c94e", size = 1834806, upload-time = "2026-03-06T09:24:29.875Z" },
+    { url = "https://files.pythonhosted.org/packages/59/d7/d2206d9f38a534b4fc4383c7dd427ba0b927075c96881274a60978411723/selectolax-0.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:7cbd1143920b7bd1b80e092d5a16c97fdc741b0325a42862f20edcb55ab493e8", size = 1783517, upload-time = "2026-03-06T09:24:31.843Z" },
+    { url = "https://files.pythonhosted.org/packages/35/5a/76f9ee49b4bbb27ebe2d3b26ad84b6887f41d181dd8682278ccea50ed75f/selectolax-0.4.7-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:9f29ad4506fe84152391998ae5b05aaae80d237795567009a518496d0daf4908", size = 2078520, upload-time = "2026-03-06T09:24:33.283Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/7d/bcc37be0537802f8d94e61d30f4d36130afa2ae2fa59758b534e4bbe80e7/selectolax-0.4.7-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2f19bb52c27f526d89383ec178daa31fcb93dbec90106bfb3e2d43c2970f3b72", size = 2076219, upload-time = "2026-03-06T09:24:34.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/4c/544385da484f6a3b8ba70ea4ad15a121adb0cf2b55b74f2560b8e01f44cc/selectolax-0.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a6735711f492532a83df6d501e8647feea48d893e703f0354e61ba868757f9b", size = 2255094, upload-time = "2026-03-06T09:24:36.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/e7/bbb13633f4378dbc390c874be4321fd4d09388a44b66f1c26625730030ba/selectolax-0.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea46dbb3592ec0aa78662ecdcac8c083313dafbc6bd8277620b8301db658d638", size = 2289342, upload-time = "2026-03-06T09:24:38.429Z" },
+    { url = "https://files.pythonhosted.org/packages/77/1b/c1fc7711ad8b1c3b60a987fa258d47cb93a8b3b9f21ca8a6aa24e5e7705c/selectolax-0.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4782cc1e162ca422a325302cdad344cd853cfde19004b870e5b6c3df651abab", size = 2285919, upload-time = "2026-03-06T09:24:39.927Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/51/d5f8bc697c84bdae90c6d5fd038662d3509879c28f2076ef70fdbd0ab61a/selectolax-0.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8e7f847b38195c45f6f6c966df5d8600ab9d522df632d61b28db2edd92deeb3c", size = 2313967, upload-time = "2026-03-06T09:24:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/01/277d3c3fa5d3c669bf8d20bd12fcde50258408dc4bd9e3f8c5fc2d28fcd6/selectolax-0.4.7-cp314-cp314-win32.whl", hash = "sha256:eaf2e15076fa7e2e5fe7c3b5a88e54b14bbd49a53da983534f6cb448f3f0e300", size = 1846621, upload-time = "2026-03-06T09:24:43.074Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c6/5b4ae2b211161b597cc6bc02e517616d045a859dbfa98b2c0dd372614bf9/selectolax-0.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:87bd651514491b9bdd8254e71295e43b790575021b87ebc2351ed6a2aeaa9313", size = 1943489, upload-time = "2026-03-06T09:24:45.049Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/c6/ab1544bbc731e653dd59dcb4f497fccbede8c84af3783c4f340ef1d6b606/selectolax-0.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:771710fe52b082804d959944e3e0fe67f094ea1bf81669b4f654b957a7490d95", size = 1896489, upload-time = "2026-03-06T09:24:46.496Z" },
+    { url = "https://files.pythonhosted.org/packages/83/77/59593bfd132f6af138720c09cae3f0969d3f5366e3457c5309ab9c020d92/selectolax-0.4.7-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8edbec5ad8a51cb60e6761231d88d34ed3a8158db3ae1f448aede2d146111d0f", size = 2098945, upload-time = "2026-03-06T09:24:47.935Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/74/90d0718b9f7898aa422ae5f9969fb43b3c5abc543cfd4eb64987aa052fe4/selectolax-0.4.7-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2c275e5e5579e308a09ae77922c468a8ca63666534d00a42ebfd912f3c842a2e", size = 2098041, upload-time = "2026-03-06T09:24:49.377Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bc/bbe7c98a3eb4b83e164c56a3245a272427b2d03672a18456bd96325a1929/selectolax-0.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9591ec48af16003a79db89f070688fe0fb68d2c16ac6b479b0ee8b78eb4e486", size = 2263047, upload-time = "2026-03-06T09:24:50.743Z" },
+    { url = "https://files.pythonhosted.org/packages/de/0e/5929821c7f7a9c9a753feef59433ba16a0ca8e5f8f7ac0efa2dea6a84edf/selectolax-0.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fc504cad873bc4e95fca9141008ccf0d5e44350dfe450b71ccee86bd0b7b0572", size = 2290751, upload-time = "2026-03-06T09:24:52.088Z" },
+    { url = "https://files.pythonhosted.org/packages/34/30/3426668e83dcaf7f8fac3117140119556436e8de00de4ebbfde5bbf56d45/selectolax-0.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:64de787422ad342b35fef86e488d8b76d70fc3266cb74dfc154d4a89291c62b1", size = 2297728, upload-time = "2026-03-06T09:24:53.494Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/a1937960cf98bf3cdc32963fb3ed30ee6364cf8e4c458bba21ca8cf98308/selectolax-0.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eb2757147ba48c2ac75ad79ad47e4b4d9e7ddb08ac614b90347cdff6b98c860b", size = 2315531, upload-time = "2026-03-06T09:24:54.929Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/64/1f699580093cc0582c07124137bdb78162086d7ef822dabbad2a2b051793/selectolax-0.4.7-cp314-cp314t-win32.whl", hash = "sha256:da9afa778ebce19c48de1e6fe5ff5bf7c719cd7f9cd14e5d530bd00ec15b149f", size = 1900408, upload-time = "2026-03-06T09:24:56.294Z" },
+    { url = "https://files.pythonhosted.org/packages/26/df/1035432c42eb76feaf696b7318411be908dab01b5b2907566c820d390fdb/selectolax-0.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:ad71d3b31ceb49820787d19d983e2851835ad03bbfd302c6e243a97215e36557", size = 2011199, upload-time = "2026-03-06T09:24:57.736Z" },
+    { url = "https://files.pythonhosted.org/packages/61/99/d4de702bdd436e108891df2105adb7c6f44a11833a88c08686b18d4a6693/selectolax-0.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:85e4ada1c4a3a69e503c9866e74bce24e716bd0ada060c7c2b56677d4f073928", size = 1915624, upload-time = "2026-03-06T09:24:59.406Z" },
 ]
 
 [[package]]
@@ -5173,6 +5397,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/f9/054e6e2f1071e963b5e746b48d1e3727470b2a490834d18ad92364929db3/wasabi-1.1.3.tar.gz", hash = "sha256:4bb3008f003809db0c3e28b4daf20906ea871a2bb43f9914197d540f4f2e0878", size = 30391, upload-time = "2024-05-31T16:56:18.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/06/7c/34330a89da55610daa5f245ddce5aab81244321101614751e7537f125133/wasabi-1.1.3-py3-none-any.whl", hash = "sha256:f76e16e8f7e79f8c4c8be49b4024ac725713ab10cd7f19350ad18a8e3f71728c", size = 27880, upload-time = "2024-05-31T16:56:16.699Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393, upload-time = "2024-11-01T14:06:31.756Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392, upload-time = "2024-11-01T14:06:32.99Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019, upload-time = "2024-11-01T14:06:34.963Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds research-use compliance guardrails for public EU-facing Phentrieve deployments while keeping LLM extraction available.

- Adds API research-use acknowledgement enforcement for text-bearing endpoints when public-hosted or research-ack mode is enabled.
- Keeps LLM mode functional and adds an LLM-specific disclosure in the frontend instead of blocking the feature.
- Sends `X-Phentrieve-Research-Use-Acknowledged: true` from frontend text-bearing requests.
- Versions the frontend disclaimer acknowledgement so updated legal copy is re-accepted.
- Adds CLI research-use notices and avoids echoing raw submitted query text.
- Adds research-use and privacy/LLM-processing compliance docs, plus public-facing copy updates.
- Adds tests for API guardrails, LLM allowance after acknowledgement, frontend acknowledgement headers, disclaimer versioning, and CLI notices.

## Deployment Notes

For a hosted research service such as `phentrieve.kidney-genetics.org`, configure:

```bash
PHENTRIEVE_PUBLIC_HOSTED_MODE=true
PHENTRIEVE_REQUIRE_RESEARCH_ACK=true
```

There is intentionally no LLM-disabling flag in this PR. LLM extraction remains available; the legal-safety posture is acknowledgement, disclosure, research-only framing, and avoiding raw-text logging.

## Validation

- `make check`
- `make typecheck-fast`
- `uv run --extra api pytest tests/unit/api/test_research_use_guard.py tests/unit/api/test_phenopacket_router.py tests/unit/cli/test_research_use_notice.py -q -n 0 --no-cov`
- `npm run test:run -- src/test/services/PhentrieveService.researchUse.test.js src/test/stores/disclaimer.test.js src/test/services/PhentrieveService.test.js`
- `make frontend-lint`
- `make frontend-format-check`
- `make frontend-i18n-check`

Docs build note: `uv run mkdocs build --strict` could not run in this environment because the existing MkDocs configuration requires the `glightbox` plugin, which is not installed.
