### PR TITLE
fix(proxy): honor X-Forwarded-Proto so API emits https redirects

### DIFF
--- a/.env.docker.template
+++ b/.env.docker.template
@@ -64,6 +64,12 @@ PHENTRIEVE_DATA_FORCE_SYNC=false
 # Example: CORS_EXTRA_ORIGINS=https://phentrieve.example.com,https://app.example.com
 CORS_EXTRA_ORIGINS=
 
+# uvicorn proxy-header trust. Behind a reverse proxy (NPM -> frontend nginx ->
+# API) set this to "*" so uvicorn honors X-Forwarded-Proto/For and emits https
+# redirects (otherwise /api and /mcp 307 to http://). Default 127.0.0.1 is only
+# correct for direct access without a proxy.
+FORWARDED_ALLOW_IPS=*
+
 # Production LLM quota enforcement and proxy trust settings
 PHENTRIEVE_ENV=production
 PHENTRIEVE_TRUSTED_PROXY_CIDRS=172.16.0.0/12,127.0.0.1/32

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,6 +131,12 @@ services:
       - PYTHONPATH=/app
       - PYTHONDONTWRITEBYTECODE=1
       - PYTHONUNBUFFERED=1
+      # uvicorn already runs with --proxy-headers; this tells it WHICH upstreams
+      # to trust for X-Forwarded-Proto/For. Default 127.0.0.1 ignores the
+      # frontend nginx (a different container IP), so redirects come out as
+      # http://. Behind the reverse proxy set FORWARDED_ALLOW_IPS=* in .env.docker
+      # (the API is only reachable on the internal/NPM networks).
+      - FORWARDED_ALLOW_IPS=${FORWARDED_ALLOW_IPS:-127.0.0.1}
       - HF_HOME=/app/.cache/huggingface
       - TRANSFORMERS_CACHE=/app/.cache/huggingface/hub
       # CORS: Add production frontend URLs (appends to defaults, comma-separated)

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,5 +1,15 @@
 limit_req_zone $binary_remote_addr zone=text_process_limit:10m rate=6r/m;
 
+# Honor the X-Forwarded-Proto sent by the upstream reverse proxy (NPM terminates
+# TLS and forwards https); fall back to $scheme for direct/dev access. Without
+# this, setting X-Forwarded-Proto to $scheme here (always http on :8080) would
+# overwrite the real https, making the API emit http:// redirects (e.g.
+# /api/v1/health and /mcp 307 -> http://...), which break behind HTTPS.
+map $http_x_forwarded_proto $forwarded_proto {
+    default $http_x_forwarded_proto;
+    ''      $scheme;
+}
+
 server {
     listen 8080;
     server_name _;
@@ -58,7 +68,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
 
         # Increase timeouts for long-running inference tasks
         proxy_read_timeout 300s;
@@ -71,7 +81,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
 
         # Increase timeouts for long-running inference tasks
         proxy_read_timeout 300s;
@@ -85,7 +95,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
 
         # Required for SSE (Server-Sent Events) used by MCP Streamable HTTP
         proxy_http_version 1.1;


### PR DESCRIPTION
## Problem
Behind `NPM (TLS) -> frontend nginx (:8080 http) -> API`, the API emitted **`http://` redirects**: e.g. `GET /api/v1/health` → `307 Location: http://.../api/v1/health/` and `POST /mcp` → `307 → http://.../mcp/`. Clients that don't follow scheme-downgrade redirects (and browsers, via mixed-content) can break; MCP only worked via the exact `/mcp/`.

## Root cause (two bugs)
1. `frontend/nginx.conf` set `proxy_set_header X-Forwarded-Proto $scheme;` — but `$scheme` is always `http` on the `:8080` listener, **overwriting** the `https` that NPM forwarded.
2. uvicorn runs with `--proxy-headers` but no `--forwarded-allow-ips`, so it trusts only `127.0.0.1` and ignored the frontend's (different container IP) forwarded headers.

## Fix
- Add an nginx `map` that honors the incoming `X-Forwarded-Proto` (fallback `$scheme` for direct/dev) and use it on `/api/`, `/api/v1/text/process`, `/mcp`.
- Wire `FORWARDED_ALLOW_IPS` through `docker-compose.yml` (default `127.0.0.1`; set `*` in production `.env.docker`, documented in the template). No API image rebuild needed — the CMD already has `--proxy-headers`.

SPA endpoints (`/info`, `/query/`, ...) already worked; this fixes `/api/v1/health` and `/mcp` to stay on https.

🤖 Generated with [Claude Code](https://claude.com/claude-code)