### PR TITLE
fix(api): serve OpenAPI docs under /api/v1 (reachable via reverse proxy)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 import api.config as api_config
@@ -154,6 +154,12 @@ def create_app() -> FastAPI:
         title="Phentrieve API",
         version=get_api_version(),
         lifespan=lifespan,
+        # Serve the interactive docs/OpenAPI under the /api/v1 prefix so they are
+        # reachable through the frontend reverse proxy (which only forwards /api
+        # and /mcp). At the app root they would be shadowed by the SPA.
+        docs_url="/api/v1/docs",
+        redoc_url="/api/v1/redoc",
+        openapi_url="/api/v1/openapi.json",
     )
 
     application.add_middleware(
@@ -254,6 +260,12 @@ def create_app() -> FastAPI:
     application.include_router(
         text_processing_router.router, tags=["Text Processing and HPO Extraction"]
     )
+
+    @application.get("/api/v1", include_in_schema=False)
+    @application.get("/api/v1/", include_in_schema=False)
+    async def api_v1_root() -> RedirectResponse:
+        """Redirect the API base path to the interactive Swagger docs."""
+        return RedirectResponse(url="/api/v1/docs")
 
     if api_config.PHENTRIEVE_AUTH_ENABLED:
         if not api_config.PHENTRIEVE_AUTH_JWT_SECRET:

--- a/api/main.py
+++ b/api/main.py
@@ -43,6 +43,10 @@ logger = logging.getLogger(__name__)
 # Configure logging for the API using config value
 logging.basicConfig(level=getattr(logging, LOG_LEVEL, logging.INFO))
 
+# Single source of truth for the versioned API path prefix (used by the routers
+# and to place the interactive docs/OpenAPI behind the reverse proxy).
+API_V1_PREFIX = "/api/v1"
+
 
 # =============================================================================
 # MCP (Model Context Protocol) HTTP Mounting
@@ -154,12 +158,12 @@ def create_app() -> FastAPI:
         title="Phentrieve API",
         version=get_api_version(),
         lifespan=lifespan,
-        # Serve the interactive docs/OpenAPI under the /api/v1 prefix so they are
+        # Serve the interactive docs/OpenAPI under the API prefix so they are
         # reachable through the frontend reverse proxy (which only forwards /api
         # and /mcp). At the app root they would be shadowed by the SPA.
-        docs_url="/api/v1/docs",
-        redoc_url="/api/v1/redoc",
-        openapi_url="/api/v1/openapi.json",
+        docs_url=f"{API_V1_PREFIX}/docs",
+        redoc_url=f"{API_V1_PREFIX}/redoc",
+        openapi_url=f"{API_V1_PREFIX}/openapi.json",
     )
 
     application.add_middleware(
@@ -244,28 +248,28 @@ def create_app() -> FastAPI:
         )
 
     application.include_router(
-        query_router.router, prefix="/api/v1/query", tags=["HPO Term Query"]
+        query_router.router, prefix=f"{API_V1_PREFIX}/query", tags=["HPO Term Query"]
     )
     application.include_router(
-        health.router, prefix="/api/v1/health", tags=["Health Check"]
+        health.router, prefix=f"{API_V1_PREFIX}/health", tags=["Health Check"]
     )
     application.include_router(system.router)
     application.include_router(
         similarity_router.router,
-        prefix="/api/v1/similarity",
+        prefix=f"{API_V1_PREFIX}/similarity",
         tags=["HPO Term Similarity"],
     )
     application.include_router(phenopacket_router.router)
-    application.include_router(config_info_router.router, prefix="/api/v1")
+    application.include_router(config_info_router.router, prefix=API_V1_PREFIX)
     application.include_router(
         text_processing_router.router, tags=["Text Processing and HPO Extraction"]
     )
 
-    @application.get("/api/v1", include_in_schema=False)
-    @application.get("/api/v1/", include_in_schema=False)
+    @application.get(API_V1_PREFIX, include_in_schema=False)
+    @application.get(f"{API_V1_PREFIX}/", include_in_schema=False)
     async def api_v1_root() -> RedirectResponse:
         """Redirect the API base path to the interactive Swagger docs."""
-        return RedirectResponse(url="/api/v1/docs")
+        return RedirectResponse(url=application.docs_url or f"{API_V1_PREFIX}/docs")
 
     if api_config.PHENTRIEVE_AUTH_ENABLED:
         if not api_config.PHENTRIEVE_AUTH_JWT_SECRET:

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -4,5 +4,5 @@
 
 [project]
 name = "phentrieve-api"
-version = "0.15.0"
+version = "0.15.1"
 description = "FastAPI backend for Phentrieve HPO term mapping"

--- a/tests/unit/api/test_main_char.py
+++ b/tests/unit/api/test_main_char.py
@@ -60,7 +60,9 @@ class TestRouterMounting:
         assert response.status_code == 200
 
     def test_docs_endpoint_exists(self, client):
-        response = client.get("/docs")
+        # Docs are served under the API prefix (behind the reverse proxy), not at
+        # the app root — assert against the app's configured docs_url, not a path.
+        response = client.get(client.app.docs_url)
         assert response.status_code == 200
 
 

--- a/tests/unit/api/test_research_use_guard.py
+++ b/tests/unit/api/test_research_use_guard.py
@@ -109,7 +109,7 @@ def test_public_hosted_mode_allows_llm_after_research_ack(client, monkeypatch):
 
 
 def test_text_bearing_routes_document_research_ack_header_in_openapi(client):
-    schema = client.get("/openapi.json").json()
+    schema = client.get(client.app.openapi_url).json()
     operations = [
         schema["paths"]["/api/v1/query/"]["get"],
         schema["paths"]["/api/v1/query/"]["post"],


### PR DESCRIPTION
## Problem
`https://phentrieve.org/api/v1/` returns 404, and the Swagger/OpenAPI docs are **unreachable in production**. The docs default to the app root (`/docs`, `/openapi.json`, `/redoc`), but the frontend nginx only proxies `/api` and `/mcp` to the API — so root-level `/docs` etc. hit the SPA (e.g. `/openapi.json` returns `text/html`), and `/api/v1/` has no route.

## Fix
- `docs_url=/api/v1/docs`, `redoc_url=/api/v1/redoc`, `openapi_url=/api/v1/openapi.json` — served under the proxied `/api` prefix.
- Redirect `/api/v1` and `/api/v1/` → `/api/v1/docs` so the API base path lands on Swagger UI.

After deploy: `https://phentrieve.org/api/v1/docs` (Swagger), `/api/v1/redoc`, `/api/v1/openapi.json`, and `/api/v1/` → docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)