### PR TITLE
fix(proxy): https redirect via nginx proxy_redirect, not uvicorn proxy-headers

### DIFF
--- a/.env.docker.template
+++ b/.env.docker.template
@@ -64,11 +64,14 @@ PHENTRIEVE_DATA_FORCE_SYNC=false
 # Example: CORS_EXTRA_ORIGINS=https://phentrieve.example.com,https://app.example.com
 CORS_EXTRA_ORIGINS=
 
-# uvicorn proxy-header trust. Behind a reverse proxy (NPM -> frontend nginx ->
-# API) set this to "*" so uvicorn honors X-Forwarded-Proto/For and emits https
-# redirects (otherwise /api and /mcp 307 to http://). Default 127.0.0.1 is only
-# correct for direct access without a proxy.
-FORWARDED_ALLOW_IPS=*
+# uvicorn proxy-header trust. KEEP THIS 127.0.0.1 behind the reverse proxy.
+# Do NOT set "*": the API does its own client-IP resolution for LLM quota via
+# PHENTRIEVE_TRUSTED_PROXY_CIDRS (it expects request.client.host to be the
+# immediate proxy peer). Letting uvicorn rewrite client.host from
+# X-Forwarded-For breaks that resolver ("Unable to resolve a trusted anonymous
+# subject"). HTTPS redirect scheme is handled in the frontend nginx via
+# `proxy_redirect http:// https://`, so uvicorn does not need to see the proto.
+FORWARDED_ALLOW_IPS=127.0.0.1
 
 # Production LLM quota enforcement and proxy trust settings
 PHENTRIEVE_ENV=production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,11 +131,11 @@ services:
       - PYTHONPATH=/app
       - PYTHONDONTWRITEBYTECODE=1
       - PYTHONUNBUFFERED=1
-      # uvicorn already runs with --proxy-headers; this tells it WHICH upstreams
-      # to trust for X-Forwarded-Proto/For. Default 127.0.0.1 ignores the
-      # frontend nginx (a different container IP), so redirects come out as
-      # http://. Behind the reverse proxy set FORWARDED_ALLOW_IPS=* in .env.docker
-      # (the API is only reachable on the internal/NPM networks).
+      # Keep 127.0.0.1. The API resolves the client IP itself for LLM quota
+      # (PHENTRIEVE_TRUSTED_PROXY_CIDRS) and expects request.client.host to be
+      # the immediate proxy peer; letting uvicorn rewrite it from X-Forwarded-For
+      # (e.g. FORWARDED_ALLOW_IPS=*) breaks that resolver. The https redirect
+      # scheme is fixed in the frontend nginx via `proxy_redirect http:// https://`.
       - FORWARDED_ALLOW_IPS=${FORWARDED_ALLOW_IPS:-127.0.0.1}
       - HF_HOME=/app/.cache/huggingface
       - TRANSFORMERS_CACHE=/app/.cache/huggingface/hub

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -69,6 +69,11 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $forwarded_proto;
+        # Upstream (uvicorn) is reached over plain http and does its own client-IP
+        # resolution for quota (PHENTRIEVE_TRUSTED_PROXY_CIDRS), so we must NOT
+        # enable uvicorn's proxy-header client rewriting. That leaves redirects
+        # with an http:// Location; rewrite the scheme back to https here.
+        proxy_redirect http:// https://;
 
         # Increase timeouts for long-running inference tasks
         proxy_read_timeout 300s;
@@ -82,6 +87,11 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $forwarded_proto;
+        # Upstream (uvicorn) is reached over plain http and does its own client-IP
+        # resolution for quota (PHENTRIEVE_TRUSTED_PROXY_CIDRS), so we must NOT
+        # enable uvicorn's proxy-header client rewriting. That leaves redirects
+        # with an http:// Location; rewrite the scheme back to https here.
+        proxy_redirect http:// https://;
 
         # Increase timeouts for long-running inference tasks
         proxy_read_timeout 300s;
@@ -96,6 +106,11 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $forwarded_proto;
+        # Upstream (uvicorn) is reached over plain http and does its own client-IP
+        # resolution for quota (PHENTRIEVE_TRUSTED_PROXY_CIDRS), so we must NOT
+        # enable uvicorn's proxy-header client rewriting. That leaves redirects
+        # with an http:// Location; rewrite the scheme back to https here.
+        proxy_redirect http:// https://;
 
         # Required for SSE (Server-Sent Events) used by MCP Streamable HTTP
         proxy_http_version 1.1;


### PR DESCRIPTION
## Why
PR #282 enabled `FORWARDED_ALLOW_IPS=*` so uvicorn honored `X-Forwarded-Proto`. But that **also** makes uvicorn rewrite `request.client.host` from `X-Forwarded-For`, which **breaks the API's own client-IP resolver** for LLM quota (`api/llm_quota.py::resolve_subject_ip` expects `client.host` = immediate proxy peer and walks XFF via `PHENTRIEVE_TRUSTED_PROXY_CIDRS`). Full-text (`extraction_backend=llm`) then 503'd: *"Unable to resolve a trusted anonymous subject"*.

## Fix (decouple the two concerns)
- `FORWARDED_ALLOW_IPS=127.0.0.1` → uvicorn does not rewrite `client.host`; the app resolves the client itself → quota works.
- Restore https redirects at the **nginx** layer: `proxy_redirect http:// https://` on `/api/`, `/api/v1/text/process`, `/mcp` → rewrites the upstream `http://` `Location` to `https://`.
- Updated compose + template guidance (do **not** set `FORWARDED_ALLOW_IPS=*`).

Verified on the server: full-text → 200 (gemini), and `/api/v1/health` & `/mcp` redirects → https.

🤖 Generated with [Claude Code](https://claude.com/claude-code)