### PR TITLE
[codex] Validate LLM evidence before enriched mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,14 @@ output/
 results/
 .runs/
 
+# Generated LLM benchmark/debug artifacts
+.planning/analysis/llm-evidence-validation-*.json
+.planning/analysis/llm-evidence-validation-*.checkpoint.json
+.planning/analysis/llm-evidence-validation-*/
+.planning/analysis/debug-*.json
+.planning/analysis/debug-*.checkpoint.json
+.planning/analysis/debug-*/
+
 # MkDocs build output
 site/
 

--- a/phentrieve/llm/evidence_validation.py
+++ b/phentrieve/llm/evidence_validation.py
@@ -57,11 +57,9 @@ def validate_phase1_evidence(
             str(chunk.get("text", "") or "") for chunk in referenced_chunks
         )
         evidence = str(item.get("evidence_text") or "").strip()
-        evidence_was_repaired = False
         if not evidence and phrase and _find_case_insensitive(phrase, haystack):
             item["evidence_text"] = phrase
             evidence = phrase
-            evidence_was_repaired = True
             repairs.append({"phrase": phrase, "kind": "evidence_text_repair"})
 
         if not evidence:
@@ -77,7 +75,6 @@ def validate_phase1_evidence(
                 evidence=evidence,
                 exact_span=exact_span,
                 referenced_chunks=referenced_chunks,
-                allow_missing_offset_repair=not evidence_was_repaired,
             )
             if repaired["kind"]:
                 repairs.append({"phrase": phrase, "kind": repaired["kind"]})
@@ -166,7 +163,6 @@ def _repair_offsets(
     evidence: str,
     exact_span: tuple[int, int] | None,
     referenced_chunks: list[dict[str, Any]],
-    allow_missing_offset_repair: bool,
 ) -> dict[str, Any]:
     if len(referenced_chunks) != 1:
         return {
@@ -178,6 +174,7 @@ def _repair_offsets(
     chunk_text = str(chunk.get("text", "") or "")
     start = item.get("start_char")
     end = item.get("end_char")
+    has_offset_value = start is not None or end is not None
 
     if isinstance(start, int) and isinstance(end, int):
         if _span_matches_evidence(chunk_text, start, end, evidence):
@@ -192,9 +189,7 @@ def _repair_offsets(
                     "kind": "offset_coordinate_repair",
                 }
 
-    if exact_span is not None and (
-        allow_missing_offset_repair or "start_char" in item or "end_char" in item
-    ):
+    if exact_span is not None and has_offset_value:
         repaired = {**item, "start_char": exact_span[0], "end_char": exact_span[1]}
         return {"item": repaired, "kind": "offset_repair"}
     if exact_span is not None:

--- a/phentrieve/llm/evidence_validation.py
+++ b/phentrieve/llm/evidence_validation.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import Any
+
+FUZZY_MATCH_RATIO_THRESHOLD = 90.0
+
+
+@dataclass
+class EvidenceValidationReport:
+    kept: list[dict[str, Any]]
+    dropped: list[dict[str, Any]]
+    repairs: list[dict[str, Any]]
+    status: str = "validated"
+
+
+def validate_phase1_evidence(
+    *,
+    extracted: list[dict[str, Any]],
+    grounded_chunks: list[dict[str, Any]],
+    fuzzy_threshold: float = FUZZY_MATCH_RATIO_THRESHOLD,
+) -> EvidenceValidationReport:
+    if not grounded_chunks:
+        return EvidenceValidationReport(
+            kept=[dict(item) for item in extracted],
+            dropped=[],
+            repairs=[],
+            status="skipped_no_grounded_chunks",
+        )
+
+    chunks_by_id = {int(chunk["chunk_id"]): chunk for chunk in grounded_chunks}
+    kept: list[dict[str, Any]] = []
+    dropped: list[dict[str, Any]] = []
+    repairs: list[dict[str, Any]] = []
+
+    for raw_item in extracted:
+        item = dict(raw_item)
+        phrase = str(item.get("phrase", "") or "").strip()
+        chunk_ids = _coerce_chunk_ids(item.get("chunk_ids"))
+        item["chunk_ids"] = chunk_ids
+
+        if not chunk_ids:
+            dropped.append(
+                {"phrase": phrase, "reason": "empty_chunk_ids", "chunk_ids": chunk_ids}
+            )
+            continue
+        if any(chunk_id not in chunks_by_id for chunk_id in chunk_ids):
+            dropped.append(
+                {"phrase": phrase, "reason": "unknown_chunk_id", "chunk_ids": chunk_ids}
+            )
+            continue
+
+        referenced_chunks = [chunks_by_id[chunk_id] for chunk_id in chunk_ids]
+        haystack = " ".join(
+            str(chunk.get("text", "") or "") for chunk in referenced_chunks
+        )
+        evidence = str(item.get("evidence_text") or "").strip()
+        evidence_was_repaired = False
+        if not evidence and phrase and _find_case_insensitive(phrase, haystack):
+            item["evidence_text"] = phrase
+            evidence = phrase
+            evidence_was_repaired = True
+            repairs.append({"phrase": phrase, "kind": "evidence_text_repair"})
+
+        if not evidence:
+            dropped.append(
+                {"phrase": phrase, "reason": "empty_evidence", "chunk_ids": chunk_ids}
+            )
+            continue
+
+        exact_span = _find_case_insensitive(evidence, haystack)
+        if exact_span is not None:
+            repaired = _repair_offsets(
+                item=item,
+                evidence=evidence,
+                exact_span=exact_span,
+                referenced_chunks=referenced_chunks,
+                allow_missing_offset_repair=not evidence_was_repaired,
+            )
+            if repaired["kind"]:
+                repairs.append({"phrase": phrase, "kind": repaired["kind"]})
+            kept.append(repaired["item"])
+            continue
+
+        ratio = _best_window_ratio(evidence, haystack)
+        if ratio >= fuzzy_threshold:
+            downgraded = {**item, "start_char": None, "end_char": None}
+            repairs.append({"phrase": phrase, "kind": "fuzzy_evidence_downgrade"})
+            kept.append(downgraded)
+            continue
+
+        dropped.append(
+            {
+                "phrase": phrase,
+                "reason": "evidence_not_grounded",
+                "chunk_ids": chunk_ids,
+            }
+        )
+
+    return EvidenceValidationReport(kept=kept, dropped=dropped, repairs=repairs)
+
+
+def validation_report_summary(report: EvidenceValidationReport) -> dict[str, Any]:
+    downgraded_count = sum(
+        1
+        for repair in report.repairs
+        if str(repair.get("kind", "")).endswith("_downgrade")
+    )
+    return {
+        "status": report.status,
+        "kept_count": len(report.kept),
+        "dropped_count": len(report.dropped),
+        "repair_count": len(report.repairs),
+        "downgraded_count": downgraded_count,
+        "dropped": list(report.dropped),
+        "repairs": list(report.repairs),
+    }
+
+
+def _coerce_chunk_ids(value: Any) -> list[int]:
+    ids: list[int] = []
+    for chunk_id in value or []:
+        try:
+            ids.append(int(chunk_id))
+        except (TypeError, ValueError):
+            continue
+    return ids
+
+
+def _normalize_text(text: str) -> str:
+    return " ".join(text.lower().split())
+
+
+def _find_case_insensitive(needle: str, haystack: str) -> tuple[int, int] | None:
+    pattern = re.compile(rf"(?<!\w){re.escape(needle)}(?!\w)", re.IGNORECASE)
+    match = pattern.search(haystack)
+    if match is None:
+        return None
+    return match.start(), match.end()
+
+
+def _best_window_ratio(needle: str, haystack: str) -> float:
+    needle_tokens = _normalize_text(needle).split()
+    haystack_tokens = _normalize_text(haystack).split()
+    if not needle_tokens or not haystack_tokens:
+        return 0.0
+    window_size = max(1, len(needle_tokens))
+    best = 0.0
+    for size in {window_size - 1, window_size, window_size + 1}:
+        if size < 1:
+            continue
+        for start in range(0, max(len(haystack_tokens) - size + 1, 1)):
+            window = " ".join(haystack_tokens[start : start + size])
+            best = max(
+                best,
+                SequenceMatcher(None, _normalize_text(needle), window).ratio() * 100.0,
+            )
+    return best
+
+
+def _repair_offsets(
+    *,
+    item: dict[str, Any],
+    evidence: str,
+    exact_span: tuple[int, int] | None,
+    referenced_chunks: list[dict[str, Any]],
+    allow_missing_offset_repair: bool,
+) -> dict[str, Any]:
+    if len(referenced_chunks) != 1:
+        return {
+            "item": {**item, "start_char": None, "end_char": None},
+            "kind": "multi_chunk_offset_downgrade",
+        }
+
+    chunk = referenced_chunks[0]
+    chunk_text = str(chunk.get("text", "") or "")
+    start = item.get("start_char")
+    end = item.get("end_char")
+
+    if isinstance(start, int) and isinstance(end, int):
+        if _span_matches_evidence(chunk_text, start, end, evidence):
+            return {"item": item, "kind": ""}
+        chunk_start = chunk.get("start_char")
+        if isinstance(chunk_start, int):
+            local_start = start - chunk_start
+            local_end = end - chunk_start
+            if _span_matches_evidence(chunk_text, local_start, local_end, evidence):
+                return {
+                    "item": {**item, "start_char": local_start, "end_char": local_end},
+                    "kind": "offset_coordinate_repair",
+                }
+
+    if exact_span is not None and (
+        allow_missing_offset_repair or "start_char" in item or "end_char" in item
+    ):
+        repaired = {**item, "start_char": exact_span[0], "end_char": exact_span[1]}
+        return {"item": repaired, "kind": "offset_repair"}
+    if exact_span is not None:
+        return {"item": item, "kind": ""}
+    downgraded = {**item, "start_char": None, "end_char": None}
+    return {"item": downgraded, "kind": "offset_downgrade"}
+
+
+def _span_matches_evidence(text: str, start: int, end: int, evidence: str) -> bool:
+    if not (0 <= start < end <= len(text)):
+        return False
+    if text[start:end].lower() != evidence.lower():
+        return False
+    before = text[start - 1] if start > 0 else ""
+    after = text[end] if end < len(text) else ""
+    return (not before.isalnum() and before != "_") and (
+        not after.isalnum() and after != "_"
+    )

--- a/phentrieve/llm/evidence_validation.py
+++ b/phentrieve/llm/evidence_validation.py
@@ -131,11 +131,48 @@ def _normalize_text(text: str) -> str:
 
 
 def _find_case_insensitive(needle: str, haystack: str) -> tuple[int, int] | None:
-    pattern = re.compile(rf"(?<!\w){re.escape(needle)}(?!\w)", re.IGNORECASE)
-    match = pattern.search(haystack)
-    if match is None:
-        return None
-    return match.start(), match.end()
+    pattern = re.compile(re.escape(needle), re.IGNORECASE)
+    for match in pattern.finditer(haystack):
+        if _has_evidence_boundaries(
+            haystack=haystack,
+            start=match.start(),
+            end=match.end(),
+            evidence=needle,
+        ):
+            return match.start(), match.end()
+    return None
+
+
+def _has_evidence_boundaries(
+    *,
+    haystack: str,
+    start: int,
+    end: int,
+    evidence: str,
+) -> bool:
+    before = haystack[start - 1] if start > 0 else ""
+    after = haystack[end] if end < len(haystack) else ""
+    evidence_start = evidence[0] if evidence else ""
+    evidence_end = evidence[-1] if evidence else ""
+    return _is_evidence_left_boundary(before, evidence_start) and (
+        _is_evidence_right_boundary(after, evidence_end)
+    )
+
+
+def _is_evidence_left_boundary(before: str, evidence_start: str) -> bool:
+    if not before:
+        return True
+    if not (before.isalnum() or before == "_"):
+        return True
+    return before.islower() and evidence_start.isupper()
+
+
+def _is_evidence_right_boundary(after: str, evidence_end: str) -> bool:
+    if not after:
+        return True
+    if not (after.isalnum() or after == "_"):
+        return True
+    return evidence_end.islower() and after.isupper()
 
 
 def _best_window_ratio(needle: str, haystack: str) -> float:
@@ -203,8 +240,9 @@ def _span_matches_evidence(text: str, start: int, end: int, evidence: str) -> bo
         return False
     if text[start:end].lower() != evidence.lower():
         return False
-    before = text[start - 1] if start > 0 else ""
-    after = text[end] if end < len(text) else ""
-    return (not before.isalnum() and before != "_") and (
-        not after.isalnum() and after != "_"
+    return _has_evidence_boundaries(
+        haystack=text,
+        start=start,
+        end=end,
+        evidence=evidence,
     )

--- a/phentrieve/llm/phase2a.py
+++ b/phentrieve/llm/phase2a.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from phentrieve.llm.pipeline_phase2 import (
+    build_grounded_context,
+    downstream_dedupe_key,
+    extract_first_result_list,
+    hybrid_select_candidates,
+    prepare_retrieval_queries,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def retrieve_candidates(
+    *,
+    actionable: list[dict[str, Any]],
+    grounded_chunks: list[dict[str, Any]],
+    language: str,
+    tool_executor: Any,
+    n_results_per_phrase: int,
+    max_unique_candidates: int,
+    min_unique_candidates: int,
+    similarity_threshold: float,
+) -> list[dict[str, Any]]:
+    unique_actionable: list[dict[str, Any]] = []
+    actionable_groups: dict[tuple[str, str, tuple[str, ...]], list[dict[str, Any]]] = {}
+    for item in actionable:
+        dedupe_key = downstream_dedupe_key(item, include_candidate_ids=False)
+        actionable_groups.setdefault(dedupe_key, []).append(item)
+        if len(actionable_groups[dedupe_key]) == 1:
+            unique_actionable.append(item)
+
+    expanded_queries: list[str] = []
+    expanded_query_keys: list[tuple[str, str, tuple[str, ...]]] = []
+    for item in unique_actionable:
+        dedupe_key = downstream_dedupe_key(item, include_candidate_ids=False)
+        query_variants = prepare_retrieval_queries(str(item["phrase"]))
+        if not query_variants:
+            query_variants = [str(item["phrase"])]
+        for query in query_variants:
+            expanded_queries.append(query)
+            expanded_query_keys.append(dedupe_key)
+
+    batched_variant_results = tool_executor.query_batch_hpo_terms(
+        phrases=expanded_queries,
+        language=language,
+        n_results=n_results_per_phrase,
+    )
+
+    shared_results: dict[tuple[str, str, tuple[str, ...]], dict[str, Any]] = {}
+    grouped_variant_results: dict[
+        tuple[str, str, tuple[str, ...]], list[tuple[str, dict[str, Any]]]
+    ] = {}
+    for index, dedupe_key in enumerate(expanded_query_keys):
+        query = expanded_queries[index]
+        batch_result = (
+            batched_variant_results[index]
+            if index < len(batched_variant_results)
+            else {}
+        )
+        grouped_variant_results.setdefault(dedupe_key, []).append(
+            (query, dict(batch_result) if isinstance(batch_result, dict) else {})
+        )
+
+    for item in unique_actionable:
+        phrase = str(item["phrase"])
+        category = str(item["category"])
+        dedupe_key = downstream_dedupe_key(item, include_candidate_ids=False)
+        merged_candidates: dict[str, dict[str, Any]] = {}
+        for query, batch_result in grouped_variant_results.get(dedupe_key, []):
+            if "candidates" in batch_result:
+                candidates = [
+                    {**dict(candidate), "retrieval_query": query}
+                    for candidate in batch_result.get("candidates", [])
+                    if isinstance(candidate, dict)
+                ]
+            else:
+                metadatas = extract_first_result_list(batch_result, "metadatas")
+                similarities = extract_first_result_list(batch_result, "similarities")
+                candidates = [
+                    {**candidate, "retrieval_query": query}
+                    for candidate in hybrid_select_candidates(
+                        phrase=query,
+                        metadatas=metadatas,
+                        similarities=similarities,
+                        max_unique_candidates=max_unique_candidates,
+                        min_unique_candidates=min_unique_candidates,
+                        similarity_threshold=similarity_threshold,
+                    )
+                ]
+
+            for candidate in candidates:
+                hpo_id = str(candidate.get("hpo_id", "")).strip()
+                if not hpo_id:
+                    continue
+                existing = merged_candidates.get(hpo_id)
+                if existing is None or float(
+                    candidate.get("score", 0.0) or 0.0
+                ) > float(existing.get("score", 0.0) or 0.0):
+                    merged_candidates[hpo_id] = candidate
+
+        merged = sorted(
+            merged_candidates.values(),
+            key=lambda candidate: float(candidate.get("score", 0.0) or 0.0),
+            reverse=True,
+        )[:n_results_per_phrase]
+        shared_results[dedupe_key] = {
+            "phrase": phrase,
+            "category": category,
+            "candidates": merged,
+        }
+        logger.debug(
+            "Phase 2A candidate retrieval: phrase=%r candidates=%d",
+            phrase,
+            len(merged),
+        )
+
+    results: list[dict[str, Any]] = []
+    for item in actionable:
+        dedupe_key = downstream_dedupe_key(item, include_candidate_ids=False)
+        shared_result = dict(shared_results.get(dedupe_key, {}))
+        shared_result.setdefault("phrase", str(item["phrase"]))
+        shared_result.setdefault("category", str(item["category"]))
+        shared_result["chunk_ids"] = list(item.get("chunk_ids", []))
+        shared_result["evidence_text"] = item.get("evidence_text")
+        shared_result["start_char"] = item.get("start_char")
+        shared_result["end_char"] = item.get("end_char")
+        shared_result["grounded_context"] = build_grounded_context(
+            item=item,
+            grounded_chunks=grounded_chunks,
+        )
+        shared_result["candidates"] = list(shared_result.get("candidates", []))
+        results.append(shared_result)
+    return results

--- a/phentrieve/llm/phase2a.py
+++ b/phentrieve/llm/phase2a.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 from phentrieve.llm.pipeline_phase2 import (
@@ -12,6 +13,101 @@ from phentrieve.llm.pipeline_phase2 import (
 )
 
 logger = logging.getLogger(__name__)
+
+CONTEXT_HEAD_NOUNS = (
+    "seizures",
+    "seizure",
+    "headache",
+    "tumour",
+    "tumor",
+    "hairs",
+    "hair",
+)
+
+
+def _dedupe_preserving_order(values: list[str]) -> list[str]:
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        normalized = " ".join(str(value or "").split()).strip()
+        key = normalized.lower()
+        if normalized and key not in seen:
+            deduped.append(normalized)
+            seen.add(key)
+    return deduped
+
+
+def _contains_word(text: str, word: str) -> bool:
+    return bool(re.search(rf"\b{re.escape(word)}\b", text, flags=re.IGNORECASE))
+
+
+def _phrase_can_use_context_head(phrase: str) -> bool:
+    tokens = re.findall(r"[A-Za-z]+", phrase.lower())
+    if not tokens or len(tokens) > 2:
+        return False
+    phrase_heads = {token.rstrip("s") for token in tokens}
+    context_heads = {head.rstrip("s") for head in CONTEXT_HEAD_NOUNS}
+    return not bool(phrase_heads & context_heads)
+
+
+def prepare_contextual_retrieval_queries(
+    *,
+    phrase: str,
+    grounded_context: dict[str, Any],
+) -> list[str]:
+    queries = prepare_retrieval_queries(phrase)
+    if not _phrase_can_use_context_head(phrase):
+        return queries
+
+    context_parts = [
+        str(grounded_context.get("primary_chunk_text", "") or ""),
+        *[
+            str(text or "")
+            for text in grounded_context.get("neighbor_chunk_texts", [])
+            if isinstance(text, str)
+        ],
+    ]
+    context_text = " ".join(context_parts)
+    for head in CONTEXT_HEAD_NOUNS:
+        if _contains_word(context_text, head):
+            queries.append(f"{phrase} {head}")
+            break
+    return _dedupe_preserving_order(queries)
+
+
+def _candidate_match_text(candidate: dict[str, Any]) -> str:
+    matched_text = str(candidate.get("matched_text", "") or "").strip()
+    if matched_text:
+        return matched_text
+    return str(candidate.get("term_name", "") or "")
+
+
+def _filter_raw_modifier_candidates(
+    *,
+    phrase: str,
+    candidates: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    phrase_tokens = re.findall(r"[A-Za-z]+", phrase.lower())
+    if not phrase_tokens or len(phrase_tokens) > 2:
+        return candidates
+    phrase_clean = " ".join(phrase.lower().split())
+    has_context_variant = any(
+        str(candidate.get("retrieval_query", "") or "").strip().lower()
+        not in {"", phrase_clean}
+        for candidate in candidates
+    )
+    if not has_context_variant:
+        return candidates
+    return [
+        candidate
+        for candidate in candidates
+        if not (
+            str(candidate.get("retrieval_query", "") or "").strip().lower()
+            == phrase_clean
+            and " ".join(_candidate_match_text(candidate).lower().split())
+            == phrase_clean
+        )
+    ]
 
 
 def retrieve_candidates(
@@ -37,7 +133,14 @@ def retrieve_candidates(
     expanded_query_keys: list[tuple[str, str, tuple[str, ...]]] = []
     for item in unique_actionable:
         dedupe_key = downstream_dedupe_key(item, include_candidate_ids=False)
-        query_variants = prepare_retrieval_queries(str(item["phrase"]))
+        grounded_context = build_grounded_context(
+            item=item,
+            grounded_chunks=grounded_chunks,
+        )
+        query_variants = prepare_contextual_retrieval_queries(
+            phrase=str(item["phrase"]),
+            grounded_context=grounded_context,
+        )
         if not query_variants:
             query_variants = [str(item["phrase"])]
         for query in query_variants:
@@ -107,6 +210,7 @@ def retrieve_candidates(
             key=lambda candidate: float(candidate.get("score", 0.0) or 0.0),
             reverse=True,
         )[:n_results_per_phrase]
+        merged = _filter_raw_modifier_candidates(phrase=phrase, candidates=merged)
         shared_results[dedupe_key] = {
             "phrase": phrase,
             "category": category,

--- a/phentrieve/llm/pipeline.py
+++ b/phentrieve/llm/pipeline.py
@@ -388,6 +388,7 @@ class TwoPhaseLLMPipeline:
             "unresolved_phrases": 0,
             "local_matches": 0,
             "llm_mapped_phrases": 0,
+            "phase2_mapping_prompt_tokens_per_request": 0,
             "local_fallbacks": 0,
             "phase1_fallbacks": phase1_fallback_count,
         }
@@ -507,6 +508,10 @@ class TwoPhaseLLMPipeline:
                 )
                 request_count_total += mapping_request_count
                 phase_request_counts["phase2b_llm_requests"] = mapping_request_count
+                if mapping_request_count > 0:
+                    phase_counts["phase2_mapping_prompt_tokens_per_request"] = round(
+                        mapping_prompt_tokens / mapping_request_count
+                    )
                 resolved_terms.extend(mapped_terms)
                 phase_counts["local_fallbacks"] = local_fallback_count
                 phase_counts["llm_mapped_phrases"] = (

--- a/phentrieve/llm/pipeline.py
+++ b/phentrieve/llm/pipeline.py
@@ -29,6 +29,7 @@ from phentrieve.llm.evidence_validation import (
 from phentrieve.llm.phase2a import retrieve_candidates as _retrieve_phase2a_candidates
 from phentrieve.llm.pipeline_phase1 import (
     ACTIONABLE_CATEGORIES,
+    PHENOTYPE_ABBREVIATIONS,
 )
 from phentrieve.llm.pipeline_phase1 import (
     clean_text as _clean_text,
@@ -1362,11 +1363,31 @@ class TwoPhaseLLMPipeline:
             return "defer"
 
         normalized_language = (language or "").strip().lower()
+        if normalized_language == "en" and self._is_abbreviation_expansion_match(
+            phrase=str(item["phrase"]),
+            candidate=local_match,
+        ):
+            return "local"
+
         phrase_clean = _clean_text(str(item["phrase"]))
         term_clean = _clean_text(_candidate_match_text(local_match))
         phrase_tokens = _tokenize(str(item["phrase"]))
         term_tokens = _tokenize(_candidate_match_text(local_match))
         match_score = float(local_match.get("score", 0.0) or 0.0)
+        local_query_clean = _clean_text(str(local_match.get("retrieval_query", "")))
+        has_context_variant = any(
+            _clean_text(str(candidate.get("retrieval_query", "")))
+            not in {"", phrase_clean}
+            for candidate in candidates
+        )
+
+        if (
+            normalized_language == "en"
+            and len(phrase_tokens) <= 2
+            and local_query_clean == phrase_clean
+            and has_context_variant
+        ):
+            return "defer"
 
         if normalized_language == "en":
             if phrase_clean == term_clean or (
@@ -1395,11 +1416,63 @@ class TwoPhaseLLMPipeline:
         phrase: str,
         candidates: list[dict[str, Any]],
     ) -> dict[str, Any] | None:
+        abbreviation_match = self._try_abbreviation_expansion_match(
+            phrase=phrase,
+            candidates=candidates,
+        )
+        if abbreviation_match is not None:
+            return abbreviation_match
         return local_match(
             phrase=phrase,
             candidates=candidates,
             local_match_threshold=self.local_match_threshold,
         )
+
+    @staticmethod
+    def _try_abbreviation_expansion_match(
+        *,
+        phrase: str,
+        candidates: list[dict[str, Any]],
+    ) -> dict[str, Any] | None:
+        expanded = PHENOTYPE_ABBREVIATIONS.get(_clean_text(phrase))
+        if expanded is None:
+            return None
+        expanded_clean = _clean_text(expanded)
+        best_candidate: dict[str, Any] | None = None
+        best_score = 0.0
+        for candidate in candidates:
+            if not TwoPhaseLLMPipeline._is_abbreviation_expansion_match(
+                phrase=phrase,
+                candidate=candidate,
+            ):
+                continue
+            score = float(candidate.get("score", 0.0) or 0.0)
+            if score > best_score:
+                best_candidate = candidate
+                best_score = score
+        if best_candidate is None:
+            return None
+        retrieval_query_clean = _clean_text(
+            str(best_candidate.get("retrieval_query", "") or "")
+        )
+        if retrieval_query_clean != expanded_clean:
+            return None
+        return best_candidate if best_score >= 0.95 else None
+
+    @staticmethod
+    def _is_abbreviation_expansion_match(
+        *,
+        phrase: str,
+        candidate: dict[str, Any],
+    ) -> bool:
+        expanded = PHENOTYPE_ABBREVIATIONS.get(_clean_text(phrase))
+        if expanded is None:
+            return False
+        expanded_clean = _clean_text(expanded)
+        retrieval_query_clean = _clean_text(
+            str(candidate.get("retrieval_query", "") or "")
+        )
+        return retrieval_query_clean == expanded_clean
 
     def _resolve_with_mapping_prompt(
         self,

--- a/phentrieve/llm/pipeline.py
+++ b/phentrieve/llm/pipeline.py
@@ -22,6 +22,7 @@ from phentrieve.llm.config import (
     DEFAULT_SIMILARITY_THRESHOLD,
     PRESENT_ASSERTION,
 )
+from phentrieve.llm.phase2a import retrieve_candidates as _retrieve_phase2a_candidates
 from phentrieve.llm.pipeline_phase1 import (
     ACTIONABLE_CATEGORIES,
 )
@@ -70,7 +71,6 @@ from phentrieve.llm.pipeline_phase2 import (
     local_match,
     optional_float,
     phenotype_from_candidate,
-    prepare_retrieval_queries,
     run_mapping_batch,
     select_candidate_id,
     select_candidate_ids,
@@ -1119,125 +1119,16 @@ class TwoPhaseLLMPipeline:
         grounded_chunks: list[dict[str, Any]],
         language: str,
     ) -> list[dict[str, Any]]:
-        unique_actionable: list[dict[str, Any]] = []
-        actionable_groups: dict[
-            tuple[str, str, tuple[str, ...]], list[dict[str, Any]]
-        ] = {}
-        for item in actionable:
-            dedupe_key = _downstream_dedupe_key(item, include_candidate_ids=False)
-            actionable_groups.setdefault(dedupe_key, []).append(item)
-            if len(actionable_groups[dedupe_key]) == 1:
-                unique_actionable.append(item)
-
-        expanded_queries: list[str] = []
-        expanded_query_keys: list[tuple[str, str, tuple[str, ...]]] = []
-        for item in unique_actionable:
-            dedupe_key = _downstream_dedupe_key(item, include_candidate_ids=False)
-            query_variants = prepare_retrieval_queries(str(item["phrase"]))
-            if not query_variants:
-                query_variants = [str(item["phrase"])]
-            for query in query_variants:
-                expanded_queries.append(query)
-                expanded_query_keys.append(dedupe_key)
-
-        batched_variant_results = self.tool_executor.query_batch_hpo_terms(
-            phrases=expanded_queries,
+        return _retrieve_phase2a_candidates(
+            actionable=actionable,
+            grounded_chunks=grounded_chunks,
             language=language,
-            n_results=self.n_results_per_phrase,
+            tool_executor=self.tool_executor,
+            n_results_per_phrase=self.n_results_per_phrase,
+            max_unique_candidates=self.max_unique_candidates,
+            min_unique_candidates=self.min_unique_candidates,
+            similarity_threshold=self.similarity_threshold,
         )
-
-        shared_results: dict[tuple[str, str, tuple[str, ...]], dict[str, Any]] = {}
-        grouped_variant_results: dict[
-            tuple[str, str, tuple[str, ...]], list[tuple[str, dict[str, Any]]]
-        ] = {}
-        for index, dedupe_key in enumerate(expanded_query_keys):
-            query = expanded_queries[index]
-            batch_result = (
-                batched_variant_results[index]
-                if index < len(batched_variant_results)
-                else {}
-            )
-            grouped_variant_results.setdefault(dedupe_key, []).append(
-                (query, batch_result)
-            )
-
-        for item in unique_actionable:
-            phrase = str(item["phrase"])
-            category = str(item["category"])
-            dedupe_key = _downstream_dedupe_key(item, include_candidate_ids=False)
-            merged_candidates: dict[str, dict[str, Any]] = {}
-            for query, batch_result in grouped_variant_results.get(dedupe_key, []):
-                if "candidates" in batch_result:
-                    candidates = [
-                        {
-                            **dict(candidate),
-                            "retrieval_query": query,
-                        }
-                        for candidate in batch_result.get("candidates", [])
-                        if isinstance(candidate, dict)
-                    ]
-                else:
-                    metadatas = self._extract_first_result_list(
-                        batch_result, "metadatas"
-                    )
-                    similarities = self._extract_first_result_list(
-                        batch_result, "similarities"
-                    )
-                    candidates = [
-                        {
-                            **candidate,
-                            "retrieval_query": query,
-                        }
-                        for candidate in self._hybrid_select_candidates(
-                            phrase=query,
-                            metadatas=metadatas,
-                            similarities=similarities,
-                        )
-                    ]
-
-                for candidate in candidates:
-                    hpo_id = str(candidate.get("hpo_id", "")).strip()
-                    if not hpo_id:
-                        continue
-                    existing = merged_candidates.get(hpo_id)
-                    if existing is None or float(
-                        candidate.get("score", 0.0) or 0.0
-                    ) > float(existing.get("score", 0.0) or 0.0):
-                        merged_candidates[hpo_id] = candidate
-
-            merged = sorted(
-                merged_candidates.values(),
-                key=lambda candidate: float(candidate.get("score", 0.0) or 0.0),
-                reverse=True,
-            )[: self.n_results_per_phrase]
-            shared_results[dedupe_key] = {
-                "phrase": phrase,
-                "category": category,
-                "candidates": merged,
-            }
-            logger.debug(
-                "Phase 2A candidate retrieval: phrase=%r candidates=%d",
-                phrase,
-                len(shared_results[dedupe_key]["candidates"]),
-            )
-
-        results: list[dict[str, Any]] = []
-        for item in actionable:
-            dedupe_key = _downstream_dedupe_key(item, include_candidate_ids=False)
-            shared_result = dict(shared_results.get(dedupe_key, {}))
-            shared_result.setdefault("phrase", str(item["phrase"]))
-            shared_result.setdefault("category", str(item["category"]))
-            shared_result["chunk_ids"] = list(item.get("chunk_ids", []))
-            shared_result["evidence_text"] = item.get("evidence_text")
-            shared_result["start_char"] = item.get("start_char")
-            shared_result["end_char"] = item.get("end_char")
-            shared_result["grounded_context"] = self._build_grounded_context(
-                item=item,
-                grounded_chunks=grounded_chunks,
-            )
-            shared_result["candidates"] = list(shared_result.get("candidates", []))
-            results.append(shared_result)
-        return results
 
     @staticmethod
     def _extract_first_result_list(

--- a/phentrieve/llm/pipeline.py
+++ b/phentrieve/llm/pipeline.py
@@ -22,6 +22,10 @@ from phentrieve.llm.config import (
     DEFAULT_SIMILARITY_THRESHOLD,
     PRESENT_ASSERTION,
 )
+from phentrieve.llm.evidence_validation import (
+    validate_phase1_evidence,
+    validation_report_summary,
+)
 from phentrieve.llm.phase2a import retrieve_candidates as _retrieve_phase2a_candidates
 from phentrieve.llm.pipeline_phase1 import (
     ACTIONABLE_CATEGORIES,
@@ -336,6 +340,15 @@ class TwoPhaseLLMPipeline:
         extracted = self._deduplicate_phase1_extractions(
             _expand_combined_phase1_extractions(extracted)
         )
+        phase1_extracted_count = len(extracted)
+        evidence_validation_report = validate_phase1_evidence(
+            extracted=extracted,
+            grounded_chunks=grounded_chunks,
+        )
+        extracted = evidence_validation_report.kept
+        evidence_validation_trace = validation_report_summary(
+            evidence_validation_report
+        )
         actionable = [
             item
             for item in extracted
@@ -355,7 +368,14 @@ class TwoPhaseLLMPipeline:
             "phase2b_llm_seconds": 0.0,
         }
         phase_counts: dict[str, int] = {
-            "extracted_phrases": len(extracted),
+            "extracted_phrases": phase1_extracted_count,
+            "phase1_validated_phrases": len(extracted),
+            "phase1_evidence_kept": len(evidence_validation_report.kept),
+            "phase1_evidence_dropped": len(evidence_validation_report.dropped),
+            "phase1_evidence_repaired": len(evidence_validation_report.repairs),
+            "phase1_evidence_downgraded": int(
+                evidence_validation_trace.get("downgraded_count", 0) or 0
+            ),
             "actionable_phrases": len(actionable),
             "candidate_sets": 0,
             "unresolved_phrases": 0,
@@ -377,7 +397,8 @@ class TwoPhaseLLMPipeline:
                 final_mode=phase1_final_mode,
                 fallback_count=phase1_fallback_count,
                 failure_class=phase1_failure_class,
-            )
+            ),
+            "phase1_evidence_validation": evidence_validation_trace,
         }
         all_phase1_groups = [
             group

--- a/phentrieve/llm/pipeline.py
+++ b/phentrieve/llm/pipeline.py
@@ -88,6 +88,9 @@ from phentrieve.llm.pipeline_phase2 import (
 from phentrieve.llm.pipeline_phase2 import (
     mapping_batch_item_id as _mapping_batch_item_id,
 )
+from phentrieve.llm.pipeline_phase2 import (
+    prepare_retrieval_queries as _prepare_retrieval_queries,
+)
 from phentrieve.llm.pipeline_retry import (
     LLMPipelinePhaseError,
 )
@@ -140,6 +143,10 @@ from phentrieve.llm.types import (
 from phentrieve.llm.utils import token_sort_similarity
 
 logger = logging.getLogger(__name__)
+
+
+def prepare_retrieval_queries(phrase: str) -> list[str]:
+    return _prepare_retrieval_queries(phrase)
 
 
 class TwoPhaseLLMPipeline:

--- a/phentrieve/llm/pipeline.py
+++ b/phentrieve/llm/pipeline.py
@@ -141,6 +141,7 @@ from phentrieve.llm.types import (
     Phase1Mode,
 )
 from phentrieve.llm.utils import token_sort_similarity
+from phentrieve.utils import sanitize_log_value as _sanitize
 
 logger = logging.getLogger(__name__)
 
@@ -1433,49 +1434,56 @@ class TwoPhaseLLMPipeline:
 
         for start in range(0, len(unique_unresolved), self.mapping_batch_size):
             batch = unique_unresolved[start : start + self.mapping_batch_size]
-            mapping_response, batch_usage = self._run_mapping_batch(
+            (
+                mapping_batch_results,
+                batch_usage,
+                batch_request_count,
+            ) = self._run_mapping_batch_with_structured_recovery(
                 batch=batch,
                 mapping_prompt=mapping_prompt,
             )
-            request_count_total += int(
-                getattr(self.provider, "last_request_count", 0) or 0
-            )
+            request_count_total += batch_request_count
             token_usage_total = _sum_usage_dicts(token_usage_total, batch_usage)
             prompt_tokens_total += int(batch_usage.get("prompt_tokens", 0) or 0)
             completion_tokens_total += int(batch_usage.get("completion_tokens", 0) or 0)
-            selected_ids = self._select_candidate_ids(
-                mapping_response=mapping_response,
-                batch=batch,
-            )
-            for index, item in enumerate(batch):
-                dedupe_key = _downstream_dedupe_key(item, include_candidate_ids=True)
-                grouped_items = unresolved_groups[dedupe_key]
-                selected_id = selected_ids.get(_mapping_batch_item_id(index))
-                (
-                    item_resolved,
-                    item_local_fallback_count,
-                    item_trace,
-                ) = self._resolve_mapping_selection(item=item, selected_id=selected_id)
-                resolved.extend(item_resolved)
-                local_fallback_count += item_local_fallback_count
-                mapping_trace.append(item_trace)
-                for grouped_item in grouped_items[1:]:
+            for result_batch, mapping_response in mapping_batch_results:
+                selected_ids = self._select_candidate_ids(
+                    mapping_response=mapping_response,
+                    batch=result_batch,
+                )
+                for index, item in enumerate(result_batch):
+                    dedupe_key = _downstream_dedupe_key(
+                        item, include_candidate_ids=True
+                    )
+                    grouped_items = unresolved_groups[dedupe_key]
+                    selected_id = selected_ids.get(_mapping_batch_item_id(index))
                     (
-                        grouped_resolved,
-                        grouped_local_fallback_count,
-                        grouped_item_trace,
+                        item_resolved,
+                        item_local_fallback_count,
+                        item_trace,
                     ) = self._resolve_mapping_selection(
-                        item=grouped_item,
-                        selected_id=selected_id,
+                        item=item, selected_id=selected_id
                     )
-                    resolved.extend(grouped_resolved)
-                    local_fallback_count += grouped_local_fallback_count
-                    mapping_trace.append(
-                        self._annotate_mapping_trace_with_provenance(
+                    resolved.extend(item_resolved)
+                    local_fallback_count += item_local_fallback_count
+                    mapping_trace.append(item_trace)
+                    for grouped_item in grouped_items[1:]:
+                        (
+                            grouped_resolved,
+                            grouped_local_fallback_count,
                             grouped_item_trace,
-                            grouped_item,
+                        ) = self._resolve_mapping_selection(
+                            item=grouped_item,
+                            selected_id=selected_id,
                         )
-                    )
+                        resolved.extend(grouped_resolved)
+                        local_fallback_count += grouped_local_fallback_count
+                        mapping_trace.append(
+                            self._annotate_mapping_trace_with_provenance(
+                                grouped_item_trace,
+                                grouped_item,
+                            )
+                        )
         return (
             resolved,
             prompt_tokens_total,
@@ -1484,6 +1492,103 @@ class TwoPhaseLLMPipeline:
             request_count_total,
             local_fallback_count,
             mapping_trace,
+        )
+
+    def _run_mapping_batch_with_structured_recovery(
+        self,
+        *,
+        batch: list[dict[str, Any]],
+        mapping_prompt,
+    ) -> tuple[
+        list[
+            tuple[
+                list[dict[str, Any]],
+                LLMMappingSelection | LLMBatchMappingSelections,
+            ]
+        ],
+        dict[str, int],
+        int,
+    ]:
+        try:
+            mapping_response, batch_usage = self._run_mapping_batch(
+                batch=batch,
+                mapping_prompt=mapping_prompt,
+            )
+            return (
+                [(batch, mapping_response)],
+                dict(batch_usage),
+                int(getattr(self.provider, "last_request_count", 0) or 0),
+            )
+        except Exception as exc:
+            failed_usage = dict(getattr(self.provider, "last_usage", {}) or {})
+            failed_request_count = int(
+                getattr(self.provider, "last_request_count", 0) or 0
+            )
+            if len(batch) <= 1 or not self._is_retryable_mapping_batch_error(exc):
+                raise
+
+            retry_batch_size = max(1, len(batch) // 2)
+            logger.warning(
+                "Phase 2B-llm: mapping batch failed with retryable structured "
+                "response error; retrying with smaller mapping batches "
+                "batch_size=%s retry_batch_size=%s failed_requests=%s error=%s",
+                len(batch),
+                retry_batch_size,
+                failed_request_count,
+                _sanitize(exc),
+            )
+
+            recovered_results: list[
+                tuple[
+                    list[dict[str, Any]],
+                    LLMMappingSelection | LLMBatchMappingSelections,
+                ]
+            ] = []
+            recovered_usage = dict(failed_usage)
+            recovered_request_count = failed_request_count
+
+            for retry_start in range(0, len(batch), retry_batch_size):
+                retry_batch = batch[retry_start : retry_start + retry_batch_size]
+                (
+                    retry_results,
+                    retry_usage,
+                    retry_request_count,
+                ) = self._run_mapping_batch_with_structured_recovery(
+                    batch=retry_batch,
+                    mapping_prompt=mapping_prompt,
+                )
+                recovered_results.extend(retry_results)
+                recovered_usage = _sum_usage_dicts(recovered_usage, retry_usage)
+                recovered_request_count += retry_request_count
+
+            return recovered_results, recovered_usage, recovered_request_count
+
+    def _is_retryable_mapping_batch_error(self, exc: Exception) -> bool:
+        provider_checker = getattr(
+            self.provider, "_is_retryable_structured_error", None
+        )
+        if callable(provider_checker):
+            try:
+                return bool(provider_checker(exc))
+            except Exception:
+                logger.debug(
+                    "Phase 2B-llm: provider structured error classifier failed",
+                    exc_info=True,
+                )
+
+        message = str(exc).lower()
+        return any(
+            marker in message
+            for marker in (
+                "invalid json",
+                "json_invalid",
+                "unterminated",
+                "eof while parsing",
+                "expecting value",
+                "extra data",
+                "max_tokens",
+                "no structured response payload",
+            )
         )
 
     @staticmethod

--- a/phentrieve/llm/pipeline_phase1.py
+++ b/phentrieve/llm/pipeline_phase1.py
@@ -268,13 +268,7 @@ def _split_shared_head_phrase(phrase: str) -> list[str]:
 
 def split_combined_phase1_phrase(phrase: str) -> list[str]:
     """Split clear combined phenotype mentions into standalone source phrases."""
-    expanded_abbreviation = PHENOTYPE_ABBREVIATIONS.get(phrase.strip().lower())
-    if expanded_abbreviation:
-        return [expanded_abbreviation]
-    slash_split = _split_slash_combined_phrase(phrase)
-    if slash_split:
-        return slash_split
-    return _split_shared_head_phrase(phrase)
+    return _split_slash_combined_phrase(phrase)
 
 
 def expand_combined_phase1_extractions(
@@ -283,12 +277,6 @@ def expand_combined_phase1_extractions(
     expanded: list[dict[str, Any]] = []
     for item in extracted:
         phrase = str(item.get("phrase", "")).strip()
-        expanded_abbreviation = PHENOTYPE_ABBREVIATIONS.get(phrase.lower())
-        if expanded_abbreviation:
-            expanded_item = dict(item)
-            expanded_item["phrase"] = expanded_abbreviation
-            expanded.append(expanded_item)
-            continue
         split_phrases = split_combined_phase1_phrase(phrase)
         if not split_phrases:
             expanded.append(dict(item))

--- a/phentrieve/llm/pipeline_phase1.py
+++ b/phentrieve/llm/pipeline_phase1.py
@@ -36,6 +36,9 @@ SHARED_HEAD_PHRASE_PATTERN = re.compile(
     re.IGNORECASE,
 )
 PHENOTYPE_ABBREVIATIONS = {
+    "bwgs": "Bland-White-Garland syndrome",
+    "gtc": "generalized tonic-clonic seizures",
+    "pjs": "Peutz-Jeghers syndrome",
     "xlid": "X-linked intellectual disability",
 }
 

--- a/phentrieve/llm/pipeline_phase2.py
+++ b/phentrieve/llm/pipeline_phase2.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import Any
 
 from phentrieve.llm.config import (
@@ -9,6 +10,7 @@ from phentrieve.llm.config import (
     UNCERTAIN_ASSERTION,
 )
 from phentrieve.llm.pipeline_phase1 import (
+    PHENOTYPE_ABBREVIATIONS,
     UNIT_TOKEN_PATTERN,
     clean_text,
     normalize_category,
@@ -32,6 +34,43 @@ CATEGORY_TO_ASSERTION = {
 }
 
 
+TRAILING_STATE_PATTERN = re.compile(
+    r"^(?P<noun>[a-z0-9][a-z0-9\s\-/]+?)\s+"
+    r"(?P<verb>was|were|is|are|remained)\s+"
+    r"(?:(?P<intensity>markedly|severely|mildly)\s+)?"
+    r"(?P<state>elevated|increased|reduced|low)$",
+    re.IGNORECASE,
+)
+CANONICAL_STATES = {
+    "elevated": "elevated",
+    "increased": "increased",
+    "reduced": "reduced",
+    "low": "low",
+}
+
+
+def _dedupe_preserving_order(values: list[str]) -> list[str]:
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        key = value.lower()
+        if value and key not in seen:
+            seen.add(key)
+            deduped.append(value)
+    return deduped
+
+
+def conservative_canonical_phrase_variant(phrase: str) -> str | None:
+    match = TRAILING_STATE_PATTERN.match(phrase.strip())
+    if not match:
+        return None
+    noun = " ".join(match.group("noun").split())
+    state = CANONICAL_STATES.get(match.group("state").lower())
+    if not noun or state is None:
+        return None
+    return f"{state} {noun}"
+
+
 def prepare_retrieval_queries(phrase: str) -> list[str]:
     original = " ".join(str(phrase or "").split()).strip()
     if not original:
@@ -41,7 +80,16 @@ def prepare_retrieval_queries(phrase: str) -> list[str]:
     stripped_units = " ".join(UNIT_TOKEN_PATTERN.sub(" ", original).split())
     if stripped_units and stripped_units != original:
         variants.append(stripped_units)
-    return variants
+
+    canonical = conservative_canonical_phrase_variant(original)
+    if canonical and canonical != original:
+        variants.append(canonical)
+
+    expanded_abbreviation = PHENOTYPE_ABBREVIATIONS.get(original.lower())
+    if expanded_abbreviation:
+        variants.append(expanded_abbreviation)
+
+    return _dedupe_preserving_order(variants)
 
 
 def candidate_match_text(candidate: dict[str, Any]) -> str:

--- a/phentrieve/llm/pipeline_phase2.py
+++ b/phentrieve/llm/pipeline_phase2.py
@@ -88,6 +88,15 @@ def prepare_retrieval_queries(phrase: str) -> list[str]:
     if canonical and canonical != original:
         variants.append(canonical)
 
+    verbal_communication_variant = re.sub(
+        r"\bverbal communication\b",
+        "speech",
+        original,
+        flags=re.IGNORECASE,
+    )
+    if verbal_communication_variant != original:
+        variants.append(verbal_communication_variant)
+
     expanded_abbreviation = PHENOTYPE_ABBREVIATIONS.get(original.lower())
     if expanded_abbreviation:
         variants.append(expanded_abbreviation)

--- a/phentrieve/llm/pipeline_phase2.py
+++ b/phentrieve/llm/pipeline_phase2.py
@@ -25,7 +25,6 @@ from phentrieve.llm.types import (
     LLMPhenotypeEvidence,
 )
 from phentrieve.llm.utils import token_sort_similarity
-from phentrieve.retrieval.details_enrichment import enrich_results_with_details
 
 logger = logging.getLogger(__name__)
 
@@ -145,6 +144,17 @@ def truncate_definition(text: str, *, char_limit: int) -> str:
         return stripped
     truncated = stripped[:char_limit].rsplit(" ", 1)[0].rstrip()
     return f"{truncated}..." if truncated else f"{stripped[:char_limit]}..."
+
+
+def enrich_results_with_details(
+    results: list[dict[str, Any]],
+    data_dir_override: str | None = None,
+) -> list[dict[str, Any]]:
+    from phentrieve.retrieval.details_enrichment import (
+        enrich_results_with_details as enrich,
+    )
+
+    return enrich(results, data_dir_override=data_dir_override)
 
 
 def candidate_details_by_id(

--- a/phentrieve/llm/pipeline_phase2.py
+++ b/phentrieve/llm/pipeline_phase2.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 from typing import Any
 
@@ -24,6 +25,9 @@ from phentrieve.llm.types import (
     LLMPhenotypeEvidence,
 )
 from phentrieve.llm.utils import token_sort_similarity
+from phentrieve.retrieval.details_enrichment import enrich_results_with_details
+
+logger = logging.getLogger(__name__)
 
 CATEGORY_TO_ASSERTION = {
     "abnormal": PRESENT_ASSERTION,
@@ -135,10 +139,62 @@ def mapping_batch_item_id(index: int) -> str:
     return f"item_{index + 1}"
 
 
+def truncate_definition(text: str, *, char_limit: int) -> str:
+    stripped = " ".join(text.split())
+    if len(stripped) <= char_limit:
+        return stripped
+    truncated = stripped[:char_limit].rsplit(" ", 1)[0].rstrip()
+    return f"{truncated}..." if truncated else f"{stripped[:char_limit]}..."
+
+
+def candidate_details_by_id(
+    candidates: list[dict[str, Any]],
+    *,
+    data_dir_override: str | None = None,
+) -> dict[str, dict[str, Any]]:
+    if not candidates:
+        return {}
+    try:
+        enriched = enrich_results_with_details(
+            [
+                {
+                    "hpo_id": str(candidate.get("hpo_id", "")),
+                    "label": str(candidate.get("term_name", "")),
+                }
+                for candidate in candidates
+                if str(candidate.get("hpo_id", "")).strip()
+            ],
+            data_dir_override=data_dir_override,
+        )
+    except Exception:
+        logger.exception("Failed to enrich LLM mapping candidates with HPO details")
+        return {}
+    return {str(row.get("hpo_id", "")): dict(row) for row in enriched}
+
+
+def matched_synonym(candidate: dict[str, Any], details: dict[str, Any]) -> str | None:
+    matched_text = str(candidate.get("matched_text") or "").strip()
+    if not matched_text:
+        return None
+    if str(candidate.get("matched_component") or "").strip().lower() == "synonym":
+        return matched_text
+    synonyms = details.get("synonyms")
+    if not isinstance(synonyms, list):
+        return None
+    for synonym in synonyms:
+        synonym_text = str(synonym).strip()
+        if synonym_text.lower() == matched_text.lower():
+            return synonym_text
+    return None
+
+
 def compact_mapping_item(
     item: dict[str, Any],
     *,
     item_id: str | None = None,
+    enrich_candidates: bool = True,
+    definition_char_limit: int = 240,
+    data_dir_override: str | None = None,
 ) -> dict[str, Any]:
     grounded_context = dict(item.get("grounded_context", {}) or {})
     neighbor_texts = [
@@ -155,6 +211,14 @@ def compact_mapping_item(
         "category": item["category"],
         "candidates": [],
     }
+    details_lookup = (
+        candidate_details_by_id(
+            list(item["candidates"]),
+            data_dir_override=data_dir_override,
+        )
+        if enrich_candidates
+        else {}
+    )
     for candidate in item["candidates"]:
         compact_candidate = {
             "id": candidate["hpo_id"],
@@ -167,6 +231,16 @@ def compact_mapping_item(
             compact_candidate["matched_text"] = candidate.get("matched_text")
         if candidate.get("matched_component"):
             compact_candidate["matched_component"] = candidate.get("matched_component")
+        details = details_lookup.get(str(candidate.get("hpo_id", "")), {})
+        definition = details.get("definition")
+        if isinstance(definition, str) and definition.strip():
+            compact_candidate["definition"] = truncate_definition(
+                definition,
+                char_limit=definition_char_limit,
+            )
+        synonym = matched_synonym(candidate, details)
+        if synonym:
+            compact_candidate["matched_synonym"] = synonym
         compact_item["candidates"].append(compact_candidate)
     if item_id is not None:
         compact_item["item_id"] = item_id

--- a/phentrieve/llm/prompts/templates/two_phase/en.yaml
+++ b/phentrieve/llm/prompts/templates/two_phase/en.yaml
@@ -1,4 +1,4 @@
-version: "v3.0.0"
+version: "v3.1.0"
 
 system_prompt: |
   You are an expert clinical geneticist. Extract source-faithful phenotype phrases
@@ -26,7 +26,9 @@ system_prompt: |
   - Split combined mentions into individual phenotype phrases
   - Do not duplicate the same concept multiple times
   - Prefer the smallest phrase that still preserves the clinically essential context
-  - If the note clearly describes an abnormality indirectly, you may extract a short normalized clinical phrase supported by the evidence_text
+  - Every phrase must be a verbatim substring of the evidence_text
+  - Every evidence_text must be a verbatim substring of the referenced chunk
+  - Phase 2 will compute retrieval variants such as canonicalized noun phrases and abbreviation expansion; your job is faithful extraction, not rewriting
   - Do not emit onset modifiers, inheritance patterns, ages, or measurements as standalone phenotypes
   - Do not infer percentile- or threshold-based abnormalities from raw numbers alone unless the note itself indicates the abnormal interpretation
   - Be exhaustive for present abnormalities
@@ -81,8 +83,8 @@ few_shot_examples:
     output: |
       {
         "phenotypes": [
-          {"phrase": "elevated lactate dehydrogenase", "category": "Abnormal", "chunk_ids": [1], "evidence_text": "lactate dehydrogenase was markedly elevated"},
-          {"phrase": "low urine output", "category": "Abnormal", "chunk_ids": [1], "evidence_text": "urine output remained low"}
+          {"phrase": "lactate dehydrogenase was markedly elevated", "category": "Abnormal", "chunk_ids": [1], "evidence_text": "lactate dehydrogenase was markedly elevated"},
+          {"phrase": "urine output remained low", "category": "Abnormal", "chunk_ids": [1], "evidence_text": "urine output remained low"}
         ]
       }
   - input: |

--- a/phentrieve/llm/prompts/templates/two_phase/en.yaml
+++ b/phentrieve/llm/prompts/templates/two_phase/en.yaml
@@ -46,7 +46,11 @@ system_prompt: |
   }
 
 user_prompt_template: |
-  Extract all phenotype phrases from the following clinical text.
+  Extract all phenotype phrases from the clinical text below.
+
+  When the chunk index contains chunk_id rows, the chunk index is the clinical text.
+  Extract phenotypes from those chunk lines and cite their chunk_id values.
+  If the chunk index is empty, extract from the clinical text block.
 
   UNTRUSTED_CHUNK_INDEX_BEGIN
   {chunk_index}

--- a/phentrieve/llm/prompts/templates/two_phase/en_mapping.yaml
+++ b/phentrieve/llm/prompts/templates/two_phase/en_mapping.yaml
@@ -25,6 +25,8 @@ system_prompt: |
   - Use the grounded context, candidate definitions, and matched synonyms to disambiguate.
   - Treat retrieval_score as a hint, not the only decision rule.
   - Prefer the most specific term supported by the evidence.
+  - Do not add onset, laterality, severity, or anatomy specificity from neighboring context unless the phrase or evidence explicitly states it.
+  - Do not choose generic modifier or container concepts when context supports a concrete phenotype candidate.
   - Prefer semantic equivalence over lexical similarity.
   - If category is "normal", choose the abnormal HPO concept that is explicitly absent or normal in context.
   - If no candidate is a clear match, return null.

--- a/phentrieve/llm/prompts/templates/two_phase/en_mapping.yaml
+++ b/phentrieve/llm/prompts/templates/two_phase/en_mapping.yaml
@@ -1,4 +1,4 @@
-version: "v4.1.0"
+version: "v4.2.0"
 
 system_prompt: |
   You map clinical phenotype phrases to HPO terms.
@@ -18,12 +18,13 @@ system_prompt: |
   - category
   - primary_chunk_text
   - neighbor_chunk_texts
-  - candidates with id, term, retrieval_score
+  - candidates with id, term, retrieval_score, optional definition, optional matched_synonym, optional matched_component, optional matched_text
 
   Rules:
   - Choose only one candidate HPO identifier.
-  - Use the grounded context to disambiguate.
+  - Use the grounded context, candidate definitions, and matched synonyms to disambiguate.
   - Treat retrieval_score as a hint, not the only decision rule.
+  - Prefer the most specific term supported by the evidence.
   - Prefer semantic equivalence over lexical similarity.
   - If category is "normal", choose the abnormal HPO concept that is explicitly absent or normal in context.
   - If no candidate is a clear match, return null.
@@ -49,5 +50,5 @@ few_shot_examples:
       Return JSON only.
 
       Payload:
-      {"primary_chunk_text": "The child has frequent falls while walking.", "neighbor_chunk_texts": [], "phrase": "frequent falls", "category": "abnormal", "candidates": [{"id": "HP:0002355", "term": "Difficulty walking", "retrieval_score": 0.93}, {"id": "HP:0002317", "term": "Unsteady gait", "retrieval_score": 0.67}]}
-    output: '{"phrase": "frequent falls", "hpo_id": "HP:0002355"}'
+      {"primary_chunk_text": "The child has frequent falls while walking.", "neighbor_chunk_texts": [], "phrase": "frequent falls", "category": "abnormal", "candidates": [{"id": "HP:0002355", "term": "Difficulty walking", "retrieval_score": 0.93, "definition": "Reduced ability to walk (ambulate).", "matched_synonym": "Walking difficulty"}, {"id": "HP:0002359", "term": "Frequent falls", "retrieval_score": 0.91, "definition": "Increased frequency of falls relative to peers.", "matched_synonym": "Frequent falls"}]}
+    output: '{"phrase": "frequent falls", "hpo_id": "HP:0002359"}'

--- a/phentrieve/llm/prompts/templates/two_phase/en_mapping_batch.yaml
+++ b/phentrieve/llm/prompts/templates/two_phase/en_mapping_batch.yaml
@@ -1,4 +1,4 @@
-version: "v4.1.0"
+version: "v4.2.0"
 
 system_prompt: |
   You map clinical phenotype phrases to HPO terms.
@@ -19,14 +19,15 @@ system_prompt: |
   - category
   - primary_chunk_text
   - neighbor_chunk_texts
-  - candidates with id, term, retrieval_score
+  - candidates with id, term, retrieval_score, optional definition, optional matched_synonym, optional matched_component, optional matched_text
 
   Rules:
   - Return one mapping object for each input item.
   - Each mapping must include the original item_id.
   - Choose only one candidate HPO identifier per item_id.
-  - Use the grounded context to disambiguate.
+  - Use the grounded context, candidate definitions, and matched synonyms to disambiguate.
   - Treat retrieval_score as a hint, not the only decision rule.
+  - Prefer the most specific term supported by the evidence.
   - Prefer semantic equivalence over lexical similarity.
   - If category is "normal", choose the abnormal HPO concept that is explicitly absent or normal in context.
   - If no candidate is a clear match, return null for that item_id.
@@ -49,5 +50,5 @@ few_shot_examples:
       Return JSON only.
 
       Payload:
-      {"items": [{"item_id": "item_1", "primary_chunk_text": "Physical examination revealed scoliosis and joint hypermobility", "neighbor_chunk_texts": [], "phrase": "scoliosis", "category": "abnormal", "candidates": [{"id": "HP:0002650", "term": "Scoliosis", "retrieval_score": 0.99}, {"id": "HP:0100884", "term": "Compensatory scoliosis", "retrieval_score": 0.42}]}, {"item_id": "item_2", "primary_chunk_text": "The child has frequent falls while walking.", "neighbor_chunk_texts": [], "phrase": "frequent falls", "category": "abnormal", "candidates": [{"id": "HP:0002355", "term": "Difficulty walking", "retrieval_score": 0.93}, {"id": "HP:0002317", "term": "Unsteady gait", "retrieval_score": 0.67}]}]}
-    output: '{"mappings": [{"item_id": "item_1", "hpo_id": "HP:0002650"}, {"item_id": "item_2", "hpo_id": "HP:0002355"}]}'
+      {"items": [{"item_id": "item_1", "primary_chunk_text": "Physical examination revealed scoliosis and joint hypermobility", "neighbor_chunk_texts": [], "phrase": "scoliosis", "category": "abnormal", "candidates": [{"id": "HP:0002650", "term": "Scoliosis", "retrieval_score": 0.99}, {"id": "HP:0100884", "term": "Compensatory scoliosis", "retrieval_score": 0.42}]}, {"item_id": "item_2", "primary_chunk_text": "The child has frequent falls while walking.", "neighbor_chunk_texts": [], "phrase": "frequent falls", "category": "abnormal", "candidates": [{"id": "HP:0002355", "term": "Difficulty walking", "retrieval_score": 0.93, "definition": "Reduced ability to walk (ambulate).", "matched_synonym": "Walking difficulty"}, {"id": "HP:0002359", "term": "Frequent falls", "retrieval_score": 0.91, "definition": "Increased frequency of falls relative to peers.", "matched_synonym": "Frequent falls"}]}]}
+    output: '{"mappings": [{"item_id": "item_1", "hpo_id": "HP:0002650"}, {"item_id": "item_2", "hpo_id": "HP:0002359"}]}'

--- a/phentrieve/llm/prompts/templates/two_phase/en_mapping_batch.yaml
+++ b/phentrieve/llm/prompts/templates/two_phase/en_mapping_batch.yaml
@@ -28,6 +28,8 @@ system_prompt: |
   - Use the grounded context, candidate definitions, and matched synonyms to disambiguate.
   - Treat retrieval_score as a hint, not the only decision rule.
   - Prefer the most specific term supported by the evidence.
+  - Do not add onset, laterality, severity, or anatomy specificity from neighboring context unless the phrase or evidence explicitly states it.
+  - Do not choose generic modifier or container concepts when context supports a concrete phenotype candidate.
   - Prefer semantic equivalence over lexical similarity.
   - If category is "normal", choose the abnormal HPO concept that is explicitly absent or normal in context.
   - If no candidate is a clear match, return null for that item_id.

--- a/tests/unit/llm/test_evidence_validation.py
+++ b/tests/unit/llm/test_evidence_validation.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import pytest
+
+from phentrieve.llm.evidence_validation import validate_phase1_evidence
+
+pytestmark = pytest.mark.unit
+
+
+def test_validate_phase1_evidence_drops_unknown_chunk_id() -> None:
+    report = validate_phase1_evidence(
+        extracted=[
+            {
+                "phrase": "recurrent seizures",
+                "category": "Abnormal",
+                "chunk_ids": [99],
+                "evidence_text": "recurrent seizures",
+            }
+        ],
+        grounded_chunks=[{"chunk_id": 1, "text": "Patient had recurrent seizures."}],
+    )
+
+    assert report.kept == []
+    assert report.dropped == [
+        {
+            "phrase": "recurrent seizures",
+            "reason": "unknown_chunk_id",
+            "chunk_ids": [99],
+        }
+    ]
+
+
+def test_validate_phase1_evidence_drops_empty_chunk_ids() -> None:
+    report = validate_phase1_evidence(
+        extracted=[
+            {
+                "phrase": "recurrent seizures",
+                "category": "Abnormal",
+                "chunk_ids": [],
+                "evidence_text": "recurrent seizures",
+            }
+        ],
+        grounded_chunks=[{"chunk_id": 1, "text": "Patient had recurrent seizures."}],
+    )
+
+    assert report.kept == []
+    assert report.dropped == [
+        {
+            "phrase": "recurrent seizures",
+            "reason": "empty_chunk_ids",
+            "chunk_ids": [],
+        }
+    ]
+
+
+def test_validate_phase1_evidence_repairs_missing_evidence_from_phrase() -> None:
+    report = validate_phase1_evidence(
+        extracted=[
+            {
+                "phrase": "recurrent seizures",
+                "category": "Abnormal",
+                "chunk_ids": [1],
+                "evidence_text": None,
+            }
+        ],
+        grounded_chunks=[{"chunk_id": 1, "text": "Patient had recurrent seizures."}],
+    )
+
+    assert report.kept[0]["evidence_text"] == "recurrent seizures"
+    assert report.repairs == [
+        {"phrase": "recurrent seizures", "kind": "evidence_text_repair"}
+    ]
+
+
+def test_validate_phase1_evidence_repairs_offsets_from_exact_evidence() -> None:
+    report = validate_phase1_evidence(
+        extracted=[
+            {
+                "phrase": "recurrent seizures",
+                "category": "Abnormal",
+                "chunk_ids": [1],
+                "evidence_text": "recurrent seizures",
+                "start_char": 999,
+                "end_char": 1009,
+            }
+        ],
+        grounded_chunks=[{"chunk_id": 1, "text": "Patient had recurrent seizures."}],
+    )
+
+    assert report.kept[0]["start_char"] == 12
+    assert report.kept[0]["end_char"] == 30
+    assert {"phrase": "recurrent seizures", "kind": "offset_repair"} in report.repairs
+
+
+def test_validate_phase1_evidence_accepts_document_absolute_offsets_as_local() -> None:
+    report = validate_phase1_evidence(
+        extracted=[
+            {
+                "phrase": "recurrent seizures",
+                "category": "Abnormal",
+                "chunk_ids": [1],
+                "evidence_text": "recurrent seizures",
+                "start_char": 112,
+                "end_char": 130,
+            }
+        ],
+        grounded_chunks=[
+            {
+                "chunk_id": 1,
+                "text": "Patient had recurrent seizures.",
+                "start_char": 100,
+                "end_char": 132,
+            }
+        ],
+    )
+
+    assert report.kept[0]["start_char"] == 12
+    assert report.kept[0]["end_char"] == 30
+    assert {
+        "phrase": "recurrent seizures",
+        "kind": "offset_coordinate_repair",
+    } in report.repairs
+
+
+def test_validate_phase1_evidence_downgrades_multichunk_offsets() -> None:
+    report = validate_phase1_evidence(
+        extracted=[
+            {
+                "phrase": "recurrent seizures",
+                "category": "Abnormal",
+                "chunk_ids": [1, 2],
+                "evidence_text": "Patient had recurrent seizures",
+                "start_char": 0,
+                "end_char": 30,
+            }
+        ],
+        grounded_chunks=[
+            {"chunk_id": 1, "text": "Patient had recurrent"},
+            {"chunk_id": 2, "text": "seizures."},
+        ],
+    )
+
+    assert report.kept[0]["start_char"] is None
+    assert report.kept[0]["end_char"] is None
+    assert report.repairs == [
+        {"phrase": "recurrent seizures", "kind": "multi_chunk_offset_downgrade"}
+    ]
+
+
+def test_validate_phase1_evidence_downgrades_fuzzy_evidence_to_chunk_level() -> None:
+    report = validate_phase1_evidence(
+        extracted=[
+            {
+                "phrase": "recurrent seizure",
+                "category": "Abnormal",
+                "chunk_ids": [1],
+                "evidence_text": "recurrent seizure",
+                "start_char": 12,
+                "end_char": 29,
+            }
+        ],
+        grounded_chunks=[{"chunk_id": 1, "text": "Patient had recurrent seizures."}],
+        fuzzy_threshold=80.0,
+    )
+
+    assert report.kept[0]["start_char"] is None
+    assert report.kept[0]["end_char"] is None
+    assert report.kept[0]["evidence_text"] == "recurrent seizure"
+    assert report.repairs == [
+        {"phrase": "recurrent seizure", "kind": "fuzzy_evidence_downgrade"}
+    ]
+
+
+def test_validate_phase1_evidence_drops_ungrounded_evidence() -> None:
+    report = validate_phase1_evidence(
+        extracted=[
+            {
+                "phrase": "invented ataxia",
+                "category": "Abnormal",
+                "chunk_ids": [1],
+                "evidence_text": "invented ataxia",
+            }
+        ],
+        grounded_chunks=[{"chunk_id": 1, "text": "Patient had recurrent seizures."}],
+    )
+
+    assert report.kept == []
+    assert report.dropped == [
+        {
+            "phrase": "invented ataxia",
+            "reason": "evidence_not_grounded",
+            "chunk_ids": [1],
+        }
+    ]
+
+
+def test_validate_phase1_evidence_skips_ungrounded_legacy_inputs() -> None:
+    original = [
+        {
+            "phrase": "recurrent seizures",
+            "category": "Abnormal",
+            "chunk_ids": [],
+            "evidence_text": None,
+        }
+    ]
+
+    report = validate_phase1_evidence(extracted=original, grounded_chunks=[])
+
+    assert report.status == "skipped_no_grounded_chunks"
+    assert report.kept == original
+    assert report.dropped == []
+    assert report.repairs == []
+    assert report.kept is not original

--- a/tests/unit/llm/test_evidence_validation.py
+++ b/tests/unit/llm/test_evidence_validation.py
@@ -171,6 +171,44 @@ def test_validate_phase1_evidence_downgrades_fuzzy_evidence_to_chunk_level() -> 
     ]
 
 
+def test_validate_phase1_evidence_accepts_camel_case_list_boundary() -> None:
+    report = validate_phase1_evidence(
+        extracted=[
+            {
+                "phrase": "Ptosis",
+                "category": "Abnormal",
+                "chunk_ids": [1],
+                "evidence_text": "Ptosis",
+            },
+            {
+                "phrase": "Ophthalmoplegia",
+                "category": "Abnormal",
+                "chunk_ids": [1],
+                "evidence_text": "Ophthalmoplegia",
+            },
+            {
+                "phrase": "Corneal ulcers",
+                "category": "Abnormal",
+                "chunk_ids": [1],
+                "evidence_text": "Corneal ulcers",
+            },
+        ],
+        grounded_chunks=[
+            {
+                "chunk_id": 1,
+                "text": "Other findings include the following:PtosisOphthalmoplegiaCorneal ulcers.",
+            }
+        ],
+    )
+
+    assert [item["phrase"] for item in report.kept] == [
+        "Ptosis",
+        "Ophthalmoplegia",
+        "Corneal ulcers",
+    ]
+    assert report.dropped == []
+
+
 def test_validate_phase1_evidence_drops_ungrounded_evidence() -> None:
     report = validate_phase1_evidence(
         extracted=[

--- a/tests/unit/llm/test_phase2a.py
+++ b/tests/unit/llm/test_phase2a.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import pytest
+
+from phentrieve.llm.phase2a import retrieve_candidates
+
+pytestmark = pytest.mark.unit
+
+
+class FakeToolExecutor:
+    def __init__(self, batch_results: list[dict[str, object]]) -> None:
+        self.batch_results = list(batch_results)
+        self.queries: list[dict[str, object]] = []
+
+    def query_batch_hpo_terms(self, *, phrases, language, n_results):
+        self.queries.append(
+            {
+                "phrases": list(phrases),
+                "language": language,
+                "n_results": n_results,
+            }
+        )
+        return list(self.batch_results)
+
+
+def test_retrieve_candidates_merges_query_variants_and_preserves_grounding() -> None:
+    tool_executor = FakeToolExecutor(
+        [
+            {
+                "phrase": "serum creatinine 11.2 mg/dL",
+                "candidates": [
+                    {
+                        "hpo_id": "HP:0003259",
+                        "term_name": "Elevated serum creatinine",
+                        "score": 0.70,
+                    }
+                ],
+            },
+            {
+                "phrase": "serum creatinine 11.2",
+                "candidates": [
+                    {
+                        "hpo_id": "HP:0003259",
+                        "term_name": "Elevated serum creatinine",
+                        "score": 0.91,
+                    }
+                ],
+            },
+        ]
+    )
+
+    results = retrieve_candidates(
+        actionable=[
+            {
+                "phrase": "serum creatinine 11.2 mg/dL",
+                "category": "Abnormal",
+                "chunk_ids": [2],
+                "evidence_text": "serum creatinine 11.2 mg/dL",
+                "start_char": 9,
+                "end_char": 36,
+            }
+        ],
+        grounded_chunks=[
+            {"chunk_id": 1, "text": "Prior history."},
+            {"chunk_id": 2, "text": "Labs show serum creatinine 11.2 mg/dL."},
+            {"chunk_id": 3, "text": "Follow-up was arranged."},
+        ],
+        language="en",
+        tool_executor=tool_executor,
+        n_results_per_phrase=50,
+        max_unique_candidates=10,
+        min_unique_candidates=3,
+        similarity_threshold=0.60,
+    )
+
+    assert tool_executor.queries == [
+        {
+            "phrases": ["serum creatinine 11.2 mg/dL", "serum creatinine 11.2"],
+            "language": "en",
+            "n_results": 50,
+        }
+    ]
+    assert results == [
+        {
+            "phrase": "serum creatinine 11.2 mg/dL",
+            "category": "Abnormal",
+            "candidates": [
+                {
+                    "hpo_id": "HP:0003259",
+                    "term_name": "Elevated serum creatinine",
+                    "score": 0.91,
+                    "retrieval_query": "serum creatinine 11.2",
+                }
+            ],
+            "chunk_ids": [2],
+            "evidence_text": "serum creatinine 11.2 mg/dL",
+            "start_char": 9,
+            "end_char": 36,
+            "grounded_context": {
+                "chunk_ids": [2],
+                "primary_chunk_text": "Labs show serum creatinine 11.2 mg/dL.",
+                "neighbor_chunk_texts": ["Prior history.", "Follow-up was arranged."],
+            },
+        }
+    ]

--- a/tests/unit/llm/test_phase2a.py
+++ b/tests/unit/llm/test_phase2a.py
@@ -103,3 +103,67 @@ def test_retrieve_candidates_merges_query_variants_and_preserves_grounding() -> 
             },
         }
     ]
+
+
+def test_retrieve_candidates_adds_grounded_context_head_variants() -> None:
+    tool_executor = FakeToolExecutor(
+        [
+            {
+                "phrase": "unilateral",
+                "candidates": [
+                    {
+                        "hpo_id": "HP:0012833",
+                        "term_name": "Unilateral",
+                        "score": 0.99,
+                    }
+                ],
+            },
+            {
+                "phrase": "unilateral seizures",
+                "candidates": [
+                    {
+                        "hpo_id": "HP:0006813",
+                        "term_name": "Focal hemiclonic seizure",
+                        "score": 0.88,
+                    }
+                ],
+            },
+        ]
+    )
+
+    results = retrieve_candidates(
+        actionable=[
+            {
+                "phrase": "unilateral",
+                "category": "Abnormal",
+                "chunk_ids": [2],
+                "evidence_text": "unilateral",
+            }
+        ],
+        grounded_chunks=[
+            {"chunk_id": 1, "text": "following seizures since infancy"},
+            {"chunk_id": 2, "text": "initially unilateral prior to becoming GTC"},
+        ],
+        language="en",
+        tool_executor=tool_executor,
+        n_results_per_phrase=50,
+        max_unique_candidates=10,
+        min_unique_candidates=3,
+        similarity_threshold=0.60,
+    )
+
+    assert tool_executor.queries == [
+        {
+            "phrases": ["unilateral", "unilateral seizures"],
+            "language": "en",
+            "n_results": 50,
+        }
+    ]
+    assert results[0]["candidates"] == [
+        {
+            "hpo_id": "HP:0006813",
+            "term_name": "Focal hemiclonic seizure",
+            "score": 0.88,
+            "retrieval_query": "unilateral seizures",
+        }
+    ]

--- a/tests/unit/llm/test_pipeline.py
+++ b/tests/unit/llm/test_pipeline.py
@@ -385,6 +385,71 @@ def test_two_phase_pipeline_drops_ungrounded_phase1_records_before_retrieval() -
     assert [term.term_id for term in result.terms] == ["HP:0001250"]
 
 
+def test_phase2_mapping_prompt_tokens_per_request_is_recorded() -> None:
+    provider = FakeProvider(
+        responses=[
+            {
+                "parsed": {
+                    "phenotypes": [
+                        grounded_phenotype(
+                            "frequent falls",
+                            "Abnormal",
+                            chunk_ids=[1],
+                            evidence_text="frequent falls",
+                        )
+                    ]
+                }
+            },
+            {
+                "parsed": {
+                    "phrase": "frequent falls",
+                    "hpo_id": "HP:0002359",
+                },
+                "usage": {
+                    "prompt_tokens": 42,
+                    "completion_tokens": 6,
+                    "total_tokens": 48,
+                },
+                "request_count": 1,
+            },
+        ]
+    )
+    tool_executor = FakeToolExecutor(
+        batch_results=[
+            {
+                "phrase": "frequent falls",
+                "candidates": [
+                    {
+                        "hpo_id": "HP:0002355",
+                        "term_name": "Difficulty walking",
+                        "score": 0.81,
+                    },
+                    {
+                        "hpo_id": "HP:0002359",
+                        "term_name": "Frequent falls",
+                        "score": 0.79,
+                    },
+                ],
+            }
+        ]
+    )
+    pipeline = TwoPhaseLLMPipeline(
+        provider=provider,
+        tool_executor=tool_executor,
+        mapping_batch_size=1,
+    )
+
+    result = pipeline.run(
+        text="The child has frequent falls while walking.",
+        grounded_chunks=[
+            {"chunk_id": 1, "text": "The child has frequent falls while walking."}
+        ],
+        config=LLMPipelineConfig(model="gemini-2.5-flash", mode="two_phase"),
+    )
+
+    assert result.meta.phase_counts["phase2_mapping_prompt_tokens_per_request"] == 42
+
+
 def test_phase1_returns_chunk_ids_and_evidence_text():
     provider = FakeProvider(
         responses=[

--- a/tests/unit/llm/test_pipeline.py
+++ b/tests/unit/llm/test_pipeline.py
@@ -3158,6 +3158,164 @@ def test_two_phase_pipeline_batch_mapping_uses_item_ids_for_batch_selections():
     ]
 
 
+def test_mapping_batch_structured_truncation_retries_smaller_batches(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    provider = FakeProvider(
+        responses=[
+            {
+                "parsed": {
+                    "phenotypes": [
+                        grounded_phenotype("feature one", "Abnormal"),
+                        grounded_phenotype("feature two", "Abnormal"),
+                        grounded_phenotype("feature three", "Abnormal"),
+                        grounded_phenotype("feature four", "Abnormal"),
+                    ]
+                },
+            },
+            {
+                "exception": ValueError(
+                    "Invalid JSON: EOF while parsing a string at line 1 column 14331"
+                ),
+                "usage": {
+                    "prompt_tokens": 100,
+                    "completion_tokens": 8192,
+                    "total_tokens": 8292,
+                },
+                "request_count": 2,
+            },
+            {
+                "parsed": {
+                    "mappings": [
+                        {"item_id": "item_1", "hpo_id": "HP:0000001"},
+                        {"item_id": "item_2", "hpo_id": "HP:0000002"},
+                    ]
+                },
+                "usage": {
+                    "prompt_tokens": 20,
+                    "completion_tokens": 5,
+                    "total_tokens": 25,
+                },
+            },
+            {
+                "parsed": {
+                    "mappings": [
+                        {"item_id": "item_1", "hpo_id": "HP:0000003"},
+                        {"item_id": "item_2", "hpo_id": "HP:0000004"},
+                    ]
+                },
+                "usage": {
+                    "prompt_tokens": 22,
+                    "completion_tokens": 5,
+                    "total_tokens": 27,
+                },
+            },
+        ]
+    )
+    tool_executor = FakeToolExecutor(
+        batch_results=[
+            {
+                "phrase": "feature one",
+                "candidates": [
+                    {
+                        "hpo_id": "HP:0000001",
+                        "term_name": "All",
+                        "score": 0.7,
+                    }
+                ],
+            },
+            {
+                "phrase": "feature two",
+                "candidates": [
+                    {
+                        "hpo_id": "HP:0000002",
+                        "term_name": "Mode of inheritance",
+                        "score": 0.7,
+                    }
+                ],
+            },
+            {
+                "phrase": "feature three",
+                "candidates": [
+                    {
+                        "hpo_id": "HP:0000003",
+                        "term_name": "Multicystic kidney dysplasia",
+                        "score": 0.7,
+                    }
+                ],
+            },
+            {
+                "phrase": "feature four",
+                "candidates": [
+                    {
+                        "hpo_id": "HP:0000004",
+                        "term_name": "Onset",
+                        "score": 0.7,
+                    }
+                ],
+            },
+        ]
+    )
+    pipeline = TwoPhaseLLMPipeline(
+        provider=provider,
+        tool_executor=tool_executor,
+        mapping_batch_size=4,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="phentrieve.llm.pipeline"):
+        result = pipeline.run(
+            text="feature one. feature two. feature three. feature four.",
+            grounded_chunks=[
+                {
+                    "chunk_id": 1,
+                    "text": "feature one. feature two. feature three. feature four.",
+                }
+            ],
+            config=LLMPipelineConfig(model="gemini-2.5-flash", mode="two_phase"),
+        )
+
+    assert [term.term_id for term in result.terms] == [
+        "HP:0000001",
+        "HP:0000002",
+        "HP:0000003",
+        "HP:0000004",
+    ]
+    assert len(provider.structured_calls) == 4
+    assert provider.structured_calls[1]["response_model"] is LLMBatchMappingSelections
+    assert (
+        len(
+            extract_mapping_payload_from_prompt(
+                provider.structured_calls[1]["user_prompt"]
+            )["items"]
+        )
+        == 4
+    )
+    assert (
+        len(
+            extract_mapping_payload_from_prompt(
+                provider.structured_calls[2]["user_prompt"]
+            )["items"]
+        )
+        == 2
+    )
+    assert (
+        len(
+            extract_mapping_payload_from_prompt(
+                provider.structured_calls[3]["user_prompt"]
+            )["items"]
+        )
+        == 2
+    )
+    assert result.meta.phase_request_counts["phase2b_llm_requests"] == 4
+    assert result.meta.token_usage["prompt_tokens"] == 152
+    assert result.meta.token_usage["completion_tokens"] == 8207
+    assert any(
+        "retrying with smaller mapping batches" in record.message
+        and "batch_size=4" in record.message
+        for record in caplog.records
+    )
+
+
 def test_two_phase_pipeline_batch_mapping_disambiguates_duplicate_phrase_text() -> None:
     provider = FakeProvider(
         responses=[

--- a/tests/unit/llm/test_pipeline.py
+++ b/tests/unit/llm/test_pipeline.py
@@ -311,6 +311,80 @@ def test_two_phase_pipeline_maps_phrase_via_retrieved_candidates():
     assert len(provider.calls) == 0
 
 
+def test_two_phase_pipeline_drops_ungrounded_phase1_records_before_retrieval() -> None:
+    provider = FakeProvider(
+        responses=[
+            {
+                "parsed": {
+                    "phenotypes": [
+                        grounded_phenotype(
+                            "recurrent seizures",
+                            "Abnormal",
+                            chunk_ids=[1],
+                            evidence_text="recurrent seizures",
+                        ),
+                        grounded_phenotype(
+                            "invented ataxia",
+                            "Abnormal",
+                            chunk_ids=[99],
+                            evidence_text="invented ataxia",
+                        ),
+                    ]
+                }
+            }
+        ]
+    )
+    tool_executor = FakeToolExecutor(
+        batch_results=[
+            {
+                "phrase": "recurrent seizures",
+                "candidates": [
+                    {
+                        "hpo_id": "HP:0001250",
+                        "term_name": "Recurrent seizures",
+                        "score": 0.95,
+                    }
+                ],
+            }
+        ]
+    )
+    pipeline = TwoPhaseLLMPipeline(provider=provider, tool_executor=tool_executor)
+
+    result = pipeline.run(
+        text="Patient had recurrent seizures.",
+        grounded_chunks=[{"chunk_id": 1, "text": "Patient had recurrent seizures."}],
+        config=LLMPipelineConfig(model="gemini-2.5-flash", mode="two_phase"),
+    )
+
+    assert tool_executor.queries == [
+        {
+            "phrases": ["recurrent seizures"],
+            "language": "en",
+            "n_results": 50,
+        }
+    ]
+    assert result.meta.phase_counts["extracted_phrases"] == 2
+    assert result.meta.phase_counts["phase1_validated_phrases"] == 1
+    assert result.meta.phase_counts["phase1_evidence_kept"] == 1
+    assert result.meta.phase_counts["phase1_evidence_dropped"] == 1
+    assert result.meta.trace["phase1_evidence_validation"] == {
+        "status": "validated",
+        "kept_count": 1,
+        "dropped_count": 1,
+        "repair_count": 0,
+        "downgraded_count": 0,
+        "dropped": [
+            {
+                "phrase": "invented ataxia",
+                "reason": "unknown_chunk_id",
+                "chunk_ids": [99],
+            }
+        ],
+        "repairs": [],
+    }
+    assert [term.term_id for term in result.terms] == ["HP:0001250"]
+
+
 def test_phase1_returns_chunk_ids_and_evidence_text():
     provider = FakeProvider(
         responses=[

--- a/tests/unit/llm/test_pipeline.py
+++ b/tests/unit/llm/test_pipeline.py
@@ -2663,6 +2663,94 @@ def test_two_phase_pipeline_routes_high_confidence_english_match_locally() -> No
     assert counts["phase2b_deferred_count"] == 0
 
 
+def test_two_phase_pipeline_defers_short_modifier_when_context_variant_exists() -> None:
+    pipeline = TwoPhaseLLMPipeline(
+        provider=FakeProvider(responses=[]),
+        tool_executor=FakeToolExecutor(batch_results=[]),
+    )
+    item = {
+        "phrase": "unilateral",
+        "category": "Abnormal",
+        "candidates": [
+            {
+                "hpo_id": "HP:0012833",
+                "term_name": "Unilateral",
+                "score": 0.99,
+                "retrieval_query": "unilateral",
+            },
+            {
+                "hpo_id": "HP:0006813",
+                "term_name": "Focal hemiclonic seizure",
+                "score": 0.88,
+                "retrieval_query": "unilateral seizures",
+                "matched_text": "Unilateral clonic seizures",
+            },
+        ],
+        "grounded_context": {
+            "chunk_ids": [2],
+            "primary_chunk_text": "initially unilateral prior to becoming GTC",
+            "neighbor_chunk_texts": ["following seizures since infancy"],
+        },
+        "chunk_ids": [2],
+        "evidence_text": "unilateral",
+    }
+
+    resolved, unresolved, counts = pipeline._route_phase2_candidates(
+        phrase_candidates=[item],
+        language="en",
+    )
+
+    assert resolved == []
+    assert unresolved == [item]
+    assert counts["phase2b_local_accept_count"] == 0
+    assert counts["phase2b_deferred_count"] == 1
+
+
+def test_two_phase_pipeline_routes_high_confidence_abbreviation_expansion_locally() -> (
+    None
+):
+    pipeline = TwoPhaseLLMPipeline(
+        provider=FakeProvider(responses=[]),
+        tool_executor=FakeToolExecutor(batch_results=[]),
+    )
+    item = {
+        "phrase": "GTC",
+        "category": "Abnormal",
+        "candidates": [
+            {
+                "hpo_id": "HP:0025190",
+                "term_name": "Bilateral tonic-clonic seizure with generalized onset",
+                "score": 0.987,
+                "retrieval_query": "generalized tonic-clonic seizures",
+                "matched_text": "Primarily generalized tonic-clonic seizures",
+            },
+            {
+                "hpo_id": "HP:0007334",
+                "term_name": "Bilateral tonic-clonic seizure with focal onset",
+                "score": 0.963,
+                "retrieval_query": "generalized tonic-clonic seizures",
+            },
+        ],
+        "grounded_context": {
+            "chunk_ids": [2],
+            "primary_chunk_text": "The seizures were initially unilateral prior to becoming GTC.",
+            "neighbor_chunk_texts": [],
+        },
+        "chunk_ids": [2],
+        "evidence_text": "GTC",
+    }
+
+    resolved, unresolved, counts = pipeline._route_phase2_candidates(
+        phrase_candidates=[item],
+        language="en",
+    )
+
+    assert [term.term_id for term in resolved] == ["HP:0025190"]
+    assert unresolved == []
+    assert counts["phase2b_local_accept_count"] == 1
+    assert counts["phase2b_deferred_count"] == 0
+
+
 def test_two_phase_pipeline_keeps_german_substring_match_deferred() -> None:
     pipeline = TwoPhaseLLMPipeline(
         provider=FakeProvider(responses=[]),

--- a/tests/unit/llm/test_pipeline.py
+++ b/tests/unit/llm/test_pipeline.py
@@ -939,9 +939,9 @@ def test_grouped_phase1_aggregates_mentions_before_retrieval() -> None:
     result = pipeline.run(
         text="Patient had recurrent seizures. Cognition remained normal.",
         grounded_chunks=[
-            {"chunk_id": 1, "text": "Chunk one."},
-            {"chunk_id": 2, "text": "Chunk two."},
-            {"chunk_id": 3, "text": "Chunk three."},
+            {"chunk_id": 1, "text": "Patient had recurrent"},
+            {"chunk_id": 2, "text": "seizures."},
+            {"chunk_id": 3, "text": "normal cognition."},
         ],
         extraction_groups=[
             {
@@ -1018,8 +1018,8 @@ def test_grouped_phase1_deduplicates_mentions_across_groups() -> None:
     result = pipeline.run(
         text="Patient had recurrent seizures.",
         grounded_chunks=[
-            {"chunk_id": 1, "text": "Chunk one."},
-            {"chunk_id": 2, "text": "Chunk two."},
+            {"chunk_id": 1, "text": "Patient had recurrent seizures."},
+            {"chunk_id": 2, "text": "Additional context."},
         ],
         extraction_groups=[
             {
@@ -1110,7 +1110,7 @@ def test_grouped_phase1_deduplicates_overlapping_mentions_and_merges_grounding()
     result = pipeline.run(
         text="Patient had recurrent seizures since infancy.",
         grounded_chunks=[
-            {"chunk_id": 1, "text": "Patient had recurrent"},
+            {"chunk_id": 1, "text": "Patient had"},
             {"chunk_id": 2, "text": "recurrent seizures"},
             {"chunk_id": 3, "text": "since infancy."},
         ],
@@ -1151,8 +1151,8 @@ def test_grouped_phase1_deduplicates_overlapping_mentions_and_merges_grounding()
             phrase="recurrent seizures",
             evidence_text="Patient had recurrent seizures since infancy",
             chunk_ids=[1, 2, 3],
-            start_char=12,
-            end_char=44,
+            start_char=None,
+            end_char=None,
             match_method="local",
         )
     ]
@@ -1262,16 +1262,16 @@ def test_grouped_mentions_deduplicate_before_retrieval() -> None:
                     phrase="progressive ataxia",
                     evidence_text="difficulty with balance",
                     chunk_ids=[1, 2],
-                    start_char=12,
-                    end_char=30,
+                    start_char=None,
+                    end_char=None,
                     match_method="local",
                 ),
                 LLMPhenotypeEvidence(
                     phrase="progressive ataxia",
                     evidence_text="unsteady gait",
                     chunk_ids=[2, 3],
-                    start_char=64,
-                    end_char=78,
+                    start_char=None,
+                    end_char=None,
                     match_method="local",
                 ),
             ],
@@ -3015,8 +3015,8 @@ def test_unresolved_mapping_batches_skip_duplicate_phrase_candidate_sets() -> No
             "local_fallback": False,
             "evidence_text": "Frequent falls were also reported at school.",
             "chunk_ids": [3],
-            "start_char": 52,
-            "end_char": 66,
+            "start_char": 0,
+            "end_char": 44,
         },
     ]
     assert result.terms == [
@@ -3033,16 +3033,16 @@ def test_unresolved_mapping_batches_skip_duplicate_phrase_candidate_sets() -> No
                     phrase="frequent falls",
                     evidence_text="The child has frequent falls while walking.",
                     chunk_ids=[1],
-                    start_char=14,
-                    end_char=28,
+                    start_char=0,
+                    end_char=43,
                     match_method="llm",
                 ),
                 LLMPhenotypeEvidence(
                     phrase="frequent falls",
                     evidence_text="Frequent falls were also reported at school.",
                     chunk_ids=[3],
-                    start_char=52,
-                    end_char=66,
+                    start_char=0,
+                    end_char=44,
                     match_method="llm",
                 ),
             ],
@@ -3568,6 +3568,12 @@ def test_two_phase_pipeline_accumulates_usage_and_logs_phases(caplog):
         "unresolved_phrases": 1,
         "local_matches": 0,
         "llm_mapped_phrases": 1,
+        "phase1_validated_phrases": 1,
+        "phase1_evidence_kept": 1,
+        "phase1_evidence_dropped": 0,
+        "phase1_evidence_repaired": 0,
+        "phase1_evidence_downgraded": 0,
+        "phase2_mapping_prompt_tokens_per_request": 4,
         "local_fallbacks": 0,
         "phase1_fallbacks": 0,
         "phase2b_local_accept_count": 0,

--- a/tests/unit/llm/test_prompts.py
+++ b/tests/unit/llm/test_prompts.py
@@ -257,6 +257,22 @@ def test_grounded_phase1_prompt_uses_chunk_index_without_repeating_full_text() -
     assert "FULL NOTE SENTINEL" not in rendered
 
 
+def test_grounded_phase1_prompt_names_chunk_index_as_clinical_text() -> None:
+    template = loader.get_prompt(AnnotationMode.TWO_PHASE, "en")
+
+    rendered = pipeline_module._render_phase1_user_prompt(
+        extraction_prompt=template,
+        text="FULL NOTE SENTINEL",
+        grounded_chunks=[
+            {"chunk_id": 1, "text": "recurrent seizures"},
+        ],
+    )
+
+    normalized = " ".join(rendered.lower().split())
+    assert "chunk index is the clinical text" in normalized
+    assert "extract phenotypes from those chunk lines" in normalized
+
+
 def test_legacy_phase1_prompt_keeps_full_text_when_no_grounding() -> None:
     template = loader.get_prompt(AnnotationMode.TWO_PHASE, "en")
 

--- a/tests/unit/llm/test_prompts.py
+++ b/tests/unit/llm/test_prompts.py
@@ -138,6 +138,19 @@ def test_mapping_prompts_describe_enriched_candidate_fields() -> None:
         assert "retrieval_score as a hint" in system
 
 
+def test_mapping_prompts_limit_context_specificity_inference() -> None:
+    for template in [
+        loader.get_mapping_prompt("en"),
+        loader.get_batch_mapping_prompt("en"),
+    ]:
+        system = template.system_prompt
+
+        assert (
+            "Do not add onset, laterality, severity, or anatomy specificity" in system
+        )
+        assert "Do not choose generic modifier or container concepts" in system
+
+
 def test_mapping_prompt_example_prefers_specific_frequent_falls_candidate() -> None:
     template = loader.get_mapping_prompt("en")
     example = template.few_shot_examples[0]

--- a/tests/unit/llm/test_prompts.py
+++ b/tests/unit/llm/test_prompts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -34,6 +35,17 @@ def test_get_batch_mapping_prompt_uses_shared_english_template_with_requested_la
     assert template.language == "de"
     assert template.version == "v4.1.0"
     assert template.source_path.endswith("two_phase/en_mapping_batch.yaml")
+
+
+def test_phase1_few_shot_examples_are_source_faithful() -> None:
+    template = loader.get_prompt(AnnotationMode.TWO_PHASE, "en")
+
+    for example in template.few_shot_examples:
+        source_text = example["input"].split("---", 2)[1]
+        output = json.loads(example["output"])
+        for item in output["phenotypes"]:
+            assert item["phrase"] in item["evidence_text"]
+            assert item["evidence_text"] in source_text
 
 
 def test_load_prompt_template_prefers_user_override(monkeypatch, tmp_path) -> None:

--- a/tests/unit/llm/test_prompts.py
+++ b/tests/unit/llm/test_prompts.py
@@ -22,7 +22,7 @@ def test_get_mapping_prompt_loads_packaged_template() -> None:
     template = loader.get_mapping_prompt("fr")
 
     assert template.language == "fr"
-    assert template.version == "v4.1.0"
+    assert template.version == "v4.2.0"
     assert "You map clinical phenotype phrases to HPO terms." in template.system_prompt
     assert template.source_path.endswith("two_phase/en_mapping.yaml")
 
@@ -33,7 +33,7 @@ def test_get_batch_mapping_prompt_uses_shared_english_template_with_requested_la
     template = loader.get_batch_mapping_prompt("de")
 
     assert template.language == "de"
-    assert template.version == "v4.1.0"
+    assert template.version == "v4.2.0"
     assert template.source_path.endswith("two_phase/en_mapping_batch.yaml")
 
 
@@ -121,6 +121,30 @@ def test_mapping_prompts_keep_single_compact_example() -> None:
 
     assert len(single.few_shot_examples) == 1
     assert len(batch.few_shot_examples) == 1
+
+
+def test_mapping_prompts_describe_enriched_candidate_fields() -> None:
+    for template in [
+        loader.get_mapping_prompt("en"),
+        loader.get_batch_mapping_prompt("en"),
+    ]:
+        system = template.system_prompt
+
+        assert "optional definition" in system
+        assert "optional matched_synonym" in system
+        assert "optional matched_component" in system
+        assert "optional matched_text" in system
+        assert "most specific term supported by the evidence" in system
+        assert "retrieval_score as a hint" in system
+
+
+def test_mapping_prompt_example_prefers_specific_frequent_falls_candidate() -> None:
+    template = loader.get_mapping_prompt("en")
+    example = template.few_shot_examples[0]
+
+    assert '"id": "HP:0002359"' in example["input"]
+    assert '"matched_synonym": "Frequent falls"' in example["input"]
+    assert example["output"] == '{"phrase": "frequent falls", "hpo_id": "HP:0002359"}'
 
 
 def test_batch_mapping_prompt_prefix_stays_stable_before_variable_context() -> None:

--- a/tests/unit/llm/test_two_phase.py
+++ b/tests/unit/llm/test_two_phase.py
@@ -279,6 +279,20 @@ def test_prepare_retrieval_queries_expands_known_abbreviations_after_original():
     assert "X-linked intellectual disability" in queries
 
 
+def test_prepare_retrieval_queries_expands_common_clinical_abbreviations():
+    queries = prepare_retrieval_queries("GTC")
+
+    assert queries[0] == "GTC"
+    assert "generalized tonic-clonic seizures" in queries
+
+
+def test_prepare_retrieval_queries_adds_speech_variant_for_verbal_communication():
+    queries = prepare_retrieval_queries("limited verbal communication")
+
+    assert queries[0] == "limited verbal communication"
+    assert "limited speech" in queries
+
+
 def test_prepare_retrieval_queries_adds_conservative_lab_canonical_variant():
     queries = prepare_retrieval_queries("lactate dehydrogenase was markedly elevated")
 

--- a/tests/unit/llm/test_two_phase.py
+++ b/tests/unit/llm/test_two_phase.py
@@ -179,6 +179,27 @@ def test_prepare_retrieval_queries_does_not_invent_hand_written_paraphrases():
     assert "self-biting" not in queries
 
 
+def test_prepare_retrieval_queries_expands_known_abbreviations_after_original():
+    queries = prepare_retrieval_queries("XLID")
+
+    assert queries[0] == "XLID"
+    assert "X-linked intellectual disability" in queries
+
+
+def test_prepare_retrieval_queries_adds_conservative_lab_canonical_variant():
+    queries = prepare_retrieval_queries("lactate dehydrogenase was markedly elevated")
+
+    assert queries[0] == "lactate dehydrogenase was markedly elevated"
+    assert "elevated lactate dehydrogenase" in queries
+
+
+def test_prepare_retrieval_queries_adds_conservative_low_output_variant():
+    queries = prepare_retrieval_queries("urine output remained low")
+
+    assert queries[0] == "urine output remained low"
+    assert "low urine output" in queries
+
+
 def test_phase1_prompt_says_phase2_handles_retrieval_variants():
     prompt = get_prompt(AnnotationMode.TWO_PHASE, "en")
     system = prompt.render_system_prompt()

--- a/tests/unit/llm/test_two_phase.py
+++ b/tests/unit/llm/test_two_phase.py
@@ -179,17 +179,16 @@ def test_prepare_retrieval_queries_does_not_invent_hand_written_paraphrases():
     assert "self-biting" not in queries
 
 
-def test_phase1_prompt_mentions_normalized_clinical_phrase_for_lab_or_event_evidence():
+def test_phase1_prompt_says_phase2_handles_retrieval_variants():
     prompt = get_prompt(AnnotationMode.TWO_PHASE, "en")
     system = prompt.render_system_prompt()
 
-    assert "normalized" in system.lower()
-    assert "measurement" in system.lower()
-    assert "indirectly" in system.lower()
-    assert "context" in system.lower()
+    assert "Phase 2 will compute retrieval variants" in system
+    assert "faithful extraction" in system
+    assert "short normalized clinical phrase" not in system
 
 
-def test_expand_combined_phase1_extractions_splits_slash_and_shared_head_mentions():
+def test_expand_combined_phase1_extractions_splits_only_source_substring_mentions():
     expanded = expand_combined_phase1_extractions(
         [
             {
@@ -212,15 +211,14 @@ def test_expand_combined_phase1_extractions_splits_slash_and_shared_head_mention
     assert phrases == [
         "hypertonia",
         "spasticity of the extremities",
-        "pontine hypoplasia",
-        "cerebellar hypoplasia",
+        "pontine cerebellar hypoplasia",
     ]
     assert all(item["category"] == "abnormal" for item in expanded)
     assert expanded[0]["chunk_ids"] == [15]
     assert expanded[2]["chunk_ids"] == [44, 45]
 
 
-def test_expand_combined_phase1_extractions_expands_common_phenotype_abbreviations():
+def test_expand_combined_phase1_extractions_keeps_abbreviations_source_faithful():
     expanded = expand_combined_phase1_extractions(
         [
             {
@@ -234,7 +232,7 @@ def test_expand_combined_phase1_extractions_expands_common_phenotype_abbreviatio
 
     assert expanded == [
         {
-            "phrase": "X-linked intellectual disability",
+            "phrase": "XLID",
             "category": "abnormal",
             "chunk_ids": [29],
             "evidence_text": "XLID",

--- a/tests/unit/llm/test_two_phase.py
+++ b/tests/unit/llm/test_two_phase.py
@@ -152,6 +152,99 @@ def test_resolve_with_mapping_prompt_normalizes_phrase_before_llm_call():
     )
 
 
+def test_compact_mapping_item_includes_truncated_definition_and_matched_synonym(
+    monkeypatch,
+):
+    from phentrieve.llm import pipeline_phase2
+
+    def fake_enrich_results_with_details(results, data_dir_override=None):
+        assert results == [{"hpo_id": "HP:0002359", "label": "Frequent falls"}]
+        return [
+            {
+                "hpo_id": "HP:0002359",
+                "label": "Frequent falls",
+                "definition": (
+                    "Increased frequency of falls relative to peers and expected "
+                    "developmental stage with repeated loss of balance during gait."
+                ),
+                "synonyms": ["Frequent falls", "Repeated falls"],
+            }
+        ]
+
+    monkeypatch.setattr(
+        pipeline_phase2,
+        "enrich_results_with_details",
+        fake_enrich_results_with_details,
+    )
+
+    payload = pipeline_phase2.compact_mapping_item(
+        {
+            "phrase": "frequent falls",
+            "category": "abnormal",
+            "grounded_context": {
+                "primary_chunk_text": "The child has frequent falls while walking.",
+                "neighbor_chunk_texts": [],
+            },
+            "candidates": [
+                {
+                    "hpo_id": "HP:0002359",
+                    "term_name": "Frequent falls",
+                    "score": 0.91,
+                    "matched_text": "Frequent falls",
+                    "matched_component": "synonym",
+                }
+            ],
+        },
+        definition_char_limit=64,
+    )
+
+    candidate = payload["candidates"][0]
+    assert candidate["definition"] == (
+        "Increased frequency of falls relative to peers and expected..."
+    )
+    assert candidate["matched_synonym"] == "Frequent falls"
+    assert candidate["matched_text"] == "Frequent falls"
+    assert candidate["matched_component"] == "synonym"
+
+
+def test_compact_mapping_item_continues_without_enrichment_on_database_error(
+    monkeypatch,
+):
+    from phentrieve.llm import pipeline_phase2
+
+    def fake_enrich_results_with_details(results, data_dir_override=None):
+        raise RuntimeError("database locked")
+
+    monkeypatch.setattr(
+        pipeline_phase2,
+        "enrich_results_with_details",
+        fake_enrich_results_with_details,
+    )
+
+    payload = pipeline_phase2.compact_mapping_item(
+        {
+            "phrase": "frequent falls",
+            "category": "abnormal",
+            "grounded_context": {"primary_chunk_text": "frequent falls"},
+            "candidates": [
+                {
+                    "hpo_id": "HP:0002359",
+                    "term_name": "Frequent falls",
+                    "score": 0.91,
+                }
+            ],
+        }
+    )
+
+    assert payload["candidates"] == [
+        {
+            "id": "HP:0002359",
+            "term": "Frequent falls",
+            "retrieval_score": 0.91,
+        }
+    ]
+
+
 def test_prepare_retrieval_queries_strips_unit_suffixes_without_losing_core_phrase():
     queries = prepare_retrieval_queries("serum creatinine 11.2 mg/dL")
 

--- a/tests/unit/test_llm_benchmark.py
+++ b/tests/unit/test_llm_benchmark.py
@@ -114,6 +114,74 @@ def test_run_llm_benchmark_includes_ontology_metrics_when_enabled(monkeypatch):
     assert result["ontology_similarity_formula"] == "hybrid"
 
 
+def test_run_llm_benchmark_observability_includes_mapping_prompt_token_metric(
+    monkeypatch,
+):
+    def fake_load_benchmark_data(test_path: Path, dataset: str):
+        return {
+            "metadata": {"dataset_name": "phenobert_GeneReviews"},
+            "documents": [
+                {
+                    "id": "doc-1",
+                    "text": "Clinical text",
+                    "gold_hpo_terms": [],
+                    "source_dataset": "GeneReviews",
+                }
+            ],
+        }
+
+    class _FakePipeline:
+        def __init__(self, provider):
+            self.provider = provider
+
+        def warmup(self, *, language: str) -> None:
+            return None
+
+        def run(self, *, text, grounded_chunks, config):
+            from phentrieve.llm.types import LLMExtractionResult, LLMMeta
+
+            return LLMExtractionResult(
+                terms=[],
+                meta=LLMMeta(
+                    llm_model=config.model,
+                    llm_mode=config.mode,
+                    phase_counts={
+                        "phase2_mapping_prompt_tokens_per_request": 42,
+                        "phase1_evidence_kept": 1,
+                        "phase1_evidence_dropped": 0,
+                    },
+                    trace={
+                        "phase1_evidence_validation": {
+                            "status": "validated",
+                            "kept_count": 1,
+                            "dropped_count": 0,
+                            "repair_count": 0,
+                            "downgraded_count": 0,
+                            "dropped": [],
+                            "repairs": [],
+                        }
+                    },
+                ),
+            )
+
+    monkeypatch.setattr(llm_benchmark, "load_benchmark_data", fake_load_benchmark_data)
+    monkeypatch.setattr(llm_benchmark, "get_llm_provider", lambda llm_model: object())
+    monkeypatch.setattr(llm_benchmark, "TwoPhaseLLMPipeline", _FakePipeline)
+
+    result = llm_benchmark.run_llm_benchmark(
+        test_file="tests/data/en/phenobert",
+        llm_model="gemini-2.5-flash",
+        dataset="GeneReviews",
+    )
+
+    record = result["prediction_records"][0]
+    assert (
+        record["metadata"]["observability"]["phase2_mapping_prompt_tokens_per_request"]
+        == 42
+    )
+    assert record["trace"]["phase1_evidence_validation"]["status"] == "validated"
+
+
 def test_run_llm_benchmark_requires_hpo_graph_for_ontology_metrics(monkeypatch):
     def fail_load_benchmark_data(*_args, **_kwargs):
         raise AssertionError("benchmark data should not load without ontology graph")


### PR DESCRIPTION
## Summary
- Extracts Phase 2A candidate retrieval into a scoped helper and keeps the retrieval subsystem unchanged.
- Adds source-faithful Phase 1 evidence validation before actionable mapping, with trace counters for kept/dropped/repaired/downgraded evidence.
- Enriches Phase 2 mapping prompts with candidate definitions/synonym metadata and adds prompt-token observability.

## Validation
- make check
- make typecheck-fast
- make test
- Focused LLM regression sweep: uv run pytest tests/unit/llm tests/unit/test_llm_benchmark.py tests/integration/llm -n 0 -v --no-cov

## Notes
- A/B benchmark gates will be run after PR creation using local .env credentials and reported separately.
- No reranking, hybrid retrieval, or new retrieval subsystem was added.