### PR TITLE
[codex] reduce image scanner SARIF noise

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -131,6 +131,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-api-results.sarif'
           severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
           exit-code: '0'  # Don't fail build, just report
 
       - name: Upload Trivy results to GitHub Security
@@ -150,10 +151,15 @@ jobs:
           failure-threshold: high
           exit-code: 0  # Don't fail build, just report
           # Accept known deviations from CIS benchmarks
-          accept-keys: |
-            CIS-DI-0010
-          accept-file: settings.py
+          accept-filenames: settings.py
           # CIS-DI-0010: Do not store secrets - we use env vars at runtime
+
+      - name: Filter accepted Dockle API findings
+        run: |
+          jq '(.runs[]?.results) |= map(select((.ruleId // .rule.id // "") != "DKL-DI-0005"))' \
+            dockle-api-results.sarif > dockle-api-results.filtered.sarif
+          mv dockle-api-results.filtered.sarif dockle-api-results.sarif
+        # DKL-DI-0005 is emitted from the upstream python:slim base image apt layer.
 
       - name: Upload Dockle API results to GitHub Security
         uses: github/codeql-action/upload-sarif@v4
@@ -239,6 +245,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-frontend-results.sarif'
           severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
           exit-code: '0'  # Don't fail build, just report
 
       - name: Upload Trivy results to GitHub Security


### PR DESCRIPTION
## Summary

- Upload Trivy image SARIF with `ignore-unfixed: true` so unfixed base image and distro package CVEs do not stay open as actionable code scanning alerts.
- Correct the Dockle action input from the unsupported `accept-file`/`accept-keys` names to `accept-filenames` so the known `settings.py` credential false positives are actually suppressed.
- Filter the accepted Dockle `DKL-DI-0005` base-image apt cache finding from API SARIF before upload, because it is emitted from the upstream `python:slim` base image layer.

## Root Cause

The latest Docker publish run was green, but the uploaded SARIF still contained scanner findings. Trivy was run with `ignore-unfixed: false`, so GitHub kept unfixed Debian package CVEs open. Dockle was configured with input names that `erzz/dockle-action@v1` does not expose, so the intended suppressions were not applied.

## Validation

- `make check`
- `make typecheck-fast`
- `make test` after `make install-dev` (`1519 passed, 44 skipped`)
- Parsed `.github/workflows/docker-publish.yml` with PyYAML
- Verified `aquasecurity/trivy-action@v0.36.0` exposes `ignore-unfixed`
- Verified `erzz/dockle-action@v1` exposes `accept-filenames`
- Tested the SARIF `jq` filter against representative JSON
