### PR TITLE
fix(frontend): migrate production URL to phentrieve.org

### DIFF
--- a/frontend/src/composables/usePhenotypeCollection.js
+++ b/frontend/src/composables/usePhenotypeCollection.js
@@ -113,7 +113,7 @@ export function usePhenotypeCollection() {
               id: 'phentrieve',
               name: 'Phentrieve',
               namespacePrefix: 'Phentrieve',
-              url: 'https://phentrieve.kidney-genetics.org/',
+              url: 'https://phentrieve.org/',
               version: import.meta.env.VITE_APP_VERSION || '1.0.0',
               iriPrefix: 'phentrieve',
             },

--- a/frontend/src/constants/urls.js
+++ b/frontend/src/constants/urls.js
@@ -4,4 +4,4 @@
 
 export const HPO_TERM_URL = (hpoId) => `https://hpo.jax.org/browse/term/${hpoId}`;
 export const GITHUB_REPO_URL = 'https://github.com/berntpopp/phentrieve';
-export const PHENTRIEVE_PRODUCTION_URL = 'https://phentrieve.kidney-genetics.org/';
+export const PHENTRIEVE_PRODUCTION_URL = 'https://phentrieve.org/';


### PR DESCRIPTION
Migrates the two hardcoded `phentrieve.kidney-genetics.org` references to the new canonical domain `phentrieve.org`:

- `frontend/src/constants/urls.js:7` — `PHENTRIEVE_PRODUCTION_URL`
- `frontend/src/composables/usePhenotypeCollection.js:116` — phenopacket export resource `url` (provenance embedded in exported phenopackets)

All other domain coupling is already environment-driven (`CORS_EXTRA_ORIGINS`, `PHENTRIEVE_PUBLIC_BASE_URL`, `VITE_API_URL_PUBLIC`). The existing `constants.test.js` assertion (`PHENTRIEVE_PRODUCTION_URL` contains `https://`) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)