### PR TITLE
fix(frontend): detect titled names across PII locales

### DIFF
--- a/.planning/active/2026-04-30-local-browser-pii-guard-implementation-plan.md
+++ b/.planning/active/2026-04-30-local-browser-pii-guard-implementation-plan.md
@@ -1,0 +1,1673 @@
+# Local Browser PII Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a browser-only, five-language PII/PHI warning and redaction gate before both Query and Full Text submissions.
+
+**Architecture:** Build a config-driven frontend PII module with global rules plus `en`, `de`, `fr`, `es`, and `nl` locale overlays. Integrate it into `QueryInterface` before conversation turns, logs, or API calls are created, and use a Vuetify review dialog to let users cancel, redact locally, or continue with mandatory high-confidence redaction.
+
+**Tech Stack:** Vue 3, Vuetify, Pinia, Vue I18n, Vitest, `libphonenumber-js`, existing `PhentrieveService` and `useQueryInterfaceController`.
+
+---
+
+## File Structure
+
+- Create: `frontend/src/pii/types.js` - JSDoc typedefs for PII rules, findings, scan results, pending submissions, and redaction results.
+- Create: `frontend/src/pii/validators.js` - checksum and format validators for Spanish DNI/NIE, Dutch BSN, French NIR-like values, and German KVNR-like values.
+- Create: `frontend/src/pii/ruleConfig.js` - global rules and locale overlays for English, German, French, Spanish, and Dutch.
+- Create: `frontend/src/pii/detector.js` - config-driven scanner that produces in-memory findings and category summaries without snippets.
+- Create: `frontend/src/pii/redactor.js` - deterministic redaction with overlap handling and category tokens.
+- Create: `frontend/src/pii/index.js` - public PII API exports.
+- Create: `frontend/src/components/PiiReviewDialog.vue` - Vuetify dialog for category review and local redaction actions.
+- Create: `frontend/src/test/pii/validators.test.js` - validator coverage.
+- Create: `frontend/src/test/pii/detector.test.js` - global and locale detector coverage.
+- Create: `frontend/src/test/pii/redactor.test.js` - overlap and token redaction coverage.
+- Modify: `frontend/package.json` and `frontend/package-lock.json` - add `libphonenumber-js`.
+- Modify: `frontend/src/components/QueryInterface.vue` - mount the dialog, store pending PII submission state, and pass controller hooks.
+- Modify: `frontend/src/composables/useQueryInterfaceController.js` - run PII scan before submission and add a resume path after user acknowledgement.
+- Modify: `frontend/src/plugins/vuetify.js` - register any Vuetify components used by the dialog that are not already registered.
+- Modify: `frontend/src/plugins/icons.js` - add PII dialog icons used in templates.
+- Modify: `frontend/src/locales/en.json`, `de.json`, `fr.json`, `es.json`, `nl.json` - add matching UI strings.
+- Modify: `frontend/src/test/components/QueryInterface.test.js` - cover no-network-before-review and redacted submission.
+- Modify: `frontend/src/test/services/PhentrieveService.test.js` or `frontend/src/test/services/PhentrieveService.researchUse.test.js` only if service logging assertions need adjustment.
+- Modify: `docs/compliance/privacy-and-llm-processing.md` - document local warning/redaction behavior and limitations.
+
+## Task 1: Dependency And Validator Foundation
+
+**Files:**
+- Modify: `frontend/package.json`
+- Modify: `frontend/package-lock.json`
+- Create: `frontend/src/pii/types.js`
+- Create: `frontend/src/pii/validators.js`
+- Create: `frontend/src/test/pii/validators.test.js`
+
+- [ ] **Step 1: Add the phone parsing dependency**
+
+Run:
+
+```bash
+cd frontend
+npm install libphonenumber-js
+```
+
+Expected: `frontend/package.json` and `frontend/package-lock.json` include `libphonenumber-js` under dependencies.
+
+- [ ] **Step 2: Create failing validator tests**
+
+Create `frontend/src/test/pii/validators.test.js`:
+
+```js
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeIdentifierCandidate,
+  validateDutchBsn,
+  validateFrenchNir,
+  validateGermanKvnr,
+  validateSpanishDniNie,
+} from '../../pii/validators';
+
+describe('PII validators', () => {
+  it('normalizes separators and case without changing digits or letters', () => {
+    expect(normalizeIdentifierCandidate(' x-123 4567-l ')).toBe('X1234567L');
+  });
+
+  it('validates Spanish DNI checksum letters', () => {
+    expect(validateSpanishDniNie('12345678Z')).toBe(true);
+    expect(validateSpanishDniNie('12345678A')).toBe(false);
+  });
+
+  it('validates Spanish NIE checksum letters', () => {
+    expect(validateSpanishDniNie('X1234567L')).toBe(true);
+    expect(validateSpanishDniNie('X1234567A')).toBe(false);
+  });
+
+  it('validates Dutch BSN values with the eleven proof', () => {
+    expect(validateDutchBsn('111222333')).toBe(true);
+    expect(validateDutchBsn('111222334')).toBe(false);
+  });
+
+  it('validates German KVNR-like values conservatively', () => {
+    expect(validateGermanKvnr('A123456789')).toBe(true);
+    expect(validateGermanKvnr('AB23456789')).toBe(false);
+  });
+
+  it('validates French NIR-like values with 13 digits and optional key', () => {
+    expect(validateFrenchNir('1900675123456')).toBe(true);
+    expect(validateFrenchNir('190067512345699')).toBe(true);
+    expect(validateFrenchNir('9909975123456')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run validator tests and verify they fail**
+
+Run:
+
+```bash
+cd frontend
+npm run test:run -- src/test/pii/validators.test.js
+```
+
+Expected: FAIL because `frontend/src/pii/validators.js` does not exist.
+
+- [ ] **Step 4: Add PII typedefs**
+
+Create `frontend/src/pii/types.js`:
+
+```js
+/**
+ * @typedef {'high'|'review'} PiiConfidence
+ * @typedef {'email'|'phone'|'url'|'ip_address'|'date'|'dob'|'medical_record'|'accession_id'|'sample_id'|'national_identifier'|'address'|'person_name'|'location'|'organization'} PiiCategory
+ *
+ * @typedef {Object} PiiRule
+ * @property {string} id
+ * @property {PiiCategory} category
+ * @property {PiiConfidence} confidence
+ * @property {string[]} locales
+ * @property {string} redactionToken
+ * @property {boolean} enabled
+ * @property {RegExp[]} patterns
+ * @property {string[]} [contextKeywords]
+ * @property {string} [validator]
+ *
+ * @typedef {Object} PiiFinding
+ * @property {string} id
+ * @property {string} ruleId
+ * @property {PiiCategory} category
+ * @property {PiiConfidence} confidence
+ * @property {number} start
+ * @property {number} end
+ * @property {string} redactionToken
+ *
+ * @typedef {Object} PiiScanResult
+ * @property {boolean} hasFindings
+ * @property {PiiFinding[]} findings
+ * @property {{ high: Record<string, number>, review: Record<string, number> }} summary
+ *
+ * @typedef {Object} PiiRedactionResult
+ * @property {string} text
+ * @property {boolean} changed
+ * @property {{ high: Record<string, number>, review: Record<string, number> }} summary
+ */
+
+export {};
+```
+
+- [ ] **Step 5: Implement validators**
+
+Create `frontend/src/pii/validators.js`:
+
+```js
+export function normalizeIdentifierCandidate(value) {
+  return String(value ?? '')
+    .replace(/[\s.-]/gu, '')
+    .toUpperCase();
+}
+
+export function validateSpanishDniNie(value) {
+  const normalized = normalizeIdentifierCandidate(value);
+  const match = /^(?:(\d{8})|([XYZ])(\d{7}))([A-Z])$/u.exec(normalized);
+  if (!match) return false;
+
+  const checksumLetters = 'TRWAGMYFPDXBNJZSQVHLCKE';
+  const prefixMap = { X: '0', Y: '1', Z: '2' };
+  const number = match[1] ?? `${prefixMap[match[2]]}${match[3]}`;
+  const expected = checksumLetters[Number(number) % 23];
+  return match[4] === expected;
+}
+
+export function validateDutchBsn(value) {
+  const normalized = normalizeIdentifierCandidate(value);
+  if (!/^\d{9}$/u.test(normalized)) return false;
+
+  const digits = [...normalized].map(Number);
+  const checksum =
+    digits[0] * 9 +
+    digits[1] * 8 +
+    digits[2] * 7 +
+    digits[3] * 6 +
+    digits[4] * 5 +
+    digits[5] * 4 +
+    digits[6] * 3 +
+    digits[7] * 2 -
+    digits[8];
+  return checksum % 11 === 0;
+}
+
+export function validateGermanKvnr(value) {
+  return /^[A-Z]\d{9}$/u.test(normalizeIdentifierCandidate(value));
+}
+
+export function validateFrenchNir(value) {
+  const normalized = normalizeIdentifierCandidate(value);
+  if (!/^[12]\d{12}(?:\d{2})?$/u.test(normalized)) return false;
+  const month = Number(normalized.slice(3, 5));
+  return month >= 1 && month <= 12;
+}
+
+export const VALIDATORS = Object.freeze({
+  validateSpanishDniNie,
+  validateDutchBsn,
+  validateGermanKvnr,
+  validateFrenchNir,
+});
+```
+
+- [ ] **Step 6: Run validator tests and verify they pass**
+
+Run:
+
+```bash
+cd frontend
+npm run test:run -- src/test/pii/validators.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit validator foundation**
+
+Run:
+
+```bash
+git add frontend/package.json frontend/package-lock.json frontend/src/pii/types.js frontend/src/pii/validators.js frontend/src/test/pii/validators.test.js
+git commit -m "feat(frontend): add PII validator foundation"
+```
+
+Expected: commit succeeds.
+
+## Task 2: Config-Driven Detector And Redactor
+
+**Files:**
+- Create: `frontend/src/pii/ruleConfig.js`
+- Create: `frontend/src/pii/detector.js`
+- Create: `frontend/src/pii/redactor.js`
+- Create: `frontend/src/pii/index.js`
+- Create: `frontend/src/test/pii/detector.test.js`
+- Create: `frontend/src/test/pii/redactor.test.js`
+
+- [ ] **Step 1: Write failing detector tests**
+
+Create `frontend/src/test/pii/detector.test.js`:
+
+```js
+import { describe, expect, it } from 'vitest';
+import { scanPii } from '../../pii';
+
+describe('scanPii', () => {
+  it('detects global high-confidence identifiers without exposing snippets', () => {
+    const result = scanPii('Email jane@example.org or call +1 202 555 0199.', { locale: 'en' });
+
+    expect(result.summary.high.email).toBe(1);
+    expect(result.summary.high.phone).toBe(1);
+    expect(result.findings[0]).not.toHaveProperty('text');
+  });
+
+  it('detects English medical record labels', () => {
+    const result = scanPii('MRN: AB-123456. Patient has seizures.', { locale: 'en' });
+    expect(result.summary.high.medical_record).toBe(1);
+  });
+
+  it('detects German KVNR and DOB labels', () => {
+    const result = scanPii('Geburtsdatum: 12.03.1980. Krankenversichertennummer A123456789.', {
+      locale: 'de',
+    });
+    expect(result.summary.high.dob).toBe(1);
+    expect(result.summary.high.national_identifier).toBe(1);
+  });
+
+  it('detects French NIR labels', () => {
+    const result = scanPii('NIR 1900675123456 pour le patient.', { locale: 'fr' });
+    expect(result.summary.high.national_identifier).toBe(1);
+  });
+
+  it('detects Spanish DNI/NIE and clinical history labels', () => {
+    const result = scanPii('DNI 12345678Z. Número de historia clínica HC-778899.', {
+      locale: 'es',
+    });
+    expect(result.summary.high.national_identifier).toBe(1);
+    expect(result.summary.high.medical_record).toBe(1);
+  });
+
+  it('detects Dutch BSN and address context', () => {
+    const result = scanPii('BSN 111222333. Adres: Hoofdstraat 12, 1234 AB Leiden.', {
+      locale: 'nl',
+    });
+    expect(result.summary.high.national_identifier).toBe(1);
+    expect(result.summary.high.address).toBe(1);
+  });
+
+  it('does not flag common HPO IDs or model identifiers', () => {
+    const result = scanPii('HP:0001250 with model FremyCompany/BioLORD-2023-M.', { locale: 'en' });
+    expect(result.hasFindings).toBe(false);
+  });
+
+  it('marks standalone exact dates as review confidence', () => {
+    const result = scanPii('Follow-up discussed on 12/03/2024.', { locale: 'en' });
+    expect(result.summary.review.date).toBe(1);
+    expect(result.summary.high.date).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Write failing redactor tests**
+
+Create `frontend/src/test/pii/redactor.test.js`:
+
+```js
+import { describe, expect, it } from 'vitest';
+import { redactPiiFindings, scanPii } from '../../pii';
+
+describe('redactPiiFindings', () => {
+  it('redacts high-confidence findings with category tokens', () => {
+    const text = 'Email jane@example.org. MRN: AB-123456.';
+    const scan = scanPii(text, { locale: 'en' });
+    const redacted = redactPiiFindings(text, scan.findings, { includeReviewFindings: false });
+
+    expect(redacted.text).toContain('[REDACTED_EMAIL]');
+    expect(redacted.text).toContain('[REDACTED_MRN]');
+    expect(redacted.text).not.toContain('jane@example.org');
+    expect(redacted.changed).toBe(true);
+  });
+
+  it('keeps review-confidence findings unless requested', () => {
+    const text = 'Seen on 12/03/2024.';
+    const scan = scanPii(text, { locale: 'en' });
+
+    expect(redactPiiFindings(text, scan.findings, { includeReviewFindings: false }).text).toBe(
+      text
+    );
+    expect(
+      redactPiiFindings(text, scan.findings, { includeReviewFindings: true }).text
+    ).toContain('[REDACTED_DATE]');
+  });
+
+  it('handles overlapping findings by keeping the longest span', () => {
+    const text = 'Contact jane@example.org';
+    const findings = [
+      {
+        id: 'a',
+        ruleId: 'short',
+        category: 'person_name',
+        confidence: 'review',
+        start: 8,
+        end: 12,
+        redactionToken: '[REDACTED_NAME]',
+      },
+      {
+        id: 'b',
+        ruleId: 'email',
+        category: 'email',
+        confidence: 'high',
+        start: 8,
+        end: 24,
+        redactionToken: '[REDACTED_EMAIL]',
+      },
+    ];
+
+    expect(redactPiiFindings(text, findings, { includeReviewFindings: true }).text).toBe(
+      'Contact [REDACTED_EMAIL]'
+    );
+  });
+});
+```
+
+- [ ] **Step 3: Run detector/redactor tests and verify they fail**
+
+Run:
+
+```bash
+cd frontend
+npm run test:run -- src/test/pii/detector.test.js src/test/pii/redactor.test.js
+```
+
+Expected: FAIL because detector/redactor modules do not exist.
+
+- [ ] **Step 4: Add rule configuration**
+
+Create `frontend/src/pii/ruleConfig.js` with global and locale rules:
+
+```js
+export const SUPPORTED_PII_LOCALES = Object.freeze(['en', 'de', 'fr', 'es', 'nl']);
+
+const DATE_PATTERN = /\b(?:\d{1,2}[./-]\d{1,2}[./-]\d{2,4}|\d{4}-\d{2}-\d{2})\b/gu;
+const ID_VALUE_PATTERN = /\b[A-Z]{0,4}[- ]?\d{4,12}[A-Z0-9-]*\b/giu;
+
+export const GLOBAL_RULES = Object.freeze([
+  {
+    id: 'global.email',
+    category: 'email',
+    confidence: 'high',
+    locales: ['*'],
+    redactionToken: '[REDACTED_EMAIL]',
+    enabled: true,
+    patterns: [/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/giu],
+  },
+  {
+    id: 'global.url',
+    category: 'url',
+    confidence: 'high',
+    locales: ['*'],
+    redactionToken: '[REDACTED_URL]',
+    enabled: true,
+    patterns: [/\bhttps?:\/\/[^\s<>"']+|\bwww\.[^\s<>"']+/giu],
+  },
+  {
+    id: 'global.ipv4',
+    category: 'ip_address',
+    confidence: 'high',
+    locales: ['*'],
+    redactionToken: '[REDACTED_IP]',
+    enabled: true,
+    patterns: [/\b(?:\d{1,3}\.){3}\d{1,3}\b/gu],
+  },
+  {
+    id: 'global.date',
+    category: 'date',
+    confidence: 'review',
+    locales: ['*'],
+    redactionToken: '[REDACTED_DATE]',
+    enabled: true,
+    patterns: [DATE_PATTERN],
+  },
+]);
+
+export const LOCALE_RULES = Object.freeze({
+  en: [
+    {
+      id: 'en.dob',
+      category: 'dob',
+      confidence: 'high',
+      locales: ['en'],
+      redactionToken: '[REDACTED_DOB]',
+      enabled: true,
+      patterns: [/(?:DOB|date of birth|born)\s*[:#-]?\s*(?:\d{1,2}[./-]\d{1,2}[./-]\d{2,4}|\d{4}-\d{2}-\d{2})/giu],
+    },
+    {
+      id: 'en.medical_record',
+      category: 'medical_record',
+      confidence: 'high',
+      locales: ['en'],
+      redactionToken: '[REDACTED_MRN]',
+      enabled: true,
+      patterns: [/(?:MRN|medical record number|patient ID|NHS number)\s*[:#-]?\s*[A-Z0-9 -]{4,24}/giu],
+    },
+  ],
+  de: [
+    {
+      id: 'de.dob',
+      category: 'dob',
+      confidence: 'high',
+      locales: ['de'],
+      redactionToken: '[REDACTED_DOB]',
+      enabled: true,
+      patterns: [/(?:Geburtsdatum|geboren)\s*[:#-]?\s*(?:\d{1,2}[.]\d{1,2}[.]\d{2,4}|\d{4}-\d{2}-\d{2})/giu],
+    },
+    {
+      id: 'de.kvnr',
+      category: 'national_identifier',
+      confidence: 'high',
+      locales: ['de'],
+      redactionToken: '[REDACTED_NATIONAL_ID]',
+      enabled: true,
+      patterns: [/(?:Krankenversichertennummer|Versichertennummer|KVNR)\s*[:#-]?\s*[A-Z]\d{9}/giu],
+      validator: 'validateGermanKvnr',
+    },
+  ],
+  fr: [
+    {
+      id: 'fr.nir',
+      category: 'national_identifier',
+      confidence: 'high',
+      locales: ['fr'],
+      redactionToken: '[REDACTED_NATIONAL_ID]',
+      enabled: true,
+      patterns: [/(?:NIR|numéro de sécurité sociale|securite sociale)\s*[:#-]?\s*[12][\d .-]{12,20}/giu],
+      validator: 'validateFrenchNir',
+    },
+  ],
+  es: [
+    {
+      id: 'es.dni_nie',
+      category: 'national_identifier',
+      confidence: 'high',
+      locales: ['es'],
+      redactionToken: '[REDACTED_NATIONAL_ID]',
+      enabled: true,
+      patterns: [/(?:DNI|NIE|NIF)\s*[:#-]?\s*(?:\d{8}[A-Z]|[XYZ]\d{7}[A-Z])/giu],
+      validator: 'validateSpanishDniNie',
+    },
+    {
+      id: 'es.medical_record',
+      category: 'medical_record',
+      confidence: 'high',
+      locales: ['es'],
+      redactionToken: '[REDACTED_MRN]',
+      enabled: true,
+      patterns: [/(?:número de historia clínica|historia clínica|paciente id)\s*[:#-]?\s*[A-Z0-9 -]{4,24}/giu],
+    },
+  ],
+  nl: [
+    {
+      id: 'nl.bsn',
+      category: 'national_identifier',
+      confidence: 'high',
+      locales: ['nl'],
+      redactionToken: '[REDACTED_NATIONAL_ID]',
+      enabled: true,
+      patterns: [/(?:BSN|burgerservicenummer)\s*[:#-]?\s*\d{9}/giu],
+      validator: 'validateDutchBsn',
+    },
+  ],
+});
+
+export const ADDRESS_RULES = Object.freeze({
+  de: /\b(?:straße|strasse|str\.|weg|platz|allee)\s+\d+\b.*\b\d{5}\b/giu,
+  fr: /\b(?:rue|avenue|av\.|boulevard|bd|chemin|place)\s+[^,\n]+\d+.*\b\d{5}\b/giu,
+  es: /\b(?:calle|c\/|avenida|avda\.|paseo|plaza)\s+[^,\n]+\d+.*\b\d{5}\b/giu,
+  nl: /\b(?:straat|laan|weg|plein|adres)\s+[^,\n]*\d+[A-Z]?\b.*\b\d{4}\s?[A-Z]{2}\b/giu,
+  en: /\b(?:street|st\.|road|rd\.|avenue|ave\.|drive|dr\.)\s+[^,\n]*\d+.*\b[A-Z0-9][A-Z0-9 -]{3,10}\b/giu,
+});
+
+export const MEDICAL_ID_VALUE_PATTERN = ID_VALUE_PATTERN;
+```
+
+- [ ] **Step 5: Implement detector**
+
+Create `frontend/src/pii/detector.js`:
+
+```js
+import { findPhoneNumbersInText } from 'libphonenumber-js';
+import { ADDRESS_RULES, GLOBAL_RULES, LOCALE_RULES, SUPPORTED_PII_LOCALES } from './ruleConfig';
+import { VALIDATORS } from './validators';
+
+function createSummary() {
+  return { high: {}, review: {} };
+}
+
+function addSummary(summary, finding) {
+  summary[finding.confidence][finding.category] =
+    (summary[finding.confidence][finding.category] ?? 0) + 1;
+}
+
+function buildFinding({ rule, start, end, index }) {
+  return {
+    id: `${rule.id}-${index}`,
+    ruleId: rule.id,
+    category: rule.category,
+    confidence: rule.confidence,
+    start,
+    end,
+    redactionToken: rule.redactionToken,
+  };
+}
+
+function isRuleEnabledForLocale(rule, locale) {
+  return rule.enabled && (rule.locales.includes('*') || rule.locales.includes(locale));
+}
+
+function candidateForValidation(text, matchText) {
+  const parts = String(matchText).split(/[:#-]/u);
+  return parts[parts.length - 1] || text;
+}
+
+function applyRules(text, rules, locale) {
+  const findings = [];
+  for (const rule of rules) {
+    if (!isRuleEnabledForLocale(rule, locale)) continue;
+    for (const pattern of rule.patterns) {
+      pattern.lastIndex = 0;
+      let match;
+      while ((match = pattern.exec(text)) !== null) {
+        const matchText = match[0];
+        const validator = rule.validator ? VALIDATORS[rule.validator] : null;
+        if (validator && !validator(candidateForValidation(text, matchText))) continue;
+        findings.push(buildFinding({ rule, start: match.index, end: match.index + matchText.length, index: findings.length }));
+      }
+    }
+  }
+  return findings;
+}
+
+function applyPhoneRule(text, locale) {
+  const region = locale === 'de' ? 'DE' : locale === 'fr' ? 'FR' : locale === 'es' ? 'ES' : locale === 'nl' ? 'NL' : 'US';
+  return findPhoneNumbersInText(text, region).map((match, index) => ({
+    id: `global.phone-${index}`,
+    ruleId: 'global.phone',
+    category: 'phone',
+    confidence: 'high',
+    start: match.startsAt,
+    end: match.endsAt,
+    redactionToken: '[REDACTED_PHONE]',
+  }));
+}
+
+function applyAddressRule(text, locale) {
+  const pattern = ADDRESS_RULES[locale];
+  if (!pattern) return [];
+  const findings = [];
+  pattern.lastIndex = 0;
+  let match;
+  while ((match = pattern.exec(text)) !== null) {
+    findings.push({
+      id: `address-${locale}-${findings.length}`,
+      ruleId: `${locale}.address`,
+      category: 'address',
+      confidence: 'high',
+      start: match.index,
+      end: match.index + match[0].length,
+      redactionToken: '[REDACTED_ADDRESS]',
+    });
+  }
+  return findings;
+}
+
+export function scanPii(text, { locale = 'en', includeGlobalRules = true } = {}) {
+  const normalizedLocale = SUPPORTED_PII_LOCALES.includes(locale) ? locale : 'en';
+  const source = String(text ?? '');
+  const configuredRules = [
+    ...(includeGlobalRules ? GLOBAL_RULES : []),
+    ...(LOCALE_RULES[normalizedLocale] ?? []),
+  ];
+  const findings = [
+    ...applyRules(source, configuredRules, normalizedLocale),
+    ...applyPhoneRule(source, normalizedLocale),
+    ...applyAddressRule(source, normalizedLocale),
+  ].sort((a, b) => a.start - b.start || b.end - a.end);
+
+  const summary = createSummary();
+  findings.forEach((finding) => addSummary(summary, finding));
+  return {
+    hasFindings: findings.length > 0,
+    findings,
+    summary,
+  };
+}
+```
+
+- [ ] **Step 6: Implement redactor**
+
+Create `frontend/src/pii/redactor.js`:
+
+```js
+function mergeFindings(findings, includeReviewFindings) {
+  const selected = findings
+    .filter((finding) => finding.confidence === 'high' || includeReviewFindings)
+    .sort((a, b) => a.start - b.start || b.end - a.end);
+
+  const merged = [];
+  for (const finding of selected) {
+    const previous = merged[merged.length - 1];
+    if (previous && finding.start < previous.end) {
+      const previousLength = previous.end - previous.start;
+      const findingLength = finding.end - finding.start;
+      if (findingLength > previousLength) {
+        merged[merged.length - 1] = finding;
+      }
+      continue;
+    }
+    merged.push(finding);
+  }
+  return merged;
+}
+
+function summarize(findings) {
+  return findings.reduce(
+    (summary, finding) => {
+      summary[finding.confidence][finding.category] =
+        (summary[finding.confidence][finding.category] ?? 0) + 1;
+      return summary;
+    },
+    { high: {}, review: {} }
+  );
+}
+
+export function redactPiiFindings(text, findings, { includeReviewFindings = false } = {}) {
+  const source = String(text ?? '');
+  const selected = mergeFindings(findings, includeReviewFindings);
+  if (selected.length === 0) {
+    return { text: source, changed: false, summary: { high: {}, review: {} } };
+  }
+
+  let cursor = 0;
+  let redacted = '';
+  for (const finding of selected) {
+    redacted += source.slice(cursor, finding.start);
+    redacted += finding.redactionToken;
+    cursor = finding.end;
+  }
+  redacted += source.slice(cursor);
+
+  return {
+    text: redacted,
+    changed: redacted !== source,
+    summary: summarize(selected),
+  };
+}
+```
+
+- [ ] **Step 7: Add public PII exports**
+
+Create `frontend/src/pii/index.js`:
+
+```js
+export { scanPii } from './detector';
+export { redactPiiFindings } from './redactor';
+export {
+  normalizeIdentifierCandidate,
+  validateDutchBsn,
+  validateFrenchNir,
+  validateGermanKvnr,
+  validateSpanishDniNie,
+} from './validators';
+```
+
+- [ ] **Step 8: Run detector/redactor tests and refine until passing**
+
+Run:
+
+```bash
+cd frontend
+npm run test:run -- src/test/pii/validators.test.js src/test/pii/detector.test.js src/test/pii/redactor.test.js
+```
+
+Expected: PASS. If a regex overmatches, adjust only `ruleConfig.js` and keep the API stable.
+
+- [ ] **Step 9: Commit detector/redactor**
+
+Run:
+
+```bash
+git add frontend/src/pii frontend/src/test/pii
+git commit -m "feat(frontend): add local PII detector and redactor"
+```
+
+Expected: commit succeeds.
+
+## Task 3: PII Review Dialog And I18n
+
+**Files:**
+- Create: `frontend/src/components/PiiReviewDialog.vue`
+- Modify: `frontend/src/plugins/vuetify.js`
+- Modify: `frontend/src/plugins/icons.js`
+- Modify: `frontend/src/locales/en.json`
+- Modify: `frontend/src/locales/de.json`
+- Modify: `frontend/src/locales/fr.json`
+- Modify: `frontend/src/locales/es.json`
+- Modify: `frontend/src/locales/nl.json`
+- Create: `frontend/src/test/components/PiiReviewDialog.test.js`
+
+- [ ] **Step 1: Write failing dialog tests**
+
+Create `frontend/src/test/components/PiiReviewDialog.test.js`:
+
+```js
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createI18n } from 'vue-i18n';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import en from '../../locales/en.json';
+import PiiReviewDialog from '../../components/PiiReviewDialog.vue';
+
+const vuetify = createVuetify({ components, directives });
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } });
+
+function mountDialog(props = {}) {
+  return mount(PiiReviewDialog, {
+    props: {
+      modelValue: true,
+      summary: { high: { email: 1, medical_record: 1 }, review: { date: 1 } },
+      ...props,
+    },
+    global: { plugins: [vuetify, i18n] },
+  });
+}
+
+describe('PiiReviewDialog', () => {
+  it('shows category counts without raw snippets', () => {
+    const wrapper = mountDialog();
+    expect(wrapper.text()).toContain('Email');
+    expect(wrapper.text()).toContain('Medical record');
+    expect(wrapper.text()).toContain('Date');
+    expect(wrapper.text()).not.toContain('jane@example.org');
+  });
+
+  it('emits cancel, redact, and continue actions', async () => {
+    const wrapper = mountDialog();
+
+    await wrapper.find('[data-testid="pii-cancel"]').trigger('click');
+    await wrapper.find('[data-testid="pii-redact"]').trigger('click');
+    await wrapper.find('[data-testid="pii-continue"]').trigger('click');
+
+    expect(wrapper.emitted('cancel')).toHaveLength(1);
+    expect(wrapper.emitted('redact')).toHaveLength(1);
+    expect(wrapper.emitted('continue')).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run dialog tests and verify they fail**
+
+Run:
+
+```bash
+cd frontend
+npm run test:run -- src/test/components/PiiReviewDialog.test.js
+```
+
+Expected: FAIL because `PiiReviewDialog.vue` does not exist.
+
+- [ ] **Step 3: Add English i18n keys**
+
+In `frontend/src/locales/en.json`, add under `queryInterface`:
+
+```json
+"piiReview": {
+  "title": "Possible identifiers detected",
+  "description": "Phentrieve found possible identifiers before submitting this text.",
+  "willRedact": "Will be redacted locally",
+  "needsReview": "Needs review",
+  "overrideNotice": "High-confidence identifiers will be redacted locally before submission. Other possible identifiers may remain if you continue.",
+  "safetyAid": "This is a safety aid and cannot guarantee all PII is detected.",
+  "cancel": "Review text",
+  "redact": "Redact in text",
+  "continue": "Continue with local redaction",
+  "categories": {
+    "email": "Email",
+    "phone": "Phone",
+    "url": "URL",
+    "ip_address": "IP address",
+    "date": "Date",
+    "dob": "Date of birth",
+    "medical_record": "Medical record",
+    "accession_id": "Accession ID",
+    "sample_id": "Sample ID",
+    "national_identifier": "National identifier",
+    "address": "Address",
+    "person_name": "Name",
+    "location": "Location",
+    "organization": "Organization"
+  }
+}
+```
+
+Add equivalent keys with translated values to `de.json`, `fr.json`, `es.json`, and `nl.json`. Keep the key structure identical.
+
+- [ ] **Step 4: Implement dialog**
+
+Create `frontend/src/components/PiiReviewDialog.vue`:
+
+```vue
+<template>
+  <v-dialog
+    v-model="dialogVisible"
+    max-width="560"
+    persistent
+    role="alertdialog"
+    aria-labelledby="pii-review-title"
+  >
+    <v-card>
+      <v-card-title id="pii-review-title" class="d-flex align-center text-warning">
+        <v-icon class="mr-2" aria-hidden="true">mdi-shield-alert-outline</v-icon>
+        {{ $t('queryInterface.piiReview.title') }}
+      </v-card-title>
+
+      <v-card-text>
+        <p class="text-body-1 text-high-emphasis mb-3">
+          {{ $t('queryInterface.piiReview.description') }}
+        </p>
+
+        <v-alert type="warning" variant="tonal" density="comfortable" class="mb-4">
+          {{ $t('queryInterface.piiReview.overrideNotice') }}
+        </v-alert>
+
+        <section v-if="hasHighFindings" class="mb-4">
+          <h3 class="text-subtitle-2 mb-2">
+            {{ $t('queryInterface.piiReview.willRedact') }}
+          </h3>
+          <div class="d-flex flex-wrap ga-2">
+            <v-chip
+              v-for="item in highCategoryItems"
+              :key="`high-${item.category}`"
+              color="warning"
+              variant="tonal"
+              size="small"
+            >
+              {{ getCategoryLabel(item.category) }}: {{ item.count }}
+            </v-chip>
+          </div>
+        </section>
+
+        <section v-if="hasReviewFindings" class="mb-4">
+          <h3 class="text-subtitle-2 mb-2">
+            {{ $t('queryInterface.piiReview.needsReview') }}
+          </h3>
+          <div class="d-flex flex-wrap ga-2">
+            <v-chip
+              v-for="item in reviewCategoryItems"
+              :key="`review-${item.category}`"
+              color="info"
+              variant="tonal"
+              size="small"
+            >
+              {{ getCategoryLabel(item.category) }}: {{ item.count }}
+            </v-chip>
+          </div>
+        </section>
+
+        <p class="text-caption text-medium-emphasis mb-0">
+          {{ $t('queryInterface.piiReview.safetyAid') }}
+        </p>
+      </v-card-text>
+
+      <v-card-actions class="px-6 pb-4 flex-wrap ga-2">
+        <v-spacer />
+        <v-btn data-testid="pii-cancel" variant="text" @click="$emit('cancel')">
+          {{ $t('queryInterface.piiReview.cancel') }}
+        </v-btn>
+        <v-btn data-testid="pii-redact" variant="tonal" color="primary" @click="$emit('redact')">
+          {{ $t('queryInterface.piiReview.redact') }}
+        </v-btn>
+        <v-btn
+          data-testid="pii-continue"
+          variant="elevated"
+          color="warning"
+          @click="$emit('continue')"
+        >
+          {{ $t('queryInterface.piiReview.continue') }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+function toCategoryItems(record) {
+  return Object.entries(record ?? {}).map(([category, count]) => ({ category, count }));
+}
+
+export default {
+  name: 'PiiReviewDialog',
+  props: {
+    modelValue: {
+      type: Boolean,
+      default: false,
+    },
+    summary: {
+      type: Object,
+      default: () => ({ high: {}, review: {} }),
+    },
+  },
+  emits: ['update:modelValue', 'cancel', 'redact', 'continue'],
+  computed: {
+    dialogVisible: {
+      get() {
+        return this.modelValue;
+      },
+      set(value) {
+        this.$emit('update:modelValue', value);
+      },
+    },
+    highCategoryItems() {
+      return toCategoryItems(this.summary.high);
+    },
+    reviewCategoryItems() {
+      return toCategoryItems(this.summary.review);
+    },
+    hasHighFindings() {
+      return this.highCategoryItems.length > 0;
+    },
+    hasReviewFindings() {
+      return this.reviewCategoryItems.length > 0;
+    },
+  },
+  methods: {
+    getCategoryLabel(category) {
+      return this.$t(`queryInterface.piiReview.categories.${category}`);
+    },
+  },
+};
+</script>
+```
+
+- [ ] **Step 5: Register icon**
+
+In `frontend/src/plugins/icons.js`, add:
+
+```js
+'mdi-shield-alert-outline',
+```
+
+`VAlert`, `VChip`, `VDialog`, `VCard`, `VCardTitle`, `VCardText`, `VCardActions`, `VSpacer`, `VBtn`, and `VIcon` are already registered in `frontend/src/plugins/vuetify.js`; no new Vuetify component registration should be needed.
+
+- [ ] **Step 6: Run dialog and i18n checks**
+
+Run:
+
+```bash
+cd frontend
+npm run test:run -- src/test/components/PiiReviewDialog.test.js
+npm run i18n:check
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit dialog and i18n**
+
+Run:
+
+```bash
+git add frontend/src/components/PiiReviewDialog.vue frontend/src/test/components/PiiReviewDialog.test.js frontend/src/locales frontend/src/plugins/icons.js
+git commit -m "feat(frontend): add PII review dialog"
+```
+
+Expected: commit succeeds.
+
+## Task 4: QueryInterface Integration And No-Network Gate
+
+**Files:**
+- Modify: `frontend/src/components/QueryInterface.vue`
+- Modify: `frontend/src/composables/useQueryInterfaceController.js`
+- Modify: `frontend/src/test/components/QueryInterface.test.js`
+
+- [ ] **Step 1: Write failing QueryInterface flow tests**
+
+Append to `frontend/src/test/components/QueryInterface.test.js`:
+
+```js
+it('opens PII review before query-mode network submission', async () => {
+  const wrapper = await mountQueryInterface();
+  await flushPromises();
+
+  await setVmState(wrapper, {
+    queryText: 'MRN: AB-123456 with seizures',
+    forceEndpointMode: 'query',
+  });
+
+  await wrapper.vm.submitQuery();
+
+  expect(PhentrieveService.queryHpo).not.toHaveBeenCalled();
+  expect(wrapper.findComponent({ name: 'PiiReviewDialog' }).exists()).toBe(true);
+  expect(wrapper.vm.piiReviewDialogVisible).toBe(true);
+});
+
+it('opens PII review before full-text network submission', async () => {
+  const wrapper = await mountQueryInterface();
+  await flushPromises();
+
+  await setVmState(wrapper, {
+    queryText: 'DOB: 12/03/1980. Patient had seizures.',
+    forceEndpointMode: 'textProcess',
+  });
+
+  await wrapper.vm.submitQuery();
+
+  expect(PhentrieveService.processText).not.toHaveBeenCalled();
+  expect(wrapper.vm.piiReviewDialogVisible).toBe(true);
+});
+
+it('continues with local redaction and submits redacted query text', async () => {
+  const wrapper = await mountQueryInterface();
+  await flushPromises();
+
+  await setVmState(wrapper, {
+    queryText: 'MRN: AB-123456 with seizures',
+    forceEndpointMode: 'query',
+  });
+
+  await wrapper.vm.submitQuery();
+  await wrapper.vm.continueWithPiiRedaction();
+
+  expect(PhentrieveService.queryHpo).toHaveBeenCalledWith(
+    expect.objectContaining({ text: expect.stringContaining('[REDACTED_MRN]') })
+  );
+});
+
+it('redacts in the input without submitting', async () => {
+  const wrapper = await mountQueryInterface();
+  await flushPromises();
+
+  await setVmState(wrapper, {
+    queryText: 'Email jane@example.org and seizures',
+    forceEndpointMode: 'query',
+  });
+
+  await wrapper.vm.submitQuery();
+  await wrapper.vm.redactPiiInInput();
+
+  expect(wrapper.vm.queryText).toContain('[REDACTED_EMAIL]');
+  expect(PhentrieveService.queryHpo).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run QueryInterface tests and verify they fail**
+
+Run:
+
+```bash
+cd frontend
+npm run test:run -- src/test/components/QueryInterface.test.js
+```
+
+Expected: FAIL because `PiiReviewDialog` is not integrated and controller has no PII gate.
+
+- [ ] **Step 3: Add PII dialog state and handlers to QueryInterface**
+
+Modify `frontend/src/components/QueryInterface.vue`:
+
+```vue
+<PiiReviewDialog
+  v-model="piiReviewDialogVisible"
+  :summary="pendingPiiSubmission?.scanResult?.summary || { high: {}, review: {} }"
+  @cancel="cancelPiiReview"
+  @redact="redactPiiInInput"
+  @continue="continueWithPiiRedaction"
+/>
+```
+
+Add imports:
+
+```js
+import PiiReviewDialog from './PiiReviewDialog.vue';
+```
+
+Register component:
+
+```js
+components: {
+  ResultsDisplay,
+  ConversationSkeleton,
+  AdvancedOptionsPanel,
+  PhenotypeCollectionPanel,
+  FullTextResponseReceipt,
+  PiiReviewDialog,
+},
+```
+
+Add data:
+
+```js
+piiReviewDialogVisible: false,
+pendingPiiSubmission: null,
+```
+
+Add controller context hooks:
+
+```js
+openPiiReview(pendingSubmission) {
+  vm.pendingPiiSubmission = pendingSubmission;
+  vm.piiReviewDialogVisible = true;
+},
+```
+
+Add methods:
+
+```js
+cancelPiiReview() {
+  this.piiReviewDialogVisible = false;
+  this.pendingPiiSubmission = null;
+},
+redactPiiInInput() {
+  return this.queryInterfaceController.redactPiiInInput();
+},
+continueWithPiiRedaction() {
+  return this.queryInterfaceController.continueWithPiiRedaction();
+},
+```
+
+- [ ] **Step 4: Refactor controller submission flow**
+
+Modify `frontend/src/composables/useQueryInterfaceController.js`:
+
+```js
+import { redactPiiFindings, scanPii } from '../pii';
+```
+
+Add helper:
+
+```js
+function getSanitizedSubmissionLog({ mode, text, latestState, piiScanResult, redactionApplied }) {
+  return {
+    mode,
+    textLength: text.length,
+    selectedLanguage: latestState.selectedLanguage,
+    extractionBackend: mode === 'textProcess' ? latestState.textProcessOptions.extractionBackend : null,
+    piiSummary: piiScanResult?.summary ?? { high: {}, review: {} },
+    piiRedactionApplied: Boolean(redactionApplied),
+  };
+}
+```
+
+Split the existing API-submission body into an internal function:
+
+```js
+async function submitQueryText({ currentQuery, useTextProcessMode, isAutoSubmit, piiScanResult = null, redactionApplied = false }) {
+  const context = getContextOrThrow(getContext);
+  const latestState = context.getState();
+
+  context.setState({
+    isLoading: true,
+    shouldScrollToTop: true,
+    userHasScrolled: false,
+  });
+
+  const queryId = context.conversationStore.addQuery({
+    query: currentQuery,
+    loading: true,
+    type: useTextProcessMode ? 'textProcess' : 'query',
+  });
+
+  if (useTextProcessMode) {
+    context.setExpandedUserNote(queryId, true);
+  }
+
+  if (!isAutoSubmit) {
+    context.setState({ queryText: '' });
+  }
+
+  try {
+    let response;
+    logService.info(
+      'Submitting text request',
+      getSanitizedSubmissionLog({
+        mode: useTextProcessMode ? 'textProcess' : 'query',
+        text: currentQuery,
+        latestState,
+        piiScanResult,
+        redactionApplied,
+      })
+    );
+
+    if (useTextProcessMode) {
+      response = await service.processText({
+        text: currentQuery,
+        extractionBackend: latestState.textProcessOptions.extractionBackend,
+        llmModel: latestState.textProcessOptions.llmModel,
+        llmMode: latestState.textProcessOptions.llmMode,
+        language: latestState.selectedLanguage,
+        chunkingStrategy: latestState.chunkingStrategy,
+        windowSize: latestState.windowSize,
+        stepSize: latestState.stepSize,
+        splitThreshold: latestState.splitThreshold,
+        minSegmentLength: latestState.minSegmentLength,
+        semanticModelForChunking: latestState.semanticModelForChunking || latestState.selectedModel,
+        retrievalModelForTextProcess: latestState.retrievalModelForTextProcess || latestState.selectedModel,
+        trustRemoteCode: true,
+        chunkRetrievalThreshold: latestState.chunkRetrievalThreshold,
+        numResultsPerChunk: latestState.numResultsPerChunk,
+        noAssertionDetectionForTextProcess: latestState.noAssertionDetectionForTextProcess,
+        assertionPreferenceForTextProcess: latestState.assertionPreferenceForTextProcess,
+        aggregatedTermConfidence: latestState.aggregatedTermConfidence,
+        topTermPerChunkForAggregation: latestState.topTermPerChunkForAggregation,
+        includeDetails: latestState.includeDetails,
+      });
+    } else {
+      response = await service.queryHpo({
+        text: currentQuery,
+        model_name: latestState.selectedModel,
+        language: latestState.selectedLanguage,
+        num_results: latestState.numResults,
+        similarity_threshold: latestState.similarityThreshold,
+        query_assertion_language: latestState.selectedLanguage,
+        detect_query_assertion: true,
+        include_details: latestState.includeDetails,
+      });
+    }
+
+    context.conversationStore.updateQueryResponse(queryId, response);
+    if (useTextProcessMode) {
+      context.fullTextWorkspaceStore.initializeTurn(queryId);
+      context.fullTextWorkspaceStore.setExpanded(queryId, true);
+    }
+  } catch (error) {
+    context.conversationStore.updateQueryResponse(queryId, null, error);
+    logService.error('Error submitting query/processing text', error);
+  } finally {
+    context.setState({ isLoading: false });
+  }
+}
+```
+
+Update public `submitQuery()` to scan before calling the internal function:
+
+```js
+async function submitQuery(isAutoSubmit = false) {
+  const context = getContextOrThrow(getContext);
+  const state = context.getState();
+  const queryTextTrimmed = typeof state.queryText === 'string' ? state.queryText.trim() : '';
+
+  if (!queryTextTrimmed) {
+    logService.warn('Empty query submission prevented');
+    return;
+  }
+
+  const useTextProcessMode = state.isTextProcessModeActive;
+  const scanResult = scanPii(queryTextTrimmed, { locale: state.selectedLanguage || 'en' });
+  if (scanResult.hasFindings) {
+    context.openPiiReview({
+      text: queryTextTrimmed,
+      useTextProcessMode,
+      isAutoSubmit,
+      scanResult,
+    });
+    logService.info('PII review required before submission', {
+      mode: useTextProcessMode ? 'textProcess' : 'query',
+      textLength: queryTextTrimmed.length,
+      piiSummary: scanResult.summary,
+    });
+    return;
+  }
+
+  return submitQueryText({
+    currentQuery: queryTextTrimmed,
+    useTextProcessMode,
+    isAutoSubmit,
+    piiScanResult: scanResult,
+    redactionApplied: false,
+  });
+}
+```
+
+Add controller methods:
+
+```js
+async function continueWithPiiRedaction() {
+  const context = getContextOrThrow(getContext);
+  const pending = context.getState().pendingPiiSubmission;
+  if (!pending) return;
+
+  const redaction = redactPiiFindings(pending.text, pending.scanResult.findings, {
+    includeReviewFindings: false,
+  });
+  context.setState({ piiReviewDialogVisible: false, pendingPiiSubmission: null });
+
+  return submitQueryText({
+    currentQuery: redaction.text,
+    useTextProcessMode: pending.useTextProcessMode,
+    isAutoSubmit: pending.isAutoSubmit,
+    piiScanResult: pending.scanResult,
+    redactionApplied: redaction.changed,
+  });
+}
+
+function redactPiiInInput() {
+  const context = getContextOrThrow(getContext);
+  const pending = context.getState().pendingPiiSubmission;
+  if (!pending) return;
+
+  const redaction = redactPiiFindings(pending.text, pending.scanResult.findings, {
+    includeReviewFindings: true,
+  });
+  context.setState({
+    queryText: redaction.text,
+    piiReviewDialogVisible: false,
+    pendingPiiSubmission: null,
+  });
+}
+```
+
+Return the methods:
+
+```js
+return {
+  fetchAvailableModels,
+  setFallbackModel,
+  applyUrlParametersAndAutoSubmit,
+  submitQuery,
+  continueWithPiiRedaction,
+  redactPiiInInput,
+};
+```
+
+Ensure `getState()` in `QueryInterface.vue` returns `pendingPiiSubmission`.
+
+- [ ] **Step 5: Preserve existing URL cleanup behavior**
+
+Move the existing `autoSubmit` route cleanup into a helper and call it from `submitQueryText()` finally block:
+
+```js
+function clearAutoSubmitQueryParamIfNeeded(context, isAutoSubmit) {
+  if (!isAutoSubmit && hasOwnQueryParam(context.routeQuery, 'autoSubmit')) {
+    const newRouteQuery = { ...context.routeQuery };
+    delete newRouteQuery.autoSubmit;
+    Promise.resolve(context.replaceRouteQuery(newRouteQuery)).catch((error) => {
+      if (error.name !== 'NavigationDuplicated' && error.name !== 'NavigationCancelled') {
+        logService.warn('Error clearing autoSubmit from URL:', error);
+      }
+    });
+  }
+}
+```
+
+Call:
+
+```js
+clearAutoSubmitQueryParamIfNeeded(context, isAutoSubmit);
+```
+
+- [ ] **Step 6: Run QueryInterface tests**
+
+Run:
+
+```bash
+cd frontend
+npm run test:run -- src/test/components/QueryInterface.test.js src/test/components/PiiReviewDialog.test.js src/test/pii
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit integration**
+
+Run:
+
+```bash
+git add frontend/src/components/QueryInterface.vue frontend/src/composables/useQueryInterfaceController.js frontend/src/test/components/QueryInterface.test.js
+git commit -m "feat(frontend): gate submissions with local PII review"
+```
+
+Expected: commit succeeds.
+
+## Task 5: Logging Tests And Service Privacy Cleanup
+
+**Files:**
+- Modify: `frontend/src/test/components/QueryInterface.test.js`
+- Modify: `frontend/src/services/PhentrieveService.js` only if tests reveal raw text logging there.
+- Modify: `frontend/src/test/services/PhentrieveService.test.js` only if service behavior changes.
+
+- [ ] **Step 1: Add a log privacy regression test**
+
+In `frontend/src/test/components/QueryInterface.test.js`, import the mocked log service:
+
+```js
+import { logService } from '../../services/logService';
+```
+
+Add:
+
+```js
+it('does not log raw text or detected snippets during PII review and submit', async () => {
+  const wrapper = await mountQueryInterface();
+  await flushPromises();
+
+  await setVmState(wrapper, {
+    queryText: 'Email jane@example.org with seizures',
+    forceEndpointMode: 'query',
+  });
+
+  await wrapper.vm.submitQuery();
+  await wrapper.vm.continueWithPiiRedaction();
+
+  const serializedLogs = JSON.stringify([
+    ...logService.info.mock.calls,
+    ...logService.debug.mock.calls,
+    ...logService.warn.mock.calls,
+    ...logService.error.mock.calls,
+  ]);
+
+  expect(serializedLogs).not.toContain('jane@example.org');
+  expect(serializedLogs).not.toContain('Email jane');
+  expect(serializedLogs).toContain('piiSummary');
+});
+```
+
+- [ ] **Step 2: Run the log privacy test and verify failure or pass**
+
+Run:
+
+```bash
+cd frontend
+npm run test:run -- src/test/components/QueryInterface.test.js -t "does not log raw text"
+```
+
+Expected: PASS if Task 4 removed raw request-object logging. If it fails, remove remaining raw text from controller logs.
+
+- [ ] **Step 3: Inspect service logs for raw text**
+
+Check `frontend/src/services/PhentrieveService.js`. `queryHpo()` and `processText()` should log only `textLength`, request size, model/backend metadata, and response sizes. Do not log full payloads.
+
+If raw text appears, replace it with:
+
+```js
+logService.info('Querying HPO API', {
+  textLength: queryData.text?.length || 0,
+  numResults: queryData.num_results ?? queryData.numResults,
+  model: queryData.model_name ?? queryData.modelName,
+});
+```
+
+and:
+
+```js
+logService.info('Calling Text Processing API', {
+  requestSize: JSON.stringify(normalizedPayload).length,
+  textLength: normalizedPayload.text?.length || 0,
+  backend: normalizedPayload.extraction_backend,
+  llmTarget:
+    normalizedPayload.extraction_backend === 'llm'
+      ? 'server-owned'
+      : normalizedPayload.retrieval_model_name,
+});
+```
+
+- [ ] **Step 4: Run service and component tests**
+
+Run:
+
+```bash
+cd frontend
+npm run test:run -- src/test/services/PhentrieveService.test.js src/test/services/PhentrieveService.researchUse.test.js src/test/components/QueryInterface.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit logging cleanup**
+
+Run:
+
+```bash
+git add frontend/src/test/components/QueryInterface.test.js frontend/src/services/PhentrieveService.js frontend/src/test/services/PhentrieveService.test.js frontend/src/test/services/PhentrieveService.researchUse.test.js
+git commit -m "test(frontend): verify PII guard avoids raw text logs"
+```
+
+Expected: commit succeeds. If no service files changed, omit them from `git add`.
+
+## Task 6: Documentation And Planning Index
+
+**Files:**
+- Modify: `docs/compliance/privacy-and-llm-processing.md`
+- Modify: `.planning/README.md`
+
+- [ ] **Step 1: Update privacy documentation**
+
+In `docs/compliance/privacy-and-llm-processing.md`, add after `## User Data Guidance`:
+
+```markdown
+## Browser-Side PII Warning
+
+The frontend includes a local browser-side warning and redaction aid for English,
+German, French, Spanish, and Dutch submissions. Before Query or Full Text input
+is sent to the API, the browser checks for common direct identifiers such as
+contact details, record numbers, national identifier patterns, exact date
+labels, and address-like text.
+
+High-confidence identifiers are redacted locally before submission when the user
+continues. Lower-confidence findings require explicit acknowledgement and may
+remain if the user decides to proceed.
+
+This feature is a safety aid. It is not a guarantee that all PII or PHI is
+detected, and it does not make submitted text HIPAA Safe Harbor de-identified,
+GDPR-anonymised, or suitable for identifiable patient data in public demos.
+Users should review and remove identifiers before submitting research text.
+```
+
+- [ ] **Step 2: Update planning index**
+
+In `.planning/README.md`, add under `Current Active Work`:
+
+```markdown
+- `active/2026-04-30-local-browser-pii-guard-implementation-plan.md` -
+  implementation plan for GitHub issue #249, covering local browser-side PII
+  detection and redaction before Query and Full Text submissions.
+```
+
+- [ ] **Step 3: Run documentation-adjacent checks**
+
+Run:
+
+```bash
+make frontend-i18n-check
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit docs**
+
+Run:
+
+```bash
+git add docs/compliance/privacy-and-llm-processing.md .planning/README.md
+git commit -m "docs: document local PII guard behavior"
+```
+
+Expected: commit succeeds.
+
+## Task 7: Final Frontend And Repository Verification
+
+**Files:**
+- No new files unless verification reveals defects.
+
+- [ ] **Step 1: Run focused frontend tests**
+
+Run:
+
+```bash
+make frontend-test-ci
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run frontend build**
+
+Run:
+
+```bash
+make frontend-build-ci
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run repository-required checks**
+
+Run:
+
+```bash
+make check
+make typecheck-fast
+make test
+```
+
+Expected: all PASS.
+
+- [ ] **Step 4: Inspect git diff for privacy regressions**
+
+Run:
+
+```bash
+git diff --check
+rg -n "Sending to /query API|Sending to /text/process API|queryData|textProcessData|jane@example|AB-123456" frontend/src frontend/src/test docs .planning
+```
+
+Expected:
+
+- `git diff --check` produces no output.
+- `rg` finds only test fixtures or planned documentation references, not runtime raw-payload logging.
+
+- [ ] **Step 5: Commit final fixes if needed**
+
+If verification required fixes, run:
+
+```bash
+git add <changed-files>
+git commit -m "fix(frontend): stabilize local PII guard verification"
+```
+
+Expected: commit succeeds. If no fixes were needed, skip this step.
+
+## Self-Review Checklist
+
+- Spec coverage: the plan implements local-only detection, both Query and Full
+  Text modes, mandatory high-confidence redaction, override acknowledgement,
+  five language overlays, config-driven expansion, tests, logs, and docs.
+- Placeholder scan: no steps use placeholder markers or unspecified error handling.
+- Type consistency: public functions are `scanPii()` and `redactPiiFindings()`;
+  controller methods are `continueWithPiiRedaction()` and `redactPiiInInput()`;
+  dialog events are `cancel`, `redact`, and `continue`.
+- Scope check: backend enforcement and cloud PII APIs remain out of scope.
+
+## Execution Options
+
+Plan complete and saved to `.planning/active/2026-04-30-local-browser-pii-guard-implementation-plan.md`.
+
+1. **Subagent-Driven (recommended)** - dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** - execute tasks in this session using executing-plans, batch execution with checkpoints.

--- a/.planning/active/2026-04-30-untitled-local-person-name-pii-implementation-plan.md
+++ b/.planning/active/2026-04-30-untitled-local-person-name-pii-implementation-plan.md
@@ -1,0 +1,82 @@
+# Untitled Local Person Name PII Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add configurable browser-only review-confidence detection for untitled person names.
+
+**Architecture:** Keep deterministic detection in `frontend/src/pii/`. Add config data in `ruleConfig.js`, scanning logic in `detector.js`, and tests in existing Vitest suites. No network or model dependency is introduced.
+
+**Tech Stack:** Vue 3 frontend, Vitest, existing PII detector/redactor modules.
+
+---
+
+### Task 1: Add Failing Detector Tests
+
+**Files:**
+- Modify: `frontend/src/test/pii/detector.test.js`
+
+- [ ] Add tests for untitled names:
+  - `Bernt Popp ist dumm` with locale `en`
+  - `Jean Dupont a des crises` with locale `fr`
+  - `María García tiene convulsiones` with locale `es`
+  - `Jan van Dijk heeft aanvallen` with locale `nl`
+
+- [ ] Add false-positive tests:
+  - `Pectus Carinatum was noted.`
+  - `Down Syndrome was discussed.`
+  - `BioLORD Model returned results.`
+  - `HP:0002779 Tracheomalacia`
+
+- [ ] Run:
+  `npm run test:run -- src/test/pii/detector.test.js -t "untitled"`
+
+- [ ] Expected: FAIL because untitled name detection does not exist yet.
+
+### Task 2: Implement Config-Driven Untitled Name Detection
+
+**Files:**
+- Modify: `frontend/src/pii/ruleConfig.js`
+- Modify: `frontend/src/pii/detector.js`
+
+- [ ] Add exported config for possible names:
+  - `UNTITLED_NAME_RULE_CONFIG`
+  - locale particles
+  - locale context words
+  - blocked phrase words
+  - minimum score
+
+- [ ] Add detector helpers:
+  - extract capitalized-token candidate spans
+  - score candidates from config
+  - reject blocked/domain/identifier candidates
+  - emit `person_name` review findings only
+
+- [ ] Run:
+  `npm run test:run -- src/test/pii/detector.test.js -t "untitled"`
+
+- [ ] Expected: PASS.
+
+### Task 3: Add Submission-Guard Tests
+
+**Files:**
+- Modify: `frontend/src/test/components/QueryInterface.test.js`
+
+- [ ] Add Query mode test that `Bernt Popp ist dumm` opens PII review and does not call `queryHpo`.
+- [ ] Add Full Text mode test that `Bernt Popp ist dumm` opens PII review and does not call `processText`.
+- [ ] Run:
+  `npm run test:run -- src/test/components/QueryInterface.test.js -t "untitled name"`
+- [ ] Expected: PASS after Task 2.
+
+### Task 4: Focused Verification and Commit
+
+**Files:**
+- All modified frontend PII files and planning files.
+
+- [ ] Run:
+  `npm run test:run -- src/test/pii src/test/components/QueryInterface.test.js`
+- [ ] Run:
+  `npm run lint -- src/pii/detector.js src/pii/ruleConfig.js src/test/pii/detector.test.js src/test/components/QueryInterface.test.js`
+- [ ] Run:
+  `git diff --check`
+- [ ] Commit:
+  `git commit -m "feat(frontend): detect untitled local person names"`

--- a/.planning/specs/2026-04-30-local-browser-pii-guard-design.md
+++ b/.planning/specs/2026-04-30-local-browser-pii-guard-design.md
@@ -1,0 +1,402 @@
+# Local Browser PII Guard Design
+
+## Issue
+
+- GitHub: https://github.com/berntpopp/phentrieve/issues/249
+- Scope: Vue frontend text submission paths for both short Query mode and Full
+  Text mode.
+- Languages in scope: English, German, French, Spanish, and Dutch.
+
+## Goal
+
+Add a browser-only PII/PHI warning and redaction gate before user text is sent to
+Phentrieve APIs. The gate must scan both short phenotype queries and full
+clinical notes locally, redact high-confidence identifiers before submission,
+and require explicit user acknowledgement when lower-confidence findings remain.
+
+The feature is a safety aid for public research use. It must not claim HIPAA
+Safe Harbor de-identification, GDPR anonymisation, or complete PII detection.
+
+## Non-Goals
+
+- Do not send raw text to a backend, cloud PII API, LLM, analytics service, or
+  log sink for pre-submit PII detection.
+- Do not implement backend enforcement in this iteration. Frontend checks guide
+  users but are not a security boundary.
+- Do not add a heavy browser NLP or NER model in the first implementation.
+- Do not claim that redacted text is anonymous or legally de-identified.
+- Do not inspect image, PDF, DICOM, uploaded binary, or phenopacket export
+  content in this issue.
+- Do not persist detected snippets, finding offsets, or pre-redaction text.
+
+## Standards And Research Baseline
+
+The practical identifier categories should align with HIPAA Safe Harbor without
+claiming compliance. HHS identifies two HIPAA de-identification routes: Expert
+Determination and Safe Harbor. Safe Harbor focuses on removing 18 identifier
+classes, including names, sub-state geographic details, date elements except
+year for dates related to an individual, contact details, record/account
+numbers, device/vehicle identifiers, URLs, IP addresses, biometrics, face
+images, and other unique identifying codes.
+
+NIST SP 800-188 frames de-identification as privacy-risk reduction and cautions
+that traditional de-identification has inherent limits. This supports UI copy
+that treats Phentrieve's PII guard as a warning and redaction aid, not as a
+guarantee.
+
+GDPR/EDPB guidance distinguishes pseudonymisation from anonymisation. Because
+the frontend can only remove or replace visible identifiers and cannot assess
+full re-identification risk, Phentrieve must avoid saying user text is
+anonymised.
+
+Cloud and server-side products such as AWS Comprehend Medical DetectPHI, Google
+Sensitive Data Protection, Azure AI Language PII, and Microsoft Presidio are
+useful comparison points but are not runtime choices for this issue. They either
+send text out of the browser or require backend infrastructure before the first
+network request, which conflicts with the acceptance criteria.
+
+## Design Principles
+
+1. Local first: detection, review, and high-confidence redaction happen before
+   any network request.
+2. Config-driven: language and country-specific rules live in data/config, not
+   hard-coded branches spread through UI code.
+3. Conservative redaction: high-confidence direct identifiers are always
+   replaced locally before submission.
+4. Transparent uncertainty: lower-confidence findings trigger review and can be
+   acknowledged, but the UI must not expose raw snippets.
+5. Utility preservation: redaction tokens preserve broad category information
+   such as `[REDACTED_DATE]` or `[REDACTED_MRN]` so downstream HPO extraction is
+   not confused by silent deletion.
+6. No raw-text telemetry: logs may include counts and categories, never matched
+   text, offsets, or full submitted text.
+7. Expandability: adding a future locale should require a locale config and
+   tests, not changes to the detector core.
+
+## Architecture
+
+### PII Rule Engine
+
+Create a small frontend PII module under `frontend/src/pii/`.
+
+Recommended files:
+
+- `frontend/src/pii/types.js` - JSDoc typedefs for rule, finding, scan result,
+  and redaction result shapes.
+- `frontend/src/pii/ruleConfig.js` - global rules and locale overlays for
+  `en`, `de`, `fr`, `es`, and `nl`.
+- `frontend/src/pii/validators.js` - checksum and format validators such as
+  Spanish DNI/NIE and Dutch BSN.
+- `frontend/src/pii/detector.js` - applies configured rules and produces
+  sanitized findings.
+- `frontend/src/pii/redactor.js` - applies high-confidence redactions and
+  optional review-confidence redactions.
+- `frontend/src/pii/index.js` - public frontend PII API.
+
+The detector core accepts:
+
+```js
+scanPii(text, {
+  locale,
+  enabledLocales,
+  includeGlobalRules,
+});
+```
+
+It returns category-level findings without raw snippets:
+
+```js
+{
+  hasFindings: true,
+  findings: [
+    {
+      id: "finding-1",
+      ruleId: "global.email",
+      category: "email",
+      confidence: "high",
+      start: 10,
+      end: 26,
+      redactionToken: "[REDACTED_EMAIL]"
+    }
+  ],
+  summary: {
+    high: { email: 1 },
+    review: {}
+  }
+}
+```
+
+Offsets may exist in memory so redaction can be applied, but they must not be
+shown in the UI, saved to stores, or sent to logs.
+
+### Rule Configuration
+
+Rules should use a common shape:
+
+```js
+{
+  id: "fr.nir",
+  category: "national_identifier",
+  confidence: "high",
+  locales: ["fr"],
+  redactionToken: "[REDACTED_NATIONAL_ID]",
+  enabled: true,
+  patterns: [/.../gu],
+  contextKeywords: ["nir", "sécurité sociale", "numéro de sécurité sociale"],
+  validator: "validateFrenchNir"
+}
+```
+
+Global rules run for every language:
+
+- Email addresses.
+- URLs.
+- IPv4 and common IPv6 forms.
+- International and locale-specific phone numbers through `libphonenumber-js`.
+- Exact date patterns and date-of-birth labels.
+- MRN/record/account/accession/sample identifiers with localizable labels.
+- Address-like lines when a street keyword, house number, and postal-code-like
+  token occur together.
+
+Locale overlays add language-specific labels and identifiers:
+
+- `en`: `DOB`, `date of birth`, `MRN`, `medical record number`, `patient ID`,
+  `NHS number` as a configurable label pattern rather than a hard-coded UK-only
+  validation guarantee.
+- `de`: `Geburtsdatum`, `Versichertennummer`,
+  `Krankenversichertennummer`, `Patienten-ID`, `Aktenzeichen`, German street
+  terms, 5-digit postal-code address context, and KVNR-like values with one
+  uppercase letter followed by nine digits.
+- `fr`: `date de naissance`, `NIR`, `numéro de sécurité sociale`,
+  `identifiant patient`, French street terms, 5-digit postal-code address
+  context, and NIR-like values with 13 digits plus optional 2-digit key.
+- `es`: `fecha de nacimiento`, `DNI`, `NIE`, `NIF`, `número de historia
+  clínica`, Spanish street terms, 5-digit postal-code address context, and
+  DNI/NIE checksum validation when the candidate shape allows it.
+- `nl`: `geboortedatum`, `BSN`, `burgerservicenummer`,
+  `patiëntnummer`, `polisnummer`, Dutch street terms, Dutch postcode plus house
+  number context, and BSN-like values with modulus-11 validation.
+
+Postal codes alone are review-confidence because they often appear in research
+context. Postal code plus street/house/address context is high-confidence.
+
+### Confidence And Redaction Policy
+
+High-confidence findings are always redacted before submission:
+
+- Email.
+- Phone/fax.
+- URL.
+- IP address.
+- SSN/national ID with a recognized shape or checksum.
+- MRN, account, accession, sample, or patient ID with label context.
+- DOB-labeled dates.
+- Exact dates directly attached to admission, discharge, death, visit, birth,
+  appointment, or patient-care labels.
+- Address-like lines with street/address context.
+
+Review-confidence findings trigger a modal and can remain after explicit user
+acknowledgement:
+
+- Possible person names found through local context labels such as `Name:`,
+  `Patient`, `Paciente`, `Nom`, `Naam`, or `Name`.
+- Standalone exact dates without patient-care context.
+- Standalone postal codes.
+- Organization or place-like text detected only through labels.
+
+On override, high-confidence findings are redacted silently and locally. The
+modal must explain this before submission:
+
+> High-confidence identifiers will be redacted locally before submission. Other
+> possible identifiers may remain if you continue.
+
+The user must never be offered a path that sends high-confidence identifiers
+unchanged.
+
+### Submission Flow
+
+Update `frontend/src/composables/useQueryInterfaceController.js`.
+
+Current submission flow constructs the conversation turn, clears the input, logs
+metadata, and then calls `queryHpo()` or `processText()`. The PII guard must run
+before those actions.
+
+New flow:
+
+1. Trim submitted text.
+2. Determine active submission mode: Query or Full Text.
+3. Scan local text using current UI locale and all global rules.
+4. If no findings exist, continue with current flow.
+5. If findings exist, open a PII review dialog and stop before adding a
+   conversation turn or calling the API.
+6. If the user cancels, keep the original text in the input field and do not log
+   findings beyond category counts.
+7. If the user chooses redaction, apply high-confidence redaction and optionally
+   review-confidence redaction, update the input field, and do not submit until
+   the user clicks submit again.
+8. If the user chooses override/continue, apply high-confidence redaction in
+   memory and submit that redacted text. Review-confidence text remains only
+   after acknowledgement.
+
+Auto-submit from URL parameters must not bypass the gate. If `autoSubmit=true`
+and PII findings exist, the dialog opens and no API call happens until the user
+acts.
+
+### UI Component
+
+Create `frontend/src/components/PiiReviewDialog.vue`.
+
+The dialog should show:
+
+- concise title: `Possible identifiers detected`
+- categories and counts, not snippets
+- confidence grouping: `Will be redacted` and `Needs review`
+- short public-demo warning aligned with existing research-use posture
+- actions:
+  - `Review text` or `Cancel` keeps text local and closes the dialog
+  - `Redact in text` replaces all findings in the input and does not submit
+  - `Continue with local redaction` submits with high-confidence redactions and
+    acknowledged review-confidence findings
+
+The dialog should use existing Vuetify patterns and i18n keys. It must work at
+mobile widths without overflowing.
+
+### I18n
+
+Add UI copy to all current locale files:
+
+- `frontend/src/locales/en.json`
+- `frontend/src/locales/de.json`
+- `frontend/src/locales/fr.json`
+- `frontend/src/locales/es.json`
+- `frontend/src/locales/nl.json`
+
+Locale-specific detector labels belong in `ruleConfig.js` rather than the UI
+translation files. UI translation files are for user-facing dialog text only.
+
+### Logging And Privacy
+
+Update frontend logging around submission so raw text is not logged.
+
+Current `submitQuery()` logs request objects for both Query and Full Text paths.
+That is incompatible with this feature. Replace those logs with metadata-only
+events:
+
+- mode
+- text length
+- extraction backend for Full Text
+- selected language
+- category counts from PII scan
+- whether high-confidence redaction was applied
+
+Do not log:
+
+- raw query text
+- raw full note text
+- matched snippets
+- finding offsets
+- redacted text
+
+### Documentation
+
+Update `docs/compliance/privacy-and-llm-processing.md` with:
+
+- browser-side PII warning and redaction behavior
+- five-language scope
+- high-confidence local redaction on override
+- limitation that this is not a guarantee and not legal de-identification
+- reminder not to submit identifiable patient data to public demos
+
+Update frontend usage docs if a user-facing frontend guide already describes
+submission or public demo privacy behavior.
+
+## Testing Strategy
+
+### Unit Tests
+
+Add tests under `frontend/src/test/pii/`.
+
+Detector tests:
+
+- high-confidence email, phone, URL, IP, MRN, sample/accession IDs
+- exact dates with and without DOB/admission/discharge context
+- no false positive for common HPO IDs such as `HP:0001250`
+- no false positive for model identifiers or threshold values
+- overlapping findings are merged deterministically
+- redaction preserves surrounding text and uses category tokens
+
+Locale tests:
+
+- English: `DOB`, `MRN`, `Patient ID`
+- German: `Geburtsdatum`, `Krankenversichertennummer`, KVNR-like value
+- French: `date de naissance`, NIR-like value
+- Spanish: `fecha de nacimiento`, DNI/NIE checksum-positive value
+- Dutch: `geboortedatum`, BSN checksum-positive value, Dutch postcode plus
+  house number
+
+Validator tests:
+
+- Spanish DNI/NIE accepts valid checksums and rejects invalid checksums.
+- Dutch BSN accepts valid modulus-11 numbers and rejects invalid numbers.
+- Validator failures downgrade or discard findings according to rule config.
+
+### Component And Flow Tests
+
+Extend `frontend/src/test/components/QueryInterface.test.js` or add a focused
+PII submission test file.
+
+Required cases:
+
+- Query mode with PII opens dialog and does not call `queryHpo()`.
+- Full Text mode with PII opens dialog and does not call `processText()`.
+- Auto-submit with PII opens dialog and performs no network call before user
+  action.
+- `Continue with local redaction` submits redacted text.
+- `Redact in text` updates the input and does not submit immediately.
+- Cancel keeps original text local.
+- Logs contain counts and categories but not raw snippets.
+
+### Documentation And I18n Checks
+
+Run locale validation for UI copy changes:
+
+- `make frontend-i18n-check`
+
+Run frontend parity checks:
+
+- `make frontend-test-ci`
+- `make frontend-build-ci`
+
+Before completion of implementation, run repository-required checks:
+
+- `make check`
+- `make typecheck-fast`
+- `make test`
+
+## Open Risks
+
+- Names are difficult to detect with deterministic browser rules, especially
+  across five languages. The first version should be conservative and use name
+  label context rather than broad capitalized-word heuristics.
+- Exact dates are clinically useful. Redacting all standalone dates would reduce
+  utility, so the first version treats context-labeled patient-care dates as
+  high-confidence and standalone dates as review-confidence.
+- Frontend-only checks are bypassable. This design is appropriate for the
+  issue's browser-before-network acceptance criteria, but backend operators
+  should still avoid raw-text logging and may add server-side controls later.
+- Locale configuration can grow large. Keep the first rule set focused on direct
+  identifiers and high-signal context patterns.
+
+## Acceptance Criteria Mapping
+
+- Local browser-only detection: `frontend/src/pii/*` runs before service calls.
+- Category review and local redaction: `PiiReviewDialog.vue` shows counts and
+  redaction actions without snippets.
+- Override behavior: users can continue only after high-confidence findings are
+  locally redacted and review-confidence findings are acknowledged.
+- No network before review: controller flow stops before `queryHpo()` or
+  `processText()` when findings exist.
+- Tests: detector, redactor, locale, validator, component, auto-submit, and
+  logging tests cover the behavior.
+- Documentation: compliance docs and UI copy state that this is a safety aid,
+  not a guarantee.

--- a/.planning/specs/2026-04-30-untitled-local-person-name-pii-design.md
+++ b/.planning/specs/2026-04-30-untitled-local-person-name-pii-design.md
@@ -1,0 +1,76 @@
+# Untitled Local Person Name PII Design
+
+## Goal
+
+Improve the browser-only PII guard so it can flag likely person names without
+titles, such as `Bernt Popp`, before any query or full-text network request.
+
+## Scope
+
+This is a local, deterministic safety aid. It does not attempt guaranteed
+de-identification or anonymisation, and it does not call a server or external
+model. Untitled person-name matches are review-confidence only.
+
+## Approach
+
+Add a config-driven `possible_name` recognizer in the frontend PII layer. The
+recognizer generates name-shaped candidates from adjacent capitalized tokens and
+scores them with locale-aware context, particles, and blocklists.
+
+The recognizer runs across all configured PII locales, matching the current
+cross-locale PII behavior. It emits `person_name` findings with
+`confidence: "review"` and `redactionToken: "[REDACTED_NAME]"`.
+
+## Detection Rules
+
+A candidate is eligible when it contains at least two name-shaped tokens, with
+optional locale particles between them. Examples:
+
+- `Bernt Popp`
+- `Jean Dupont`
+- `María García`
+- `Jan van Dijk`
+
+The score starts from token shape and is adjusted using config:
+
+- Add score for explicit nearby context such as `name`, `patient`, `Patient`,
+  `Name`, `Vorname`, `Nachname`, `Paciente`, `Nom`, `Naam`.
+- Add score for valid locale particles such as `van`, `von`, `de`, `del`,
+  `da`, `le`.
+- Subtract score or reject candidates containing blocked medical/domain terms,
+  HPO IDs, model-like tokens, all-caps identifiers, or known ontology/model
+  words.
+
+The default threshold flags full-name-shaped candidates like `Bernt Popp ist
+dumm`, while avoiding common clinical/domain phrases like `Pectus Carinatum`,
+`Down Syndrome`, `BioLORD Model`, and `HP:0002779 Tracheomalacia`.
+
+## UI Behavior
+
+Untitled name findings use the existing PII review dialog. They appear under
+review-confidence `Name` findings. The user can choose `Redact in text` to
+replace review findings locally. Continuing without manual redaction still only
+auto-redacts high-confidence findings, preserving current behavior.
+
+## Non-Goals
+
+- No Transformers.js or model-based NER in this change.
+- No backend PII detector.
+- No high-confidence auto-redaction for untitled names.
+- No raw matched text, snippets, offsets beyond existing local-only offsets, or
+  redacted text in logs.
+
+## Tests
+
+Add detector tests for:
+
+- Untitled two-token names across all supported locales.
+- Particle names such as `Jan van Dijk`.
+- Cross-locale detection while selected language is English.
+- Non-matches for clinical/domain phrases and IDs.
+
+Add QueryInterface tests for:
+
+- Query mode opens PII review and sends no network request for an untitled name.
+- Full Text mode opens PII review and sends no network request for an untitled
+  name.

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -4,5 +4,5 @@
 
 [project]
 name = "phentrieve-api"
-version = "0.11.0"
+version = "0.12.0"
 description = "FastAPI backend for Phentrieve HPO term mapping"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "phentrieve-frontend",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "phentrieve-frontend",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@berntpopp/phenopackets-js": "^1.0.2",
         "axios": "^1.15.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phentrieve-frontend",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/pii/detector.js
+++ b/frontend/src/pii/detector.js
@@ -162,17 +162,22 @@ function rulesForLocale(locale) {
   }
 }
 
+function localesForScan(locale) {
+  return [
+    locale,
+    ...SUPPORTED_PII_LOCALES.filter((supportedLocale) => supportedLocale !== locale),
+  ];
+}
+
 export function scanPii(text, { locale = 'en', includeGlobalRules = true } = {}) {
   const normalizedLocale = SUPPORTED_PII_LOCALES.includes(locale) ? locale : 'en';
   const source = String(text ?? '');
-  const configuredRules = [
-    ...(includeGlobalRules ? GLOBAL_RULES : []),
-    ...rulesForLocale(normalizedLocale),
-  ];
+  const scanLocales = localesForScan(normalizedLocale);
   const findings = mergeOverlappingFindings([
-    ...applyRules(source, configuredRules, normalizedLocale),
-    ...(includeGlobalRules ? applyPhoneRule(source, normalizedLocale) : []),
-    ...applyAddressRule(source, normalizedLocale),
+    ...(includeGlobalRules ? applyRules(source, GLOBAL_RULES, normalizedLocale) : []),
+    ...scanLocales.flatMap((scanLocale) => applyRules(source, rulesForLocale(scanLocale), scanLocale)),
+    ...(includeGlobalRules ? scanLocales.flatMap((scanLocale) => applyPhoneRule(source, scanLocale)) : []),
+    ...scanLocales.flatMap((scanLocale) => applyAddressRule(source, scanLocale)),
   ]);
 
   const summary = createSummary();

--- a/frontend/src/pii/detector.js
+++ b/frontend/src/pii/detector.js
@@ -11,6 +11,7 @@ import { VALIDATORS } from './validators';
 const WORD_PATTERN = /[A-Za-zÀ-ÖØ-öø-ÿß'-]+/gu;
 const NAME_TOKEN_PATTERN = /^[A-ZÀ-ÖØ-Þ][A-Za-zÀ-ÖØ-öø-ÿß'-]*$/u;
 const CODE_LIKE_PATTERN = /(?:\d|[A-Z]{2,}[:_-]?\d|[a-z][A-Z])/u;
+const ALL_CAPS_TOKEN_PATTERN = /^[A-ZÀ-ÖØ-Þ]{2,}$/u;
 
 function createSummary() {
   return { high: {}, review: {} };
@@ -85,7 +86,7 @@ function regionForLocale(locale) {
 
 function applyPhoneRule(text, locale) {
   return findPhoneNumbersInText(text, regionForLocale(locale)).map((match, index) => ({
-    id: `global.phone-${index}`,
+    id: `global.phone-${locale}-${index}-${match.startsAt}-${match.endsAt}`,
     ruleId: 'global.phone',
     category: 'phone',
     confidence: 'high',
@@ -133,7 +134,7 @@ function applyAddressRule(text, locale) {
 }
 
 function normalizeNameToken(token) {
-  return String(token ?? '').toLocaleLowerCase();
+  return String(token ?? '').toLowerCase();
 }
 
 function tokenizeWords(text) {
@@ -156,6 +157,7 @@ function isNameToken(token, config) {
     value.length >= 2 &&
     NAME_TOKEN_PATTERN.test(value) &&
     !CODE_LIKE_PATTERN.test(value) &&
+    !ALL_CAPS_TOKEN_PATTERN.test(value) &&
     !config.blockedTerms.includes(normalizeNameToken(value))
   );
 }
@@ -171,8 +173,8 @@ function hasOnlyNameSeparators(text, previous, next) {
 function hasNameContext(text, candidate, config) {
   const start = Math.max(0, candidate.start - config.contextWindowChars);
   const end = Math.min(text.length, candidate.end + config.contextWindowChars);
-  const context = text.slice(start, end).toLocaleLowerCase();
-  return config.contextWords.some((word) => context.includes(word.toLocaleLowerCase()));
+  const context = text.slice(start, end).toLowerCase();
+  return config.contextWords.some((word) => context.includes(word.toLowerCase()));
 }
 
 function scoreNameCandidate(text, candidate, config) {
@@ -213,7 +215,9 @@ function applyUntitledNameRule(text, config = UNTITLED_NAME_RULE_CONFIG) {
     let previous = firstToken;
     const candidateTokens = [firstToken];
 
-    for (const next of tokens.slice(index + 1)) {
+    for (let nextIndex = index + 1; nextIndex < tokens.length; nextIndex += 1) {
+      // eslint-disable-next-line security/detect-object-injection -- Bounded numeric token scan avoids per-token slice allocations.
+      const next = tokens[nextIndex];
       if (candidateTokens.length >= config.maxTokens) break;
       if (!hasOnlyNameSeparators(text, previous, next)) break;
 

--- a/frontend/src/pii/detector.js
+++ b/frontend/src/pii/detector.js
@@ -1,6 +1,16 @@
 import { findPhoneNumbersInText } from 'libphonenumber-js';
-import { ADDRESS_RULES, GLOBAL_RULES, LOCALE_RULES, SUPPORTED_PII_LOCALES } from './ruleConfig';
+import {
+  ADDRESS_RULES,
+  GLOBAL_RULES,
+  LOCALE_RULES,
+  SUPPORTED_PII_LOCALES,
+  UNTITLED_NAME_RULE_CONFIG,
+} from './ruleConfig';
 import { VALIDATORS } from './validators';
+
+const WORD_PATTERN = /[A-Za-zÀ-ÖØ-öø-ÿß'-]+/gu;
+const NAME_TOKEN_PATTERN = /^[A-ZÀ-ÖØ-Þ][A-Za-zÀ-ÖØ-öø-ÿß'-]*$/u;
+const CODE_LIKE_PATTERN = /(?:\d|[A-Z]{2,}[:_-]?\d|[a-z][A-Z])/u;
 
 function createSummary() {
   return { high: {}, review: {} };
@@ -122,6 +132,123 @@ function applyAddressRule(text, locale) {
   return findings;
 }
 
+function normalizeNameToken(token) {
+  return String(token ?? '').toLocaleLowerCase();
+}
+
+function tokenizeWords(text) {
+  const tokens = [];
+  WORD_PATTERN.lastIndex = 0;
+  let match;
+  while ((match = WORD_PATTERN.exec(text)) !== null) {
+    tokens.push({
+      value: match[0],
+      start: match.index,
+      end: match.index + match[0].length,
+    });
+  }
+  return tokens;
+}
+
+function isNameToken(token, config) {
+  const value = token.value;
+  return (
+    value.length >= 2 &&
+    NAME_TOKEN_PATTERN.test(value) &&
+    !CODE_LIKE_PATTERN.test(value) &&
+    !config.blockedTerms.includes(normalizeNameToken(value))
+  );
+}
+
+function isNameParticle(token, config) {
+  return config.particles.includes(normalizeNameToken(token.value));
+}
+
+function hasOnlyNameSeparators(text, previous, next) {
+  return /^[\s'-]+$/u.test(text.slice(previous.end, next.start));
+}
+
+function hasNameContext(text, candidate, config) {
+  const start = Math.max(0, candidate.start - config.contextWindowChars);
+  const end = Math.min(text.length, candidate.end + config.contextWindowChars);
+  const context = text.slice(start, end).toLocaleLowerCase();
+  return config.contextWords.some((word) => context.includes(word.toLocaleLowerCase()));
+}
+
+function scoreNameCandidate(text, candidate, config) {
+  const normalizedValues = candidate.tokens.map((token) => normalizeNameToken(token.value));
+  if (normalizedValues.some((value) => config.blockedTerms.includes(value))) {
+    return 0;
+  }
+
+  let score = candidate.nameTokenCount >= config.minNameTokens ? 2 : 0;
+  if (candidate.hasParticle) score += 1;
+  if (hasNameContext(text, candidate, config)) score += 2;
+  return score;
+}
+
+function buildUntitledNameFinding(candidate, index, config) {
+  return {
+    id: `${config.id}-${index}`,
+    ruleId: config.id,
+    category: config.category,
+    confidence: config.confidence,
+    start: candidate.start,
+    end: candidate.end,
+    redactionToken: config.redactionToken,
+  };
+}
+
+function applyUntitledNameRule(text, config = UNTITLED_NAME_RULE_CONFIG) {
+  if (!config.enabled) return [];
+
+  const tokens = tokenizeWords(text);
+  const findings = [];
+  for (const [index, firstToken] of tokens.entries()) {
+    if (!isNameToken(firstToken, config)) continue;
+
+    let candidate = null;
+    let nameTokenCount = 1;
+    let hasParticle = false;
+    let previous = firstToken;
+    const candidateTokens = [firstToken];
+
+    for (const next of tokens.slice(index + 1)) {
+      if (candidateTokens.length >= config.maxTokens) break;
+      if (!hasOnlyNameSeparators(text, previous, next)) break;
+
+      if (isNameParticle(next, config)) {
+        hasParticle = true;
+        candidateTokens.push(next);
+        previous = next;
+        continue;
+      }
+
+      if (!isNameToken(next, config)) break;
+
+      nameTokenCount += 1;
+      candidateTokens.push(next);
+      previous = next;
+      if (nameTokenCount >= config.minNameTokens) {
+        candidate = {
+          start: firstToken.start,
+          end: next.end,
+          tokens: [...candidateTokens],
+          nameTokenCount,
+          hasParticle,
+        };
+      }
+    }
+
+    if (!candidate) continue;
+    if (scoreNameCandidate(text, candidate, config) < config.minScore) continue;
+
+    findings.push(buildUntitledNameFinding(candidate, findings.length, config));
+  }
+
+  return findings;
+}
+
 function mergeOverlappingFindings(findings) {
   const sorted = [...findings].sort((a, b) => a.start - b.start || a.end - b.end);
   const merged = [];
@@ -176,6 +303,7 @@ export function scanPii(text, { locale = 'en', includeGlobalRules = true } = {})
   const findings = mergeOverlappingFindings([
     ...(includeGlobalRules ? applyRules(source, GLOBAL_RULES, normalizedLocale) : []),
     ...scanLocales.flatMap((scanLocale) => applyRules(source, rulesForLocale(scanLocale), scanLocale)),
+    ...applyUntitledNameRule(source),
     ...(includeGlobalRules ? scanLocales.flatMap((scanLocale) => applyPhoneRule(source, scanLocale)) : []),
     ...scanLocales.flatMap((scanLocale) => applyAddressRule(source, scanLocale)),
   ]);

--- a/frontend/src/pii/detector.js
+++ b/frontend/src/pii/detector.js
@@ -290,10 +290,7 @@ function rulesForLocale(locale) {
 }
 
 function localesForScan(locale) {
-  return [
-    locale,
-    ...SUPPORTED_PII_LOCALES.filter((supportedLocale) => supportedLocale !== locale),
-  ];
+  return [locale, ...SUPPORTED_PII_LOCALES.filter((supportedLocale) => supportedLocale !== locale)];
 }
 
 export function scanPii(text, { locale = 'en', includeGlobalRules = true } = {}) {
@@ -302,9 +299,13 @@ export function scanPii(text, { locale = 'en', includeGlobalRules = true } = {})
   const scanLocales = localesForScan(normalizedLocale);
   const findings = mergeOverlappingFindings([
     ...(includeGlobalRules ? applyRules(source, GLOBAL_RULES, normalizedLocale) : []),
-    ...scanLocales.flatMap((scanLocale) => applyRules(source, rulesForLocale(scanLocale), scanLocale)),
+    ...scanLocales.flatMap((scanLocale) =>
+      applyRules(source, rulesForLocale(scanLocale), scanLocale)
+    ),
     ...applyUntitledNameRule(source),
-    ...(includeGlobalRules ? scanLocales.flatMap((scanLocale) => applyPhoneRule(source, scanLocale)) : []),
+    ...(includeGlobalRules
+      ? scanLocales.flatMap((scanLocale) => applyPhoneRule(source, scanLocale))
+      : []),
     ...scanLocales.flatMap((scanLocale) => applyAddressRule(source, scanLocale)),
   ]);
 

--- a/frontend/src/pii/ruleConfig.js
+++ b/frontend/src/pii/ruleConfig.js
@@ -12,6 +12,51 @@ const TITLED_NAME_RULE_CONFIG = Object.freeze({
   nl: { id: 'nl.titled_name', titles: ['Dhr', 'Mevrouw', 'Mw', 'Dr', 'Prof'] },
 });
 
+export const UNTITLED_NAME_RULE_CONFIG = Object.freeze({
+  id: 'global.untitled_name',
+  category: 'person_name',
+  confidence: 'review',
+  redactionToken: '[REDACTED_NAME]',
+  enabled: true,
+  minScore: 2,
+  minNameTokens: 2,
+  maxTokens: 4,
+  contextWindowChars: 32,
+  particles: ['de', 'del', 'da', 'di', 'du', 'le', 'la', 'van', 'von', 'der', 'den'],
+  contextWords: [
+    'called',
+    'case',
+    'name',
+    'patient',
+    'subject',
+    'Nachname',
+    'Name',
+    'Patient',
+    'Vorname',
+    'Naam',
+    'Patiënt',
+    'Nom',
+    'Patient',
+    'Paciente',
+    'paciente',
+  ],
+  blockedTerms: [
+    'abnormality',
+    'biolord',
+    'carinatum',
+    'clinical',
+    'disease',
+    'down',
+    'hpo',
+    'model',
+    'pectus',
+    'phenotype',
+    'syndrome',
+    'term',
+    'tracheomalacia',
+  ],
+});
+
 function escapeRegex(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
 }

--- a/frontend/src/pii/ruleConfig.js
+++ b/frontend/src/pii/ruleConfig.js
@@ -2,6 +2,40 @@ export const SUPPORTED_PII_LOCALES = Object.freeze(['en', 'de', 'fr', 'es', 'nl'
 
 export const DATE_PATTERN = /\b(?:\d{1,2}[./-]\d{1,2}[./-]\d{2,4}|\d{4}-\d{2}-\d{2})\b/gu;
 const ID_VALUE_PATTERN = /\b[A-Z]{0,4}[- ]?\d{4,12}[A-Z0-9-]*\b/giu;
+const PERSON_NAME_TOKEN = '[A-ZÀ-ÖØ-Þ][A-Za-zÀ-ÖØ-öø-ÿß-]+';
+
+const TITLED_NAME_RULE_CONFIG = Object.freeze({
+  en: { id: 'en.titled_name', titles: ['Mr', 'Mrs', 'Ms', 'Dr', 'Prof'] },
+  de: { id: 'de.titled_name', titles: ['Herr', 'Frau', 'Dr', 'Prof'] },
+  fr: { id: 'fr.titled_name', titles: ['Monsieur', 'Madame', 'M', 'Mme', 'Dr', 'Prof'] },
+  es: { id: 'es.titled_name', titles: ['Señor', 'Señora', 'Sr', 'Sra', 'Dr', 'Dra'] },
+  nl: { id: 'nl.titled_name', titles: ['Dhr', 'Mevrouw', 'Mw', 'Dr', 'Prof'] },
+});
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+}
+
+function createTitledNameRule(locale, config) {
+  const titlePattern = config.titles.map(escapeRegex).join('|');
+  const optionalDot = '\\.?';
+
+  return {
+    id: config.id,
+    category: 'person_name',
+    confidence: 'review',
+    locales: [locale],
+    redactionToken: '[REDACTED_NAME]',
+    enabled: true,
+    patterns: [
+      // Titles come from static locale config and are escaped before RegExp construction.
+      // eslint-disable-next-line security/detect-non-literal-regexp
+      new RegExp(`\\b(?:${titlePattern})${optionalDot}\\s+${PERSON_NAME_TOKEN}\\s+${PERSON_NAME_TOKEN}\\b`, 'gu'),
+      // eslint-disable-next-line security/detect-non-literal-regexp
+      new RegExp(`\\b(?:${titlePattern})${optionalDot}\\s+${PERSON_NAME_TOKEN}\\b`, 'gu'),
+    ],
+  };
+}
 
 export const GLOBAL_RULES = Object.freeze([
   {
@@ -44,6 +78,7 @@ export const GLOBAL_RULES = Object.freeze([
 
 export const LOCALE_RULES = Object.freeze({
   en: [
+    createTitledNameRule('en', TITLED_NAME_RULE_CONFIG.en),
     {
       id: 'en.dob',
       category: 'dob',
@@ -66,6 +101,7 @@ export const LOCALE_RULES = Object.freeze({
     },
   ],
   de: [
+    createTitledNameRule('de', TITLED_NAME_RULE_CONFIG.de),
     {
       id: 'de.dob',
       category: 'dob',
@@ -89,6 +125,7 @@ export const LOCALE_RULES = Object.freeze({
     },
   ],
   fr: [
+    createTitledNameRule('fr', TITLED_NAME_RULE_CONFIG.fr),
     {
       id: 'fr.nir',
       category: 'national_identifier',
@@ -101,6 +138,7 @@ export const LOCALE_RULES = Object.freeze({
     },
   ],
   es: [
+    createTitledNameRule('es', TITLED_NAME_RULE_CONFIG.es),
     {
       id: 'es.dni_nie',
       category: 'national_identifier',
@@ -122,6 +160,7 @@ export const LOCALE_RULES = Object.freeze({
     },
   ],
   nl: [
+    createTitledNameRule('nl', TITLED_NAME_RULE_CONFIG.nl),
     {
       id: 'nl.bsn',
       category: 'national_identifier',

--- a/frontend/src/pii/ruleConfig.js
+++ b/frontend/src/pii/ruleConfig.js
@@ -2,7 +2,9 @@ export const SUPPORTED_PII_LOCALES = Object.freeze(['en', 'de', 'fr', 'es', 'nl'
 
 export const DATE_PATTERN = /\b(?:\d{1,2}[./-]\d{1,2}[./-]\d{2,4}|\d{4}-\d{2}-\d{2})\b/gu;
 const ID_VALUE_PATTERN = /\b[A-Z]{0,4}[- ]?\d{4,12}[A-Z0-9-]*\b/giu;
-const PERSON_NAME_TOKEN = '[A-ZÀ-ÖØ-Þ][A-Za-zÀ-ÖØ-öø-ÿß-]+';
+const PERSON_NAME_TOKEN = String.raw`\p{Lu}[\p{L}\p{M}'-]+`;
+const LETTER_LEFT_BOUNDARY = String.raw`(?<![\p{L}\p{M}])`;
+const LETTER_RIGHT_BOUNDARY = String.raw`(?![\p{L}\p{M}])`;
 
 const TITLED_NAME_RULE_CONFIG = Object.freeze({
   en: { id: 'en.titled_name', titles: ['Mr', 'Mrs', 'Ms', 'Dr', 'Prof'] },
@@ -85,11 +87,14 @@ function createTitledNameRule(locale, config) {
       // Titles come from static locale config and are escaped before RegExp construction.
       // eslint-disable-next-line security/detect-non-literal-regexp
       new RegExp(
-        `\\b(?:${titlePattern})${optionalDot}\\s+${PERSON_NAME_TOKEN}\\s+${PERSON_NAME_TOKEN}\\b`,
+        `${LETTER_LEFT_BOUNDARY}(?:${titlePattern})${optionalDot}\\s+${PERSON_NAME_TOKEN}\\s+${PERSON_NAME_TOKEN}${LETTER_RIGHT_BOUNDARY}`,
         'gu'
       ),
       // eslint-disable-next-line security/detect-non-literal-regexp
-      new RegExp(`\\b(?:${titlePattern})${optionalDot}\\s+${PERSON_NAME_TOKEN}\\b`, 'gu'),
+      new RegExp(
+        `${LETTER_LEFT_BOUNDARY}(?:${titlePattern})${optionalDot}\\s+${PERSON_NAME_TOKEN}${LETTER_RIGHT_BOUNDARY}`,
+        'gu'
+      ),
     ],
   };
 }

--- a/frontend/src/pii/ruleConfig.js
+++ b/frontend/src/pii/ruleConfig.js
@@ -43,17 +43,26 @@ export const UNTITLED_NAME_RULE_CONFIG = Object.freeze({
   blockedTerms: [
     'abnormality',
     'biolord',
+    'called',
     'carinatum',
+    'case',
     'clinical',
     'disease',
     'down',
     'hpo',
     'model',
+    'naam',
+    'nachname',
+    'name',
+    'nom',
+    'paciente',
+    'patient',
     'pectus',
     'phenotype',
     'syndrome',
     'term',
     'tracheomalacia',
+    'vorname',
   ],
 });
 
@@ -75,7 +84,10 @@ function createTitledNameRule(locale, config) {
     patterns: [
       // Titles come from static locale config and are escaped before RegExp construction.
       // eslint-disable-next-line security/detect-non-literal-regexp
-      new RegExp(`\\b(?:${titlePattern})${optionalDot}\\s+${PERSON_NAME_TOKEN}\\s+${PERSON_NAME_TOKEN}\\b`, 'gu'),
+      new RegExp(
+        `\\b(?:${titlePattern})${optionalDot}\\s+${PERSON_NAME_TOKEN}\\s+${PERSON_NAME_TOKEN}\\b`,
+        'gu'
+      ),
       // eslint-disable-next-line security/detect-non-literal-regexp
       new RegExp(`\\b(?:${titlePattern})${optionalDot}\\s+${PERSON_NAME_TOKEN}\\b`, 'gu'),
     ],
@@ -142,7 +154,9 @@ export const LOCALE_RULES = Object.freeze({
       locales: ['en'],
       redactionToken: '[REDACTED_MRN]',
       enabled: true,
-      patterns: [/(?:MRN|medical record number|patient ID|NHS number)\s*[:#-]?\s*[A-Z0-9 -]{4,24}/giu],
+      patterns: [
+        /(?:MRN|medical record number|patient ID|NHS number)\s*[:#-]?\s*[A-Z0-9 -]{4,24}/giu,
+      ],
     },
   ],
   de: [
@@ -178,7 +192,9 @@ export const LOCALE_RULES = Object.freeze({
       locales: ['fr'],
       redactionToken: '[REDACTED_NATIONAL_ID]',
       enabled: true,
-      patterns: [/(?:NIR|numéro de sécurité sociale|securite sociale)\s*[:#-]?\s*[12][\d .-]{12,20}/giu],
+      patterns: [
+        /(?:NIR|numéro de sécurité sociale|securite sociale)\s*[:#-]?\s*[12][\d .-]{12,20}/giu,
+      ],
       validator: 'validateFrenchNir',
     },
   ],
@@ -201,7 +217,9 @@ export const LOCALE_RULES = Object.freeze({
       locales: ['es'],
       redactionToken: '[REDACTED_MRN]',
       enabled: true,
-      patterns: [/(?:número de historia clínica|historia clínica|paciente id)\s*[:#-]?\s*[A-Z0-9 -]{4,24}/giu],
+      patterns: [
+        /(?:número de historia clínica|historia clínica|paciente id)\s*[:#-]?\s*[A-Z0-9 -]{4,24}/giu,
+      ],
     },
   ],
   nl: [

--- a/frontend/src/services/PhentrieveService.js
+++ b/frontend/src/services/PhentrieveService.js
@@ -13,7 +13,7 @@ const API_URL = import.meta.env.VITE_API_URL || '/api/v1'; // Default to relativ
 const RESEARCH_USE_ACK_CONFIG = Object.freeze({
   headers: { 'X-Phentrieve-Research-Use-Acknowledged': 'true' },
 });
-const getSerializedSize = value => JSON.stringify(value)?.length || 0;
+const getSerializedSize = (value) => JSON.stringify(value)?.length || 0;
 const GENERIC_API_DETAIL = 'API returned an error. See status code for details.';
 
 class PhentrieveService {
@@ -256,10 +256,7 @@ class PhentrieveService {
       standardError.userMessageKey = 'errors.api.network';
     } else if (error.response) {
       standardError.type = 'API_ERROR';
-      const { key, params } = this._getErrorMessageKeyForStatus(
-        error.response.status,
-        ''
-      );
+      const { key, params } = this._getErrorMessageKeyForStatus(error.response.status, '');
       standardError.userMessageKey = key;
       standardError.userMessageParams = params;
       if (

--- a/frontend/src/test/components/QueryInterface.test.js
+++ b/frontend/src/test/components/QueryInterface.test.js
@@ -1003,6 +1003,24 @@ describe('QueryInterface (characterization)', () => {
     expect(wrapper.vm.piiReviewDialogVisible).toBe(true);
   });
 
+  it('opens PII review for configured titled names even when query language is English', async () => {
+    const wrapper = await mountQueryInterface();
+    await flushPromises();
+
+    await setVmState(wrapper, {
+      queryText: 'Herr Bernt Popp ist dumm',
+      selectedLanguage: 'en',
+      forceEndpointMode: 'query',
+    });
+
+    await wrapper.vm.submitQuery();
+    await wrapper.vm.$nextTick();
+
+    expect(PhentrieveService.queryHpo).not.toHaveBeenCalled();
+    expect(wrapper.vm.piiReviewDialogVisible).toBe(true);
+    expect(wrapper.vm.pendingPiiSubmission.scanResult.summary.review.person_name).toBe(1);
+  });
+
   it('opens PII review before full-text network submission', async () => {
     const wrapper = await mountQueryInterface();
     await flushPromises();

--- a/frontend/src/test/components/QueryInterface.test.js
+++ b/frontend/src/test/components/QueryInterface.test.js
@@ -1021,6 +1021,24 @@ describe('QueryInterface (characterization)', () => {
     expect(wrapper.vm.pendingPiiSubmission.scanResult.summary.review.person_name).toBe(1);
   });
 
+  it('opens PII review for untitled names before query-mode network submission', async () => {
+    const wrapper = await mountQueryInterface();
+    await flushPromises();
+
+    await setVmState(wrapper, {
+      queryText: 'Bernt Popp ist dumm',
+      selectedLanguage: 'en',
+      forceEndpointMode: 'query',
+    });
+
+    await wrapper.vm.submitQuery();
+    await wrapper.vm.$nextTick();
+
+    expect(PhentrieveService.queryHpo).not.toHaveBeenCalled();
+    expect(wrapper.vm.piiReviewDialogVisible).toBe(true);
+    expect(wrapper.vm.pendingPiiSubmission.scanResult.summary.review.person_name).toBe(1);
+  });
+
   it('opens PII review before full-text network submission', async () => {
     const wrapper = await mountQueryInterface();
     await flushPromises();
@@ -1036,6 +1054,24 @@ describe('QueryInterface (characterization)', () => {
     expect(PhentrieveService.processText).not.toHaveBeenCalled();
     expect(wrapper.vm.conversationStore.queryHistory).toHaveLength(0);
     expect(wrapper.vm.piiReviewDialogVisible).toBe(true);
+  });
+
+  it('opens PII review for untitled names before full-text network submission', async () => {
+    const wrapper = await mountQueryInterface();
+    await flushPromises();
+
+    await setVmState(wrapper, {
+      queryText: 'Bernt Popp ist dumm',
+      selectedLanguage: 'en',
+      forceEndpointMode: 'textProcess',
+    });
+
+    await wrapper.vm.submitQuery();
+    await wrapper.vm.$nextTick();
+
+    expect(PhentrieveService.processText).not.toHaveBeenCalled();
+    expect(wrapper.vm.piiReviewDialogVisible).toBe(true);
+    expect(wrapper.vm.pendingPiiSubmission.scanResult.summary.review.person_name).toBe(1);
   });
 
   it('clears autoSubmit from the URL when manual submission opens PII review', async () => {

--- a/frontend/src/test/pii/detector.test.js
+++ b/frontend/src/test/pii/detector.test.js
@@ -37,6 +37,25 @@ describe('scanPii', () => {
     expect(result.summary.high.national_identifier).toBe(1);
   });
 
+  it('marks German titled person names as review confidence', () => {
+    const result = scanPii('Herr Bernt Popp ist dumm', { locale: 'de' });
+
+    expect(result.summary.review.person_name).toBe(1);
+    expect(result.findings[0]).not.toHaveProperty('text');
+  });
+
+  it.each([
+    ['en', 'Mr John Smith has seizures'],
+    ['fr', 'Monsieur Jean Dupont a des crises'],
+    ['es', 'Señor Juan Garcia tiene convulsiones'],
+    ['nl', 'Dhr Jan Jansen heeft aanvallen'],
+  ])('marks %s titled person names as review confidence', (locale, text) => {
+    const result = scanPii(text, { locale });
+
+    expect(result.summary.review.person_name).toBe(1);
+    expect(result.findings[0]).not.toHaveProperty('text');
+  });
+
   it('detects French NIR labels', () => {
     const result = scanPii('NIR 1900675123456 pour le patient.', { locale: 'fr' });
     expect(result.summary.high.national_identifier).toBe(1);

--- a/frontend/src/test/pii/detector.test.js
+++ b/frontend/src/test/pii/detector.test.js
@@ -63,6 +63,29 @@ describe('scanPii', () => {
     expect(result.findings[0]).not.toHaveProperty('text');
   });
 
+  it.each([
+    ['en', 'Bernt Popp ist dumm'],
+    ['fr', 'Jean Dupont a des crises'],
+    ['es', 'María García tiene convulsiones'],
+    ['nl', 'Jan van Dijk heeft aanvallen'],
+  ])('marks %s untitled person names as review confidence', (locale, text) => {
+    const result = scanPii(text, { locale });
+
+    expect(result.summary.review.person_name).toBe(1);
+    expect(result.findings[0]).not.toHaveProperty('text');
+  });
+
+  it.each([
+    ['Pectus Carinatum was noted.'],
+    ['Down Syndrome was discussed.'],
+    ['BioLORD Model returned results.'],
+    ['HP:0002779 Tracheomalacia'],
+  ])('does not mark clinical or domain phrases as untitled names: %s', (text) => {
+    const result = scanPii(text, { locale: 'en' });
+
+    expect(result.summary.review.person_name).toBeUndefined();
+  });
+
   it('detects French NIR labels', () => {
     const result = scanPii('NIR 1900675123456 pour le patient.', { locale: 'fr' });
     expect(result.summary.high.national_identifier).toBe(1);

--- a/frontend/src/test/pii/detector.test.js
+++ b/frontend/src/test/pii/detector.test.js
@@ -59,6 +59,16 @@ describe('scanPii', () => {
   });
 
   it.each([
+    ['fr', 'M René a des crises'],
+    ['es', 'Sr José tiene convulsiones'],
+  ])('marks %s titled person names with accented letters', (locale, text) => {
+    const result = scanPii(text, { locale });
+
+    expect(result.summary.review.person_name).toBe(1);
+    expect(result.findings[0]).not.toHaveProperty('text');
+  });
+
+  it.each([
     ['en', 'Mr Smith has seizures'],
     ['fr', 'M Dupont a des crises'],
     ['es', 'Sr Garcia tiene convulsiones'],

--- a/frontend/src/test/pii/detector.test.js
+++ b/frontend/src/test/pii/detector.test.js
@@ -23,6 +23,13 @@ describe('scanPii', () => {
     }
   });
 
+  it('keeps finding IDs unique when phone rules run across locales', () => {
+    const result = scanPii('Call +1 202 555 0199 or +31 20 123 4567.', { locale: 'en' });
+    const ids = result.findings.map((finding) => finding.id);
+
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
   it('detects English medical record labels', () => {
     const result = scanPii('MRN: AB-123456. Patient has seizures.', { locale: 'en' });
     expect(result.summary.high.medical_record).toBe(1);
@@ -38,24 +45,24 @@ describe('scanPii', () => {
   });
 
   it('marks German titled person names as review confidence', () => {
-    const result = scanPii('Herr Bernt Popp ist dumm', { locale: 'de' });
+    const result = scanPii('Herr Popp ist dumm', { locale: 'de' });
 
     expect(result.summary.review.person_name).toBe(1);
     expect(result.findings[0]).not.toHaveProperty('text');
   });
 
   it('marks configured titled person names even when the selected language differs', () => {
-    const result = scanPii('Herr Bernt Popp ist dumm', { locale: 'en' });
+    const result = scanPii('M Dupont a des crises', { locale: 'en' });
 
     expect(result.summary.review.person_name).toBe(1);
     expect(result.findings[0]).not.toHaveProperty('text');
   });
 
   it.each([
-    ['en', 'Mr John Smith has seizures'],
-    ['fr', 'Monsieur Jean Dupont a des crises'],
-    ['es', 'Señor Juan Garcia tiene convulsiones'],
-    ['nl', 'Dhr Jan Jansen heeft aanvallen'],
+    ['en', 'Mr Smith has seizures'],
+    ['fr', 'M Dupont a des crises'],
+    ['es', 'Sr Garcia tiene convulsiones'],
+    ['nl', 'Dhr Jansen heeft aanvallen'],
   ])('marks %s titled person names as review confidence', (locale, text) => {
     const result = scanPii(text, { locale });
 
@@ -102,6 +109,7 @@ describe('scanPii', () => {
     ['Pectus Carinatum was noted.'],
     ['Down Syndrome was discussed.'],
     ['BioLORD Model returned results.'],
+    ['Brain MRI was normal.'],
     ['HP:0002779 Tracheomalacia'],
   ])('does not mark clinical or domain phrases as untitled names: %s', (text) => {
     const result = scanPii(text, { locale: 'en' });

--- a/frontend/src/test/pii/detector.test.js
+++ b/frontend/src/test/pii/detector.test.js
@@ -64,7 +64,8 @@ describe('scanPii', () => {
   });
 
   it.each([
-    ['en', 'Bernt Popp ist dumm'],
+    ['en', 'John Smith has seizures'],
+    ['de', 'Bernt Popp ist dumm'],
     ['fr', 'Jean Dupont a des crises'],
     ['es', 'María García tiene convulsiones'],
     ['nl', 'Jan van Dijk heeft aanvallen'],
@@ -73,6 +74,28 @@ describe('scanPii', () => {
 
     expect(result.summary.review.person_name).toBe(1);
     expect(result.findings[0]).not.toHaveProperty('text');
+  });
+
+  it.each([
+    ['de', 'Bernt Popp ist dumm'],
+    ['fr', 'Jean Dupont a des crises'],
+    ['es', 'María García tiene convulsiones'],
+    ['nl', 'Jan van Dijk heeft aanvallen'],
+  ])('marks %s untitled person names when selected language is English', (_locale, text) => {
+    const result = scanPii(text, { locale: 'en' });
+
+    expect(result.summary.review.person_name).toBe(1);
+    expect(result.findings[0]).not.toHaveProperty('text');
+  });
+
+  it('keeps context words outside untitled person-name spans', () => {
+    const text = 'Patient John Smith has seizures';
+    const result = scanPii(text, { locale: 'en' });
+    const finding = result.findings.find((item) => item.category === 'person_name');
+
+    expect(finding).toBeDefined();
+    expect(finding.start).toBe(text.indexOf('John'));
+    expect(finding.end).toBe(text.indexOf(' has seizures'));
   });
 
   it.each([

--- a/frontend/src/test/pii/detector.test.js
+++ b/frontend/src/test/pii/detector.test.js
@@ -44,6 +44,13 @@ describe('scanPii', () => {
     expect(result.findings[0]).not.toHaveProperty('text');
   });
 
+  it('marks configured titled person names even when the selected language differs', () => {
+    const result = scanPii('Herr Bernt Popp ist dumm', { locale: 'en' });
+
+    expect(result.summary.review.person_name).toBe(1);
+    expect(result.findings[0]).not.toHaveProperty('text');
+  });
+
   it.each([
     ['en', 'Mr John Smith has seizures'],
     ['fr', 'Monsieur Jean Dupont a des crises'],

--- a/frontend/src/test/pii/redactor.test.js
+++ b/frontend/src/test/pii/redactor.test.js
@@ -20,9 +20,9 @@ describe('redactPiiFindings', () => {
     expect(redactPiiFindings(text, scan.findings, { includeReviewFindings: false }).text).toBe(
       text
     );
-    expect(
-      redactPiiFindings(text, scan.findings, { includeReviewFindings: true }).text
-    ).toContain('[REDACTED_DATE]');
+    expect(redactPiiFindings(text, scan.findings, { includeReviewFindings: true }).text).toContain(
+      '[REDACTED_DATE]'
+    );
   });
 
   it('handles overlapping findings by keeping the longest span', () => {

--- a/frontend/src/test/services/PhentrieveService.test.js
+++ b/frontend/src/test/services/PhentrieveService.test.js
@@ -430,7 +430,9 @@ describe('PhentrieveService', () => {
     const serializedError = JSON.stringify(thrownError);
     expect(serializedError).not.toContain('jane@example.org');
     expect(serializedError).not.toContain('Email jane');
-    expect(thrownError.userMessageParams.detail).toBe('API returned an error. See status code for details.');
+    expect(thrownError.userMessageParams.detail).toBe(
+      'API returned an error. See status code for details.'
+    );
   });
 
   describe('adaptive_rechunking pass-through', () => {

--- a/phentrieve/retrieval/api_helpers.py
+++ b/phentrieve/retrieval/api_helpers.py
@@ -140,7 +140,7 @@ async def execute_hpo_retrieval_for_api(
     """
     if debug:
         logger.setLevel(logging.DEBUG)
-        logger.debug("Processing API query with text: %s...", _sanitize(text[:50]))
+        logger.debug("Processing API query text_chars=%s", _sanitize(len(text)))
     # Validate input
     if not text or not text.strip():
         return {

--- a/phentrieve/retrieval/dense_retriever.py
+++ b/phentrieve/retrieval/dense_retriever.py
@@ -387,7 +387,7 @@ class DenseRetriever:
         Returns:
             Dictionary containing query results with distances and/or similarities
         """
-        logging.info("Processing query: '%s'", _sanitize(text))
+        logging.info("Processing query text_chars=%s", _sanitize(len(text)))
 
         # Use query_batch() internally to avoid code duplication
         batch_results = self.query_batch([text], n_results, include_similarities)
@@ -515,8 +515,8 @@ class DenseRetriever:
             )
 
         logging.info(
-            "Multi-vector query: '%s' with strategy %s",
-            _sanitize(text[:50] + "..." if len(text) > 50 else text),
+            "Multi-vector query text_chars=%s with strategy %s",
+            _sanitize(len(text)),
             _sanitize(str(aggregation_strategy)),
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "phentrieve"
-version = "0.20.0"
+version = "0.21.0"
 description = "A CLI tool for retrieving Human Phenotype Ontology (HPO) terms from clinical text using multilingual embeddings."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/unit/retrieval/test_api_helpers.py
+++ b/tests/unit/retrieval/test_api_helpers.py
@@ -135,7 +135,7 @@ class TestExecuteHpoRetrievalForApi:
             )
 
         assert query_text not in caplog.text
-        assert "text_chars=24" in caplog.text
+        assert f"text_chars={len(query_text)}" in caplog.text
 
     @pytest.mark.asyncio
     async def test_no_results_found(self, mocker):

--- a/tests/unit/retrieval/test_api_helpers.py
+++ b/tests/unit/retrieval/test_api_helpers.py
@@ -116,6 +116,28 @@ class TestExecuteHpoRetrievalForApi:
         )
 
     @pytest.mark.asyncio
+    async def test_debug_logs_do_not_include_raw_query_text(self, mocker, caplog):
+        """Debug logging should report metadata without submitted text."""
+        mock_retriever = mocker.Mock()
+        query_text = "Herr Bernt Popp ist dumm"
+        mock_retriever.query.return_value = {"ids": [[]], "documents": [[]]}
+
+        with caplog.at_level("DEBUG", logger="phentrieve.retrieval.api_helpers"):
+            await execute_hpo_retrieval_for_api(
+                text=query_text,
+                language="en",
+                retriever=mock_retriever,
+                num_results=5,
+                similarity_threshold=0.5,
+                detect_query_assertion=False,
+                multi_vector=False,
+                debug=True,
+            )
+
+        assert query_text not in caplog.text
+        assert "text_chars=24" in caplog.text
+
+    @pytest.mark.asyncio
     async def test_no_results_found(self, mocker):
         """Test handling when no results are found."""
         # Arrange

--- a/tests/unit/retrieval/test_dense_retriever_logging.py
+++ b/tests/unit/retrieval/test_dense_retriever_logging.py
@@ -1,0 +1,25 @@
+import logging
+
+import pytest
+
+from phentrieve.retrieval.dense_retriever import DenseRetriever
+
+pytestmark = pytest.mark.unit
+
+
+def test_query_logs_text_length_without_raw_query(mocker, caplog):
+    retriever = DenseRetriever.__new__(DenseRetriever)
+    query_text = "Herr Bernt Popp ist dumm"
+    mocker.patch.object(
+        retriever,
+        "query_batch",
+        return_value=[
+            {"ids": [[]], "documents": [[]], "metadatas": [[]], "distances": [[]]}
+        ],
+    )
+
+    with caplog.at_level(logging.INFO):
+        retriever.query(query_text)
+
+    assert query_text not in caplog.text
+    assert "text_chars=24" in caplog.text

--- a/tests/unit/retrieval/test_dense_retriever_logging.py
+++ b/tests/unit/retrieval/test_dense_retriever_logging.py
@@ -22,4 +22,4 @@ def test_query_logs_text_length_without_raw_query(mocker, caplog):
         retriever.query(query_text)
 
     assert query_text not in caplog.text
-    assert "text_chars=24" in caplog.text
+    assert f"text_chars={len(query_text)}" in caplog.text

--- a/uv.lock
+++ b/uv.lock
@@ -3065,7 +3065,7 @@ wheels = [
 
 [[package]]
 name = "phentrieve"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Summary
- add config-driven titled and untitled person-name PII rules for en, de, fr, es, and nl
- scan configured browser-only PII rules across supported locales before Query or Full Text submission
- keep name findings review-confidence only, without exposing raw finding text/snippets in findings or logs
- harden backend retrieval/API helper logging so raw submitted query text is not emitted; logs use text length metadata instead
- include planning specs and implementation plans for the local browser PII guard and untitled-name follow-up

## Verification
- `npm run lint`
- `npm run format:check`
- `npm run test:run -- src/test/pii/detector.test.js`
- `make frontend-test-ci`
- `make frontend-build-ci`
- GitHub Actions: Frontend CI, Python matrix, CodeQL, security scans, and CI Summary passing
