### PR TITLE
chore(release): 0.23.1 — close out vite 8 / vue-router 5.1 migration (#273)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,21 @@ together:
 
 ## [Unreleased]
 
-## [0.23.0] — 2026-06-14 (CLI 0.23.0 / API 0.14.0 / Frontend 0.13.0)
+## [0.23.1] — 2026-06-14 (CLI 0.23.1 / API 0.14.0 / Frontend 0.13.1)
+
+### Changed
+
+- **Frontend build toolchain migrated to vite 8 / vue-router 5.1.** Records and
+  verifies the toolchain migration tracked in #273. The repo was held on the
+  pinned vite 6 toolchain because `vue-router` 5.1.0 declares
+  `peerOptional vite "^7.0.0 || ^8.0.0"`, which made `npm ci` fail with
+  `ERESOLVE` (held back in #270/#271). The dependency bumps landed in 0.23.0
+  (vite 6 → 8 via rolldown, `vue-router` 5.0.7 → 5.1); this release closes out
+  the migration: the production build — including `vite-plugin-compression`
+  brotli output and the bundle visualizer — and the full 306-test Vitest suite
+  are green under vite 8, and the Docker/CI Node version (`20.19`) satisfies
+  vite's `^20.19.0 || >=22.12.0` requirement. The `vue-router` dependabot ignore
+  block added in #271 has been removed so normal updates resume. Closes #273.
 
 ### Added
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "phentrieve-frontend",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "phentrieve-frontend",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "dependencies": {
         "@berntpopp/phenopackets-js": "^1.0.2",
         "axios": "^1.17.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phentrieve-frontend",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "phentrieve"
-version = "0.23.0"
+version = "0.23.1"
 description = "A CLI tool for retrieving Human Phenotype Ontology (HPO) terms from clinical text using multilingual embeddings."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -3389,7 +3389,7 @@ wheels = [
 
 [[package]]
 name = "phentrieve"
-version = "0.23.0"
+version = "0.23.1"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Summary

Patch release **0.23.1** (CLI 0.23.1 / API 0.14.0 / Frontend 0.13.1) that closes
out the frontend build-toolchain migration tracked in #273.

The dependency bumps actually landed in **0.23.0** (commits `564d853`, `d896f70`):
`vite` 6 → 8 (rolldown) and `vue-router` 5.0.7 → 5.1, which unblocks dependencies
that peer-require vite 7/8. The migration was never documented in the changelog
and #273 was left open. This patch records and **verifies** the migration.

## Verification (all green locally)

- `make ci-frontend` — ESLint, Prettier, **306 Vitest tests**, production build under `vite v8.0.16`.
- Non-CI `npm run build` — `vite-plugin-compression` brotli `.br` output + bundle visualizer work under vite 8.
- `make ci-local` + `make security-python` — Python quality (incl. `uv sync --locked`) and security scans pass.
- Docker (`frontend/Dockerfile` `node:20.19-alpine3.20`) and CI (`node-version: 20.19`) satisfy vite's `^20.19.0 || >=22.12.0`.
- `.github/dependabot.yml` — the `vue-router` ignore block from #271 is already removed; normal updates resume.

## Scope

- Bump CLI 0.23.0 → 0.23.1 (`pyproject.toml` + `uv.lock`), Frontend 0.13.0 → 0.13.1 (`package.json` + `package-lock.json`). API unchanged at 0.14.0.
- CHANGELOG `[0.23.1]` entry documenting the migration.

No functional code change — versions + changelog only.

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)