### PR TITLE
fix(auth): don't 500 registration when verification email fails to send

### DIFF
--- a/api/auth/router.py
+++ b/api/auth/router.py
@@ -119,6 +119,21 @@ def _issue_session(response: Response, store: UserStore, user: User) -> str:
     )
 
 
+async def _safe_send(*, to: str, subject: str, text: str) -> None:
+    """Send an account email without letting delivery failures break the flow.
+
+    Register / password-reset return generic, non-enumerating responses, so a
+    delivery problem (refused recipient, SMTP/TLS/connection error) must not
+    surface to the client as a 500 — that both breaks the contract and strands
+    the user on a hard error. Log it at ERROR for operators and carry on; the
+    user can re-trigger delivery later via resend-verification / password-reset.
+    """
+    try:
+        await get_email_sender().send(to=to, subject=subject, text=text)
+    except Exception:  # noqa: BLE001 - delivery must never break account flows
+        logger.exception("Failed to send account email to %s", to)
+
+
 async def _send_verify(store: UserStore, user: User) -> None:
     raw = tokens.generate_refresh_token()
     store.put_token(
@@ -129,7 +144,7 @@ async def _send_verify(store: UserStore, user: User) -> None:
     )
     link = f"{api_config.PHENTRIEVE_PUBLIC_BASE_URL}/verify?token={raw}"
     subject, text = build_verify_email(link)
-    await get_email_sender().send(to=user.email, subject=subject, text=text)
+    await _safe_send(to=user.email, subject=subject, text=text)
 
 
 @router.post("/register", response_model=MessageResponse, status_code=201)
@@ -257,7 +272,7 @@ async def password_reset_request(body: EmailRequest) -> MessageResponse:
         )
         link = f"{api_config.PHENTRIEVE_PUBLIC_BASE_URL}/reset-password?token={raw}"
         subject, text = build_reset_email(link)
-        await get_email_sender().send(to=user.email, subject=subject, text=text)
+        await _safe_send(to=user.email, subject=subject, text=text)
     return MessageResponse(message=_RESET_MSG)
 
 

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -4,5 +4,5 @@
 
 [project]
 name = "phentrieve-api"
-version = "0.15.1"
+version = "0.15.2"
 description = "FastAPI backend for Phentrieve HPO term mapping"

--- a/tests/unit/api/test_auth_router.py
+++ b/tests/unit/api/test_auth_router.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+import smtplib
 
 import pytest
 from fastapi.testclient import TestClient
@@ -169,3 +170,48 @@ def test_weak_password_rejected(auth_client):
         "/api/v1/auth/register", json={"email": "b@ex.com", "password": "short"}
     )
     assert r.status_code == 422
+
+
+def test_register_survives_email_send_failure(auth_client, monkeypatch, caplog):
+    """A delivery failure must not turn registration into a 500.
+
+    Account endpoints are non-enumerating: a refused recipient / SMTP outage
+    must be logged for operators but still return the generic 201, otherwise the
+    SPA shows a hard error and the verification email is never (re)sendable.
+    """
+    import api.auth.router as auth_router
+
+    class _BoomSender:
+        async def send(self, *, to, subject, text):
+            raise smtplib.SMTPRecipientsRefused({to: (550, b"blocked (MBL-R)")})
+
+    monkeypatch.setattr(auth_router, "get_email_sender", lambda: _BoomSender())
+    caplog.set_level(logging.ERROR, logger="api.auth.router")
+
+    r = auth_client.post(
+        "/api/v1/auth/register",
+        json={"email": "boom@ex.com", "password": _PASSWORD},
+    )
+    assert r.status_code == 201
+    # Operators still get a signal in the logs.
+    assert "boom@ex.com" in caplog.text
+
+
+def test_password_reset_survives_email_send_failure(auth_client, monkeypatch, caplog):
+    """Password-reset request must also tolerate a delivery failure."""
+    import api.auth.router as auth_router
+
+    _register(auth_client, caplog)
+
+    class _BoomSender:
+        async def send(self, *, to, subject, text):
+            raise smtplib.SMTPException("smtp down")
+
+    monkeypatch.setattr(auth_router, "get_email_sender", lambda: _BoomSender())
+    caplog.set_level(logging.ERROR, logger="api.auth.router")
+
+    r = auth_client.post(
+        "/api/v1/auth/password-reset/request", json={"email": "a@ex.com"}
+    )
+    assert r.status_code == 200
+    assert "a@ex.com" in caplog.text


### PR DESCRIPTION
## Problem

Registration was broken on production: clicking *Konto erstellen* and submitting did nothing useful — no "check your email" message, no email, can't log in.

## Root cause

`register()` (and `password_reset_request`) `await` the SMTP send with **no error handling**. Any delivery failure — a recipient refused by Strato (`SMTPRecipientsRefused`), or an SMTP auth/TLS/connection error — propagates out of the endpoint as an unhandled **HTTP 500**.

Confirmed on prod (timed curl): `POST /api/v1/auth/register` → **500 in 1.8s**, traceback ending in:
```
smtplib.SMTPRecipientsRefused: {'…': (550, b'5.7.0 … blocked due to complaints (MBL-R)')}
```
The account row is created *before* the send, so the user gets a hard error, no verification email, and retries re-trigger the same 500. It also breaks the **non-enumerating** contract of these endpoints (they're meant to always return a generic message).

SMTP auth/TLS themselves work — the failure was recipient-level.

## Fix

Wrap the send in `_safe_send`: log delivery failures at `ERROR` for operators, but still return the generic `201`/`200`. The user can re-trigger delivery later via resend-verification / password-reset.

## Tests

Adds two tests (register + password-reset) asserting the endpoint returns its generic success status when the email backend raises, and that the failure is logged. Both fail on `main`, pass here. Full auth suite: 10 passed.

API version `0.15.1` → `0.15.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)