### PR TITLE
fix(docs): allow cdn.jsdelivr.net in CSP for /api/ so Swagger UI renders

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -83,6 +83,15 @@ server {
     # Proxy API requests to the backend service
     location /api/ {
         proxy_pass http://phentrieve_api:8000/api/;
+
+        # Relax CSP for the OpenAPI docs (Swagger UI / ReDoc) which load assets
+        # from cdn.jsdelivr.net. Scoped to /api/ only, so the SPA (location /)
+        # keeps the strict 'self' policy. NOTE: an add_header here replaces the
+        # inherited security headers, so the important ones are re-stated.
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: https:; font-src 'self' data: https://cdn.jsdelivr.net; worker-src 'self' blob:; connect-src 'self' https:; frame-ancestors 'self';" always;
+
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Problem
`https://phentrieve.org/api/v1/docs` returns 200 but renders **blank**. Verified with Playwright:
```
swagger rendered: false
[error] Loading 'https://cdn.jsdelivr.net/.../swagger-ui.css' violates CSP "style-src 'self' 'unsafe-inline'"
[error] Loading 'https://cdn.jsdelivr.net/.../swagger-ui-bundle.js' violates CSP "script-src 'self' ..."
[pageerror] SwaggerUIBundle is not defined
```
Swagger UI / ReDoc load assets from `cdn.jsdelivr.net`, blocked by the frontend's strict CSP.

## Fix
Add a CSP on the **`/api/` location only** allowing `cdn.jsdelivr.net` for script/style/font (+ `worker-src blob:`). The SPA (`location /`) keeps the strict `'self'` policy — jsdelivr hosts arbitrary packages, so it's not loosened site-wide. Re-states `X-Frame-Options`/`X-Content-Type-Options` since `add_header` in a location replaces inherited headers.

Frontend-only change (no API rebuild).

🤖 Generated with [Claude Code](https://claude.com/claude-code)