### PR TITLE
fix(frontend): readable phenotype tooltip + non-collapsing annotation hover (v0.22.1)

### DIFF
--- a/.planning/specs/2026-06-13-fulltext-annotation-hover-tooltip-fix-design.md
+++ b/.planning/specs/2026-06-13-fulltext-annotation-hover-tooltip-fix-design.md
@@ -1,0 +1,162 @@
+# Full-text Annotation Hover + Tooltip Fix — Design Spec
+
+- Date: 2026-06-13
+- Branch: `fix/fulltext-annotation-hover-tooltip`
+- Status: Approved (design decisions confirmed with user)
+
+## Problem
+
+In Full Text mode, the submitted clinical note is rendered with HPO phenotype
+mentions highlighted as `<mark>` spans, each wrapped in a Vuetify `v-tooltip`.
+Two defects were reproduced and quantified live on `http://localhost:8080/`
+using Playwright with the reporter's clinical text:
+
+### Bug 1 — Hover collapses all highlights to one ("doesn't reset")
+- Baseline: 22 annotated spans highlighted.
+- On hovering any single span: total highlighted spans drops to **1** — every
+  other annotation reverts to plain text. On leaving, it restores to 22.
+- Root cause: `buildUserNoteSegments()`
+  (`frontend/src/composables/useUserNoteAnnotations.js:95`) filters the term
+  list down to only `activePhenotypeId`:
+  ```js
+  .filter((term) => !activePhenotypeId || term?.hpo_id === activePhenotypeId)
+  ```
+  The segment list is recomputed reactively on hover
+  (`QueryInterface.vue:636` passes `activePhenotypeId` into it), so hover both
+  (a) hides all non-hovered annotations and (b) re-creates the hovered `<mark>`
+  DOM node (its `key` changes from `mark-${j}-…` to `mark-0-…`). The destroyed
+  node never fires `mouseleave`, which is the "doesn't reset / one stays
+  highlighted" perception.
+
+### Bug 2 — Tooltip contrast is unreadable
+- The tooltip renders on Vuetify's **default dark-grey** `#424242` while its
+  inner text stays near-black/blue:
+  - label `rgba(15,23,42,0.92)` on `#424242` → **1.72:1**
+  - eyebrow `rgba(37,99,235,0.92)` on `#424242` → **1.83:1**
+  - WCAG 2.1 SC 1.4.3 requires **4.5:1** for normal text.
+- Root cause: the custom light background lives in a **scoped** `:deep()` rule
+  (`FullTextWorkspace.vue:143`). Scoped `:deep(.annotated-note-tooltip)`
+  compiles to `[data-v-xxx] .annotated-note-tooltip`, but the tooltip content
+  is **teleported to `<body>`**, outside the scoped ancestor, so the rule never
+  matches and Vuetify's default dark surface wins. The inner `__eyebrow` /
+  `__label` color rules *do* apply (those divs are in the component template and
+  carry the scope attribute) — producing dark-on-dark text.
+
+## Approved Decisions
+
+1. **Hover behavior:** keep ALL annotations highlighted; emphasize the hovered
+   phenotype's mention(s). (No dimming of others.)
+2. **Tooltip style:** theme-aware light surface using Vuetify theme tokens —
+   readable at WCAG AA in light AND dark mode.
+3. **Extra scope:** keyboard/focus a11y; audit legacy `AnnotatedDocumentPane.vue`;
+   add regression tests.
+
+## Solution
+
+### Live path (the rendering at `localhost:8080`)
+Components: `QueryInterface.vue` → `components/query/FullTextWorkspace.vue`,
+backed by `composables/useUserNoteAnnotations.js`.
+
+- **Bug 1 fix:** Remove the `activePhenotypeId` filter and parameter from
+  `buildUserNoteSegments()`. Segments become a pure function of
+  `(note, chunks, terms)` and are therefore **stable across hovers** — all
+  spans stay rendered, no DOM re-creation, `mouseleave` always fires. The
+  hovered phenotype's emphasis is driven purely by the existing
+  `annotated-note-span--active` class bound to the `activePhenotypeId` prop
+  (`segment.termIds.includes(activePhenotypeId)`), which is a class toggle, not
+  a structural change. `QueryInterface.vue` stops passing `activePhenotypeId`
+  into the builder (the prop still flows to the child for the emphasis class).
+  Note↔findings cross-highlight already works via shared
+  `hoveredTextProcessPhenotypes` state and is preserved.
+
+- **Bug 2 fix:** Move the tooltip surface styling out of scoped `:deep()` into a
+  **global** (unscoped) `<style>` rule targeting
+  `.v-overlay__content.annotated-note-tooltip`, using:
+  - background `rgb(var(--v-theme-surface))`
+  - text `rgb(var(--v-theme-on-surface))`
+  - eyebrow `rgb(var(--v-theme-primary))`
+  - border `rgba(var(--v-theme-on-surface), 0.12)`
+  This resolves correctly inside the teleported overlay (theme vars cascade from
+  the app theme root) and adapts to light/dark. Target ≥ 4.5:1.
+
+- **A11y (WCAG 1.4.13 + keyboard parity):** make each annotated `<mark>`
+  focusable (`tabindex="0"`, `role="button"`, `aria-label` describing the linked
+  phenotype). The Vuetify `v-tooltip` already opens on focus for bound
+  activators; ensure focus emphasis matches hover emphasis and the tooltip is
+  dismissible (Escape / blur). No change to the dismissible/hoverable defaults.
+
+### Legacy path (audit + align only)
+`components/AnnotatedDocumentPane.vue` (+ `AnnotationActionPopover.vue`), reached
+via `ResultsDisplay.vue` → `FullTextAnnotationWorkspace.vue`. On inspection this
+path uses the CSS Custom Highlight API with a click popover already styled via
+theme tokens (`--v-theme-surface` / `--v-theme-on-surface`), so it does NOT have
+the contrast bug or the collapse-filter. Action: verify it does not regress and
+apply only minimal contrast/focus alignment if a concrete gap is found — no
+rewrite.
+
+## Tests
+
+- `useUserNoteAnnotations.test.js`: with multiple terms AND a non-null
+  `activePhenotypeId`, ALL mentions remain `highlighted` (no collapse); segment
+  structure is independent of `activePhenotypeId`.
+- `FullTextWorkspace.test.js`: rendering N segments yields N `<mark>` elements
+  regardless of `activePhenotypeId`; `--active` toggles only on spans whose
+  `termIds` include the active id; highlighted marks are focusable and expose an
+  `aria-label`; tooltip uses the `annotated-note-tooltip` content-class.
+- Live Playwright re-verification: hovering keeps 22 spans at 22; measured
+  tooltip contrast ≥ 4.5:1; keyboard focus opens a readable tooltip.
+
+## Verification Gate
+
+- `make ci-frontend` (lint + format:check + unit tests + i18n where relevant)
+- `make frontend-test-ci` and `make frontend-build-ci` (GitHub Actions parity)
+- Live Playwright re-check on the running dev stack (Vite dev server against the
+  running API), capturing before/after evidence.
+
+## Implementation Plan (task order)
+
+1. (TDD) Add failing tests for hover-stability in `useUserNoteAnnotations.test.js`.
+2. Remove filter + `activePhenotypeId` param from `buildUserNoteSegments()`.
+3. Update `QueryInterface.vue` builder call (drop `activePhenotypeId`).
+4. `FullTextWorkspace.vue`: global theme-aware tooltip styling; a11y on marks;
+   confirm `--active` emphasis treatment.
+5. (TDD) Extend `FullTextWorkspace.test.js` for all-marks-stable + a11y + tooltip class.
+6. Audit legacy `AnnotatedDocumentPane.vue` / `AnnotationActionPopover.vue`; align if needed.
+7. Run CI-parity frontend gate; fix until green.
+8. Live Playwright + contrast re-verification; capture evidence.
+
+## Verification Results (2026-06-13, live on `localhost:8080`)
+
+- Bug 1: hovering a span now keeps **all** marks highlighted (23/23, 45/45 across
+  multiple notes); `--active` emphasis applies to only the hovered phenotype;
+  highlight resets to 0 active on leave; `<mark>` keys are stable across hovers.
+- Bug 2: tooltip now renders on a theme surface — measured contrast **21:1**
+  (label, black on white) and **5.61:1** (eyebrow, primary on white), both above
+  WCAG AA 4.5:1 (was 1.72:1 / 1.83:1).
+- A11y: marks are focusable (`tabindex=0`) with `aria-label`; tooltip opens on
+  keyboard focus (`open-on-focus`); focus applies the same emphasis as hover.
+  axe-core (wcag2a/2aa/21a/21aa) on the annotated note region: **0 violations**.
+  Fixed an adjacent `button-name` gap (note expand/collapse toggle now named).
+- Legacy `AnnotatedDocumentPane.vue` / `AnnotationActionPopover.vue`: audited —
+  uses the CSS Custom Highlight API + a theme-token light v-menu popover and
+  `sr-only` detail spans; it has neither bug, so it was left unchanged (avoid
+  unrelated refactors).
+- Tests: full frontend suite green (324 passed). `make ci-frontend` green
+  (ESLint, Prettier, tests, build). Python `make typecheck-fast` green (no
+  Python changes).
+- Local-dev LLM quota disabled via `docker-compose.dev.yml`
+  (`PHENTRIEVE_ENV=development`); full-text annotation now succeeds where it
+  previously returned the daily-limit message.
+
+### Known pre-existing finding (out of scope)
+- axe `aria-tooltip-name` flags 118 nodes app-wide — these are **other**
+  Vuetify `v-tooltip` usages (footer icons, log viewer, mode pills), **not** the
+  annotated-note tooltips (0 of the 118). Tracked for a separate a11y pass.
+
+## Out of Scope
+
+- Changing the highlight color identity of the marks (kept; optionally migrated
+  to theme tokens for dark-mode parity as a minor consistency tweak).
+- Backend / annotation pipeline changes.
+- The separate local-dev LLM quota change (already applied in
+  `docker-compose.dev.yml`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,39 @@ together:
 
 ## [Unreleased]
 
+## [0.22.1] — 2026-06-13 (CLI 0.22.1 / API 0.13.0 / Frontend 0.12.1)
+
+### Fixed
+
+- **Full-text annotation hover no longer collapses the highlights.** Hovering a
+  single annotated phrase previously filtered the note down to that one
+  phenotype, so every other highlight disappeared and the re-rendered `<mark>`
+  could leave a highlight "stuck". Annotated segments are now a pure function of
+  the note, chunks, and terms, so all mentions stay highlighted and the hovered
+  phenotype is emphasised purely via a CSS class — no annotations collapse and
+  the highlight always resets on leave.
+- **Phenotype tooltip is now readable.** The tooltip rendered near-black text on
+  Vuetify's default dark surface (~1.7:1 contrast) because the custom surface
+  style sat in a scoped `:deep()` rule that could not reach the body-teleported
+  overlay. It now uses a global, theme-aware surface (`surface` / `on-surface` /
+  `primary` tokens) that meets WCAG AA (≈21:1 label, ≈5.6:1 eyebrow) in both
+  light and dark themes.
+
+### Added
+
+- **Keyboard accessibility for annotated spans.** Annotated mentions are now
+  focusable (`tabindex`, `aria-label`), reveal their tooltip on keyboard focus
+  (`open-on-focus`), and show the same emphasis on focus as on hover (WCAG
+  1.4.13). The clinical-note expand/collapse toggle gained an accessible name.
+
+### Changed
+
+- **Local dev stack no longer enforces the public LLM daily quota.** The quota
+  gate only fires when `PHENTRIEVE_ENV=production`; `docker-compose.dev.yml` now
+  runs the dev API as `development`, so full-text LLM extraction works locally
+  without hitting the daily limit. Set `PHENTRIEVE_ENV=production` in `.env` to
+  exercise production quota behaviour.
+
 ## [0.22.0] — 2026-06-13 (CLI 0.22.0 / API 0.13.0 / Frontend 0.12.0)
 
 ### Changed

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,6 +6,11 @@ services:
     environment:
       # Dynamic ALLOWED_ORIGINS based on configured frontend port
       - ALLOWED_ORIGINS=http://localhost:${FRONTEND_PORT_HOST:-8080},http://localhost:${API_PORT_HOST:-8001},http://localhost:5734,http://localhost:8734
+      # Run the local dev stack as a development environment so the public LLM
+      # daily quota is NOT enforced. The quota gate only fires when
+      # PHENTRIEVE_ENV=production (see api/routers/text_processing_router.py).
+      # Set PHENTRIEVE_ENV=production in .env to test production quota behaviour.
+      - PHENTRIEVE_ENV=${PHENTRIEVE_ENV:-development}
     # Override volumes for development - map local data directory
     volumes:
       - ./data:/phentrieve_data_mount:rw

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "phentrieve-frontend",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "phentrieve-frontend",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "dependencies": {
         "@berntpopp/phenopackets-js": "^1.0.2",
         "axios": "^1.17.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phentrieve-frontend",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/components/QueryInterface.vue
+++ b/frontend/src/components/QueryInterface.vue
@@ -629,11 +629,14 @@ export default {
       this.setHoveredNotePhenotype(turnId, termIds[0]);
     },
     buildUserNoteSegments(item) {
+      // Segments are independent of the hovered phenotype on purpose: the
+      // active phenotype is emphasised via the `active-phenotype-id` prop on
+      // FullTextWorkspace (a CSS class toggle), keeping all annotations
+      // highlighted and the <mark> nodes stable across hovers.
       return deriveUserNoteSegments({
         note: this.getHistoryDisplayQuery(item),
         chunks: item?.response?.processed_chunks,
         terms: item?.response?.aggregated_hpo_terms,
-        activePhenotypeId: this.getHoveredNotePhenotype(item?.id),
       });
     },
     resolveChunkOffsetsInNote(noteText, chunks) {

--- a/frontend/src/components/query/FullTextWorkspace.vue
+++ b/frontend/src/components/query/FullTextWorkspace.vue
@@ -11,6 +11,7 @@
         size="x-small"
         variant="text"
         icon
+        :aria-label="expanded ? 'Collapse clinical note' : 'Expand clinical note'"
         @click="$emit('toggle')"
       >
         <v-icon size="small">
@@ -27,6 +28,7 @@
           v-if="segment.highlighted"
           location="top"
           :open-delay="180"
+          open-on-focus
           max-width="280"
           content-class="annotated-note-tooltip"
           :content-props="{ 'aria-label': segment.tooltip }"
@@ -40,8 +42,12 @@
                 'annotated-note-span--active':
                   activePhenotypeId && segment.termIds.includes(activePhenotypeId),
               }"
+              tabindex="0"
+              :aria-label="`Linked phenotype: ${segment.tooltip}`"
               @mouseenter="$emit('hover', segment.termIds)"
               @mouseleave="$emit('clear-hover')"
+              @focus="$emit('hover', segment.termIds)"
+              @blur="$emit('clear-hover')"
             >
               {{ segment.text }}
             </mark>
@@ -140,30 +146,50 @@ export default {
   box-shadow: inset 0 -0.5em 0 rgba(37, 99, 235, 0.24);
 }
 
-:deep(.annotated-note-tooltip) {
+/* Keyboard focus parity: a focused span gets the same emphasis as hover, plus a
+   visible focus ring for non-pointer users (WCAG 2.4.7 / 1.4.13). */
+.annotated-note-span:focus-visible {
+  outline: 2px solid rgb(var(--v-theme-primary));
+  outline-offset: 2px;
+  background: rgba(37, 99, 235, 0.22);
+}
+</style>
+
+<!--
+  The v-tooltip content is teleported to <body>, outside this component's
+  scoped styles, so a scoped :deep() rule can never reach it. Style it from a
+  GLOBAL block instead. Vuetify's default tooltip surface is dark
+  (surface-variant); we override it with the theme surface/on-surface tokens so
+  the text stays readable (WCAG AA contrast) in BOTH light and dark themes.
+  The selector includes `.v-tooltip >` to out-specify Vuetify's own
+  `.v-tooltip > .v-overlay__content` rule deterministically.
+-->
+<style>
+.v-tooltip > .v-overlay__content.annotated-note-tooltip {
   border-radius: 14px;
-  border: 1px solid rgba(var(--v-theme-outline), 0.12);
-  background: linear-gradient(180deg, rgba(248, 250, 252, 0.98), rgba(255, 255, 255, 1));
-  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.14);
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
+  background: rgb(var(--v-theme-surface));
+  color: rgb(var(--v-theme-on-surface));
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.18);
   padding: 10px 12px;
 }
 
-.annotated-note-tooltip__content {
+.annotated-note-tooltip .annotated-note-tooltip__content {
   display: grid;
   gap: 4px;
 }
 
-.annotated-note-tooltip__eyebrow {
+.annotated-note-tooltip .annotated-note-tooltip__eyebrow {
   font-size: 0.68rem;
   font-weight: 700;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: rgba(37, 99, 235, 0.92);
+  color: rgb(var(--v-theme-primary));
 }
 
-.annotated-note-tooltip__label {
+.annotated-note-tooltip .annotated-note-tooltip__label {
   font-size: 0.82rem;
   line-height: 1.4;
-  color: rgba(15, 23, 42, 0.92);
+  color: rgb(var(--v-theme-on-surface));
 }
 </style>

--- a/frontend/src/composables/useUserNoteAnnotations.js
+++ b/frontend/src/composables/useUserNoteAnnotations.js
@@ -76,7 +76,7 @@ export function resolveMatchedTextRange(noteText, matchedText) {
   };
 }
 
-export function buildUserNoteSegments({ note, chunks, terms, activePhenotypeId }) {
+export function buildUserNoteSegments({ note, chunks, terms }) {
   const fallbackText = typeof note === 'string' ? note : '';
   const normalizedChunks = Array.isArray(chunks) ? chunks : [];
   const normalizedTerms = Array.isArray(terms) ? terms : [];
@@ -91,8 +91,12 @@ export function buildUserNoteSegments({ note, chunks, terms, activePhenotypeId }
   }
 
   const chunkOffsets = resolveChunkOffsetsInNote(fallbackText, normalizedChunks);
+  // Always build highlights for every term. The hovered/active phenotype is
+  // emphasised purely via a CSS class in the template (driven by the
+  // activePhenotypeId prop), so the segment list stays stable across hovers:
+  // no annotations collapse and the <mark> DOM nodes are never re-created
+  // (which previously dropped mouseleave and left a highlight stuck).
   const highlights = normalizedTerms
-    .filter((term) => !activePhenotypeId || term?.hpo_id === activePhenotypeId)
     .flatMap((term) =>
       (Array.isArray(term.text_attributions) ? term.text_attributions : []).map((attr) => ({
         ...attr,

--- a/frontend/src/test/components/FullTextWorkspace.test.js
+++ b/frontend/src/test/components/FullTextWorkspace.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import FullTextWorkspace from '../../components/query/FullTextWorkspace.vue';
+
+const vuetify = createVuetify({ components, directives });
+
+const baseSegments = [
+  { key: 'plain-0', text: 'Patient had ', highlighted: false },
+  {
+    key: 'mark-0',
+    text: 'seizures',
+    highlighted: true,
+    termIds: ['HP:0001250'],
+    tooltip: 'Seizure (HP:0001250)',
+  },
+  { key: 'plain-1', text: ' and ', highlighted: false },
+  {
+    key: 'mark-1',
+    text: 'developmental delay',
+    highlighted: true,
+    termIds: ['HP:0001263'],
+    tooltip: 'Developmental delay (HP:0001263)',
+  },
+];
+
+function mountWorkspace(props = {}) {
+  return mount(FullTextWorkspace, {
+    props: {
+      summary: 'Patient had seizures and developmental delay',
+      meta: '6 words',
+      expanded: true,
+      segments: baseSegments,
+      activePhenotypeId: null,
+      ...props,
+    },
+    global: { plugins: [vuetify] },
+  });
+}
+
+describe('FullTextWorkspace annotated note', () => {
+  it('renders every highlighted segment as a mark (no hover collapse)', () => {
+    const wrapper = mountWorkspace();
+    expect(wrapper.findAll('[data-testid="annotated-note-span"]')).toHaveLength(2);
+  });
+
+  it('exposes each annotated span to keyboard and assistive technology', () => {
+    const wrapper = mountWorkspace();
+    const marks = wrapper.findAll('[data-testid="annotated-note-span"]');
+    marks.forEach((mark) => {
+      expect(mark.attributes('tabindex')).toBe('0');
+      expect(mark.attributes('aria-label')).toBeTruthy();
+    });
+    expect(marks[0].attributes('aria-label')).toContain('Seizure (HP:0001250)');
+  });
+
+  it('keeps all spans highlighted while emphasising only the active phenotype', () => {
+    const wrapper = mountWorkspace({ activePhenotypeId: 'HP:0001250' });
+    const marks = wrapper.findAll('[data-testid="annotated-note-span"]');
+    expect(marks).toHaveLength(2);
+    expect(marks[0].classes()).toContain('annotated-note-span--active');
+    expect(marks[1].classes()).not.toContain('annotated-note-span--active');
+  });
+
+  it('gives the expand/collapse toggle an accessible name', () => {
+    const collapsed = mountWorkspace({ expanded: false });
+    expect(collapsed.get('[data-testid="user-note-summary-toggle"]').attributes('aria-label')).toBe(
+      'Expand clinical note'
+    );
+
+    const expanded = mountWorkspace({ expanded: true });
+    expect(expanded.get('[data-testid="user-note-summary-toggle"]').attributes('aria-label')).toBe(
+      'Collapse clinical note'
+    );
+  });
+
+  it('emits hover/clear for keyboard focus parity with mouse', async () => {
+    const wrapper = mountWorkspace();
+    const firstMark = wrapper.findAll('[data-testid="annotated-note-span"]')[0];
+
+    await firstMark.trigger('focus');
+    expect(wrapper.emitted('hover')?.[0]?.[0]).toEqual(['HP:0001250']);
+
+    await firstMark.trigger('blur');
+    expect(wrapper.emitted('clear-hover')).toBeTruthy();
+  });
+});

--- a/frontend/src/test/components/QueryInterface.test.js
+++ b/frontend/src/test/components/QueryInterface.test.js
@@ -1008,9 +1008,23 @@ describe('QueryInterface (characterization)', () => {
     const phenotypes = wrapper.findAll('[data-testid="full-text-response-phenotype"]');
     await phenotypes[0].trigger('mouseenter');
 
+    // Hovering one phenotype must NOT hide the others: every mention stays
+    // highlighted, and only the hovered phenotype's span gains the active
+    // emphasis class.
     const marks = wrapper.findAll('[data-testid="user-note-expanded"] mark');
-    expect(marks).toHaveLength(1);
-    expect(marks[0].text()).toContain('seizures');
+    expect(marks).toHaveLength(2);
+    const seizuresMark = marks.find((mark) => mark.text().includes('seizures'));
+    const delayMark = marks.find((mark) => mark.text().includes('developmental delay'));
+    expect(seizuresMark.classes()).toContain('annotated-note-span--active');
+    expect(delayMark.classes()).not.toContain('annotated-note-span--active');
+
+    // Leaving resets emphasis without losing any highlight.
+    await phenotypes[0].trigger('mouseleave');
+    const marksAfterLeave = wrapper.findAll('[data-testid="user-note-expanded"] mark');
+    expect(marksAfterLeave).toHaveLength(2);
+    expect(
+      marksAfterLeave.every((mark) => !mark.classes().includes('annotated-note-span--active'))
+    ).toBe(true);
   });
 
   it('shows the linked HPO term in the annotated note span tooltip', async () => {

--- a/frontend/src/test/composables/useUserNoteAnnotations.test.js
+++ b/frontend/src/test/composables/useUserNoteAnnotations.test.js
@@ -33,6 +33,66 @@ describe('useUserNoteAnnotations', () => {
     expect(segments.find((segment) => segment.highlighted)?.text).toBe('seizures');
   });
 
+  it('keeps every phenotype highlighted while one is active (no hover collapse)', () => {
+    const note = 'Patient had seizures. Developmental delay documented.';
+    const chunks = [
+      { chunk_id: 1, text: 'Patient had seizures.' },
+      { chunk_id: 2, text: 'Developmental delay documented.' },
+    ];
+    const terms = [
+      {
+        hpo_id: 'HP:0001250',
+        name: 'Seizure',
+        text_attributions: [{ chunk_id: 1, start_char: 12, end_char: 20 }],
+      },
+      {
+        hpo_id: 'HP:0001263',
+        name: 'Global developmental delay',
+        text_attributions: [{ chunk_id: 2, start_char: 0, end_char: 19 }],
+      },
+    ];
+
+    const highlightedTexts = (activePhenotypeId) =>
+      buildUserNoteSegments({ note, chunks, terms, activePhenotypeId })
+        .filter((segment) => segment.highlighted)
+        .map((segment) => segment.text);
+
+    // Both mentions are highlighted at rest...
+    expect(highlightedTexts(null)).toEqual(['seizures', 'Developmental delay']);
+    // ...and stay highlighted even when one phenotype is the active/hovered one.
+    expect(highlightedTexts('HP:0001250')).toEqual(['seizures', 'Developmental delay']);
+    expect(highlightedTexts('HP:0001263')).toEqual(['seizures', 'Developmental delay']);
+  });
+
+  it('produces identical segment structure regardless of the active phenotype', () => {
+    const note = 'Patient had seizures. Developmental delay documented.';
+    const chunks = [
+      { chunk_id: 1, text: 'Patient had seizures.' },
+      { chunk_id: 2, text: 'Developmental delay documented.' },
+    ];
+    const terms = [
+      {
+        hpo_id: 'HP:0001250',
+        name: 'Seizure',
+        text_attributions: [{ chunk_id: 1, start_char: 12, end_char: 20 }],
+      },
+      {
+        hpo_id: 'HP:0001263',
+        name: 'Global developmental delay',
+        text_attributions: [{ chunk_id: 2, start_char: 0, end_char: 19 }],
+      },
+    ];
+
+    const keysFor = (activePhenotypeId) =>
+      buildUserNoteSegments({ note, chunks, terms, activePhenotypeId }).map(
+        (segment) => segment.key
+      );
+
+    // Stable keys => no DOM re-creation on hover => mouseleave always fires => no stuck highlight.
+    expect(keysFor('HP:0001250')).toEqual(keysFor(null));
+    expect(keysFor('HP:0001263')).toEqual(keysFor(null));
+  });
+
   it('resolves chunk offsets in order within the note', () => {
     const offsets = resolveChunkOffsetsInNote('alpha beta gamma', [
       { chunk_id: 1, text: 'alpha beta' },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "phentrieve"
-version = "0.22.0"
+version = "0.22.1"
 description = "A CLI tool for retrieving Human Phenotype Ontology (HPO) terms from clinical text using multilingual embeddings."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -3389,7 +3389,7 @@ wheels = [
 
 [[package]]
 name = "phentrieve"
-version = "0.22.0"
+version = "0.22.1"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Summary

Fixes two full-text annotation bugs reported from the live UI, plus a local-dev quota papercut, and cuts patch release **v0.22.1** (CLI 0.22.1 / API 0.13.0 / Frontend 0.12.1).

### Bug 1 — hover collapsed all highlights to one
`buildUserNoteSegments()` filtered the note's term list down to the hovered phenotype, so hovering one annotation made **every other highlight disappear** (22 → 1), and the re-rendered `<mark>` could leave a highlight stuck ("doesn't reset"). Segments are now a pure function of `(note, chunks, terms)`; the active phenotype is emphasised via a CSS class only — all mentions stay highlighted and the highlight always resets on leave.

### Bug 2 — unreadable tooltip
The tooltip rendered near-black text on Vuetify's default dark surface (**~1.7:1** contrast) because the custom surface style sat in a scoped `:deep()` rule that can't reach the body-teleported overlay. It now uses a **global, theme-aware** surface (`surface`/`on-surface`/`primary` tokens) meeting WCAG AA (**≈21:1** label, **≈5.6:1** eyebrow) in light and dark themes.

### Accessibility (WCAG 1.4.13)
Annotated spans are focusable (`tabindex`, `aria-label`), reveal the tooltip on keyboard focus (`open-on-focus`) with focus/hover emphasis parity, and the note expand/collapse toggle now has an accessible name. axe-core on the annotated region: **0 violations**.

### Local dev quota
The public LLM daily quota only fires when `PHENTRIEVE_ENV=production`, but the dev stack defaulted to `production`. `docker-compose.dev.yml` now runs the dev API as `development`.

## Verification
- Reproduced + fixed live via Playwright on `localhost:8080`: hover keeps all marks (23/23, 45/45); tooltip 21:1 / 5.6:1 on white; keyboard focus opens a readable tooltip.
- TDD: new/updated unit + component tests (stable segments, all-marks-stay, active emphasis, a11y attrs, toggle name).
- `make ci-local` ✓ (Python quality + frontend, 324 tests), `make security-python` ✓, `make typecheck-fast` ✓.
- Legacy `AnnotatedDocumentPane.vue` audited — uses a different (theme-token) mechanism, has neither bug, left unchanged.

## Out of scope (pre-existing)
- axe `aria-tooltip-name` on ~118 **other** app tooltips (footer / log viewer / mode pills) — not the annotated tooltips.

Spec: `.planning/specs/2026-06-13-fulltext-annotation-hover-tooltip-fix-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)