### PR TITLE
feat(frontend): API + MCP footer shortcuts and /connect MCP guide (frontend 0.16.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,37 @@ together:
 
 ---
 
+## [Unreleased] (Frontend 0.16.0)
+
+Frontend-only changes; CLI/API unchanged at 0.24.0 / 0.16.0. These roll into the
+next unified release.
+
+### Added
+
+- **Footer shortcuts for the API and MCP.** The bottom bar gains two
+  developer-integration icons in the lower right, set off by a divider and
+  placed just before the live status indicator: `mdi-api` opens the live OpenAPI
+  (Swagger UI) docs in a new tab (URL derived from the configured API base), and
+  `mdi-robot-outline` links to the new MCP connection page. Tooltips are
+  localized via `app.footer.apiTooltip` / `app.footer.mcpTooltip` across all five
+  locales.
+- **"Connect an AI Agent (MCP)" page (`/connect`).** A new view
+  (`views/McpAccess.vue`) explaining how to attach Phentrieve's public,
+  read-only MCP server to Claude (web & desktop), ChatGPT developer mode, Claude
+  Code, and Codex CLI, with copy-to-clipboard recipes, the read-only tool
+  inventory, and the research-use disclaimer. The server address is derived from
+  `window.location.origin` (overridable via `VITE_MCP_URL`). The route is
+  `/connect`, not `/mcp`, because the MCP transport is proxied same-origin under
+  the `/mcp` prefix. Includes a "Back to home" affordance mirroring the FAQ view.
+
+### Fixed
+
+- **Anonymous `/auth/refresh` 403 console error.** Silent session restore on app
+  start now skips the refresh request entirely when the readable `csrf_token`
+  cookie is absent (no session to restore, and the request would 403 anyway),
+  eliminating a guaranteed console error on every anonymous visit. A stale
+  persisted user is cleared without a network call.
+
 ## [0.24.0] — 2026-06-14 (CLI 0.24.0 / API 0.16.0 / Frontend 0.15.0)
 
 MCP server stabilization: every quality dimension lifted toward >9/10, traced to

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "phentrieve-frontend",
-  "version": "0.14.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "phentrieve-frontend",
-      "version": "0.14.0",
+      "version": "0.16.0",
       "dependencies": {
         "@berntpopp/phenopackets-js": "^1.0.2",
         "axios": "^1.17.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phentrieve-frontend",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -185,6 +185,46 @@
             />
           </template>
         </v-tooltip>
+        <!-- Developer integrations: live OpenAPI docs + AI agent (MCP) guide -->
+        <v-divider vertical class="mx-1" />
+        <v-tooltip
+          location="top"
+          :text="$t('app.footer.apiTooltip')"
+          :content-props="{ 'aria-label': $t('app.footer.apiTooltip') }"
+        >
+          <template #activator="{ props }">
+            <v-btn
+              v-bind="props"
+              icon="mdi-api"
+              size="small"
+              :href="apiDocsUrl"
+              target="_blank"
+              rel="noopener noreferrer"
+              variant="text"
+              color="primary"
+              aria-label="Open the API documentation (OpenAPI)"
+              class="mr-1"
+            />
+          </template>
+        </v-tooltip>
+        <v-tooltip
+          location="top"
+          :text="$t('app.footer.mcpTooltip')"
+          :content-props="{ 'aria-label': $t('app.footer.mcpTooltip') }"
+        >
+          <template #activator="{ props }">
+            <v-btn
+              v-bind="props"
+              icon="mdi-robot-outline"
+              size="small"
+              :to="{ name: 'connect' }"
+              variant="text"
+              color="primary"
+              aria-label="Connect an AI agent via MCP"
+              class="mr-1"
+            />
+          </template>
+        </v-tooltip>
         <v-tooltip
           location="top"
           text="Version & API Status"
@@ -303,6 +343,7 @@ import { logService } from './services/logService';
 import { tutorialService } from './services/tutorialService';
 import { useApiHealth } from './services/api-health';
 import { GITHUB_REPO_URL } from './constants/urls';
+import { API_URL } from './services/apiClient';
 import { useVersionCheck } from './composables/useVersionCheck';
 import DisclaimerDialog from './components/DisclaimerDialog.vue';
 import LogViewer from './components/LogViewer.vue';
@@ -369,6 +410,11 @@ export default {
     responseTime() {
       const { responseTime } = useApiHealth();
       return responseTime.value;
+    },
+    // Live OpenAPI (Swagger UI) docs URL, derived from the configured API base
+    // (relative '/api/v1' in deployed setups, absolute in local dev).
+    apiDocsUrl() {
+      return `${API_URL.replace(/\/+$/, '')}/docs`;
     },
   },
   created() {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -47,6 +47,8 @@
       "githubTooltip": "Quellcode auf GitHub anzeigen",
       "docsTooltip": "Projektdokumentation ansehen",
       "licenseTooltip": "Projektlizenz ansehen",
+      "apiTooltip": "API-Dokumentation öffnen (OpenAPI)",
+      "mcpTooltip": "KI-Agent verbinden (MCP)",
       "homeTooltip": "Zur Startseite"
     }
   },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -47,7 +47,9 @@
       "copyright": "© {year} Phentrieve",
       "githubTooltip": "View source code on GitHub",
       "docsTooltip": "View project documentation",
-      "licenseTooltip": "View project license"
+      "licenseTooltip": "View project license",
+      "apiTooltip": "Open the API documentation (OpenAPI)",
+      "mcpTooltip": "Connect an AI agent (MCP)"
     }
   },
   "disclaimerDialog": {

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -47,6 +47,8 @@
       "githubTooltip": "Ver código fuente en GitHub",
       "docsTooltip": "Ver documentación del proyecto",
       "licenseTooltip": "Ver licencia del proyecto",
+      "apiTooltip": "Abrir la documentación de la API (OpenAPI)",
+      "mcpTooltip": "Conectar un agente de IA (MCP)",
       "homeTooltip": "Ir a inicio"
     }
   },

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -47,6 +47,8 @@
       "githubTooltip": "Voir le code source sur GitHub",
       "docsTooltip": "Voir la documentation du projet",
       "licenseTooltip": "Voir la licence du projet",
+      "apiTooltip": "Ouvrir la documentation de l'API (OpenAPI)",
+      "mcpTooltip": "Connecter un agent IA (MCP)",
       "homeTooltip": "Aller à l'accueil"
     }
   },

--- a/frontend/src/locales/nl.json
+++ b/frontend/src/locales/nl.json
@@ -47,6 +47,8 @@
       "githubTooltip": "Bekijk broncode op GitHub",
       "docsTooltip": "Bekijk projectdocumentatie",
       "licenseTooltip": "Bekijk projectlicentie",
+      "apiTooltip": "API-documentatie openen (OpenAPI)",
+      "mcpTooltip": "Een AI-agent verbinden (MCP)",
       "homeTooltip": "Ga naar startpagina"
     }
   },

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -16,6 +16,14 @@ const router = createRouter({
       component: () => import('../views/FAQView.vue'),
     },
     {
+      // Informational page on connecting AI agents over MCP. It lives at
+      // `/connect` (not `/mcp`) because the MCP transport itself is served
+      // same-origin under `/mcp` by the Nginx proxy.
+      path: '/connect',
+      name: 'connect',
+      component: () => import('../views/McpAccess.vue'),
+    },
+    {
       path: '/verify',
       name: 'verify-email',
       component: () => import('../views/VerifyEmailView.vue'),

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -14,7 +14,7 @@ import { defineStore } from 'pinia';
 import { ref, computed } from 'vue';
 
 import AuthService from '../services/AuthService';
-import apiClient from '../services/apiClient';
+import apiClient, { readCookie } from '../services/apiClient';
 import { setAccessToken, clearAccessToken } from '../services/authToken';
 import { logService } from '../services/logService';
 
@@ -90,9 +90,21 @@ export const useAuthStore = defineStore(
     /**
      * Silent session restore on app start: try to refresh using the HttpOnly
      * cookie. On failure, clear any stale persisted user. Never throws.
+     *
+     * The refresh exchanges the HttpOnly refresh cookie for a fresh access
+     * token, but it also requires the readable `csrf_token` cookie (double-submit
+     * CSRF) that the server sets alongside it. When that cookie is absent there
+     * is no session to restore, so we skip the network call entirely — this
+     * avoids a guaranteed 403 (and its console noise) on every anonymous visit.
+     * Any stale persisted user is cleared in that case.
      */
     async function initialize() {
       if (initialized.value) return;
+      if (!readCookie('csrf_token')) {
+        if (user.value) clearSession();
+        initialized.value = true;
+        return;
+      }
       try {
         const data = await AuthService.refresh();
         setSession(data.access_token, data.user);

--- a/frontend/src/test/stores/auth.test.js
+++ b/frontend/src/test/stores/auth.test.js
@@ -14,9 +14,10 @@ vi.mock('../../services/AuthService', () => ({
     confirmPasswordReset: vi.fn(),
   },
 }));
-vi.mock('../../services/apiClient', () => ({ default: { get: vi.fn() } }));
+vi.mock('../../services/apiClient', () => ({ default: { get: vi.fn() }, readCookie: vi.fn() }));
 
 import AuthService from '../../services/AuthService';
+import { readCookie } from '../../services/apiClient';
 import { useAuthStore } from '../../stores/auth';
 import { getAccessToken } from '../../services/authToken';
 
@@ -59,23 +60,46 @@ describe('auth store', () => {
     expect(getAccessToken()).toBe(null);
   });
 
-  it('initialize restores a session via refresh', async () => {
+  it('initialize restores a session via refresh when the csrf cookie is present', async () => {
+    readCookie.mockReturnValue('csrf-1');
     AuthService.refresh.mockResolvedValue({
       access_token: 'r1',
       user: { email: 'b@ex.com', is_verified: true },
     });
     const store = useAuthStore();
     await store.initialize();
+    expect(AuthService.refresh).toHaveBeenCalledTimes(1);
     expect(store.isAuthenticated).toBe(true);
     expect(getAccessToken()).toBe('r1');
   });
 
   it('initialize clears a stale persisted user when refresh fails', async () => {
+    readCookie.mockReturnValue('csrf-1');
     AuthService.refresh.mockRejectedValue(new Error('401'));
     const store = useAuthStore();
     store.user = { email: 'stale@ex.com', is_verified: false };
     await store.initialize();
     expect(store.isAuthenticated).toBe(false);
     expect(getAccessToken()).toBe(null);
+  });
+
+  it('initialize skips refresh entirely when no session cookie exists', async () => {
+    // Anonymous visit: no csrf_token cookie -> no session to restore, so the
+    // refresh request (which would 403) must not be made at all.
+    readCookie.mockReturnValue(null);
+    const store = useAuthStore();
+    await store.initialize();
+    expect(AuthService.refresh).not.toHaveBeenCalled();
+    expect(store.isAuthenticated).toBe(false);
+    expect(getAccessToken()).toBe(null);
+  });
+
+  it('initialize clears a stale persisted user without a network call when the cookie is gone', async () => {
+    readCookie.mockReturnValue(null);
+    const store = useAuthStore();
+    store.user = { email: 'stale@ex.com', is_verified: false };
+    await store.initialize();
+    expect(AuthService.refresh).not.toHaveBeenCalled();
+    expect(store.isAuthenticated).toBe(false);
   });
 });

--- a/frontend/src/views/McpAccess.vue
+++ b/frontend/src/views/McpAccess.vue
@@ -1,0 +1,359 @@
+<!-- src/views/McpAccess.vue -->
+<!--
+  Connect an AI Agent (MCP) page.
+
+  Explains how to connect Phentrieve's public, read-only Model Context Protocol
+  (MCP) server to AI clients: Claude (web + desktop), ChatGPT developer mode,
+  and coding agents (Claude Code, Codex CLI).
+
+  The Phentrieve MCP server is served same-origin under `/mcp` (the frontend
+  Nginx proxies it to the API). That is why this informational page lives at
+  `/connect` rather than `/mcp`: anything under `/mcp` is the MCP transport
+  endpoint for AI clients, not a website that renders in a browser.
+-->
+<template>
+  <v-container class="py-8">
+    <v-row justify="center">
+      <v-col cols="12" md="10" lg="9">
+        <!-- Back to home — mirrors the FAQ view's affordance; ms-n2 optically
+             aligns the icon with the content edge below it. -->
+        <v-btn
+          variant="text"
+          color="primary"
+          class="mb-4 ms-n2"
+          :to="{ name: 'home' }"
+          prepend-icon="mdi-arrow-left"
+          aria-label="Navigate back to home page"
+        >
+          Back to home
+        </v-btn>
+
+        <!-- Header -->
+        <div class="text-center mb-8">
+          <v-avatar color="primary" size="80" class="mb-4">
+            <v-icon size="48" color="white">mdi-robot-outline</v-icon>
+          </v-avatar>
+          <h1 class="text-h3 font-weight-bold text-high-emphasis mb-2">
+            Connect an AI Agent (MCP)
+          </h1>
+          <p class="text-h6 text-medium-emphasis">
+            Map clinical text to HPO terms from Claude, ChatGPT, and coding agents over the Model
+            Context Protocol
+          </p>
+        </div>
+
+        <!-- Page-vs-endpoint notice -->
+        <v-alert type="info" variant="tonal" class="mb-6" icon="mdi-information-outline">
+          This page explains how to connect. The address below is an MCP
+          <strong>transport endpoint for AI clients</strong> — not a website, so opening it in a
+          browser will not show a page.
+        </v-alert>
+
+        <!-- What you get -->
+        <v-card class="mb-6" elevation="2">
+          <v-card-title class="card-band">
+            <v-icon color="primary" class="mr-2">mdi-database-search-outline</v-icon>
+            What you get
+          </v-card-title>
+          <v-card-text class="pa-6">
+            <p class="text-body-1 mb-4">
+              A <strong>read-only</strong> connection to Phentrieve's HPO term retrieval and
+              annotation tools. Your agent can search candidate HPO terms, extract phenotypes from
+              research text (deterministic or LLM-assisted), compare term similarity, chunk long
+              documents, and export GA4GH Phenopackets — no write access, no sign-in, and no API
+              key.
+            </p>
+            <div class="d-flex flex-wrap ga-2 mb-4">
+              <v-chip
+                v-for="tool in tools"
+                :key="tool"
+                size="small"
+                variant="tonal"
+                color="primary"
+                label
+              >
+                <v-icon start size="14">mdi-tools</v-icon>
+                {{ tool }}
+              </v-chip>
+            </div>
+            <p class="text-body-2 text-medium-emphasis mb-0">
+              Research use only — Phentrieve's outputs are algorithmic research suggestions, not
+              clinical decision support. Do not submit identifiable patient data to public
+              instances.
+            </p>
+          </v-card-text>
+        </v-card>
+
+        <!-- Server address -->
+        <v-card class="mb-6" elevation="2">
+          <v-card-title class="card-band">
+            <v-icon color="primary" class="mr-2">mdi-link-variant</v-icon>
+            Server address
+          </v-card-title>
+          <v-card-text class="pa-6">
+            <div class="d-flex align-center flex-wrap ga-3">
+              <code class="endpoint-code">{{ mcpEndpoint }}</code>
+              <v-btn
+                size="small"
+                variant="tonal"
+                color="primary"
+                prepend-icon="mdi-content-copy"
+                @click="copy(mcpEndpoint, 'Server address')"
+              >
+                Copy
+              </v-btn>
+              <v-btn
+                size="small"
+                variant="text"
+                color="primary"
+                prepend-icon="mdi-api"
+                :href="apiDocsUrl"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                REST API docs
+              </v-btn>
+            </div>
+            <p class="text-body-2 text-medium-emphasis mt-3 mb-0">
+              Transport: MCP Streamable HTTP. Use this same address in every client below. Some
+              clients need a trailing slash (<code>{{ mcpEndpoint }}/</code>) if they do not follow
+              HTTP redirects.
+            </p>
+          </v-card-text>
+        </v-card>
+
+        <!-- Per-client instructions -->
+        <h2 class="text-h5 font-weight-bold text-high-emphasis mb-4">How to connect</h2>
+        <v-row>
+          <v-col v-for="client in clients" :key="client.id" cols="12" md="6">
+            <v-card class="h-100 d-flex flex-column" elevation="2">
+              <v-card-title class="d-flex align-center">
+                <v-icon :color="client.color" class="mr-2">{{ client.icon }}</v-icon>
+                {{ client.name }}
+              </v-card-title>
+              <v-card-text class="flex-grow-1">
+                <ol class="client-steps mb-3">
+                  <li v-for="(step, i) in client.steps" :key="i" class="mb-1">{{ step }}</li>
+                </ol>
+                <div class="snippet-wrap">
+                  <pre class="snippet"><code>{{ client.snippet }}</code></pre>
+                  <v-btn
+                    class="snippet-copy"
+                    size="x-small"
+                    variant="text"
+                    icon="mdi-content-copy"
+                    :aria-label="`Copy ${client.name} configuration`"
+                    @click="copy(client.snippet, `${client.name} configuration`)"
+                  />
+                </div>
+                <p v-if="client.note" class="text-caption text-medium-emphasis mt-2 mb-0">
+                  {{ client.note }}
+                </p>
+              </v-card-text>
+            </v-card>
+          </v-col>
+        </v-row>
+
+        <!-- Verify tip -->
+        <v-alert type="success" variant="tonal" class="mt-6" icon="mdi-check-circle-outline">
+          Once connected, ask your agent to call <code>phentrieve_get_capabilities</code> first — it
+          lists every available tool, the response modes, limits, error codes, and the citation
+          contract.
+        </v-alert>
+
+        <p class="text-caption text-medium-emphasis mt-4 mb-0">
+          New to MCP? See the
+          <a href="https://modelcontextprotocol.io" target="_blank" rel="noopener noreferrer">
+            Model Context Protocol
+          </a>
+          documentation, or the
+          <a
+            href="https://berntpopp.github.io/phentrieve/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Phentrieve project docs </a
+          >.
+        </p>
+      </v-col>
+    </v-row>
+
+    <!-- Copy confirmation -->
+    <v-snackbar v-model="snackbar" :timeout="2000" :color="snackbarSuccess ? 'success' : 'error'">
+      {{ snackbarMessage }}
+    </v-snackbar>
+  </v-container>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue';
+import { API_URL } from '@/services/apiClient';
+import { logService } from '@/services/logService';
+
+// Phentrieve serves MCP same-origin under `/mcp` (Nginx proxies it to the API),
+// so derive the endpoint from the current origin. This adapts automatically to
+// production (https://phentrieve.org/mcp), staging, and the local Docker stack
+// (http://localhost:8080/mcp). VITE_MCP_URL overrides it for custom deployments.
+const origin = typeof window !== 'undefined' ? window.location.origin : 'https://phentrieve.org';
+const mcpEndpoint = ref((import.meta.env.VITE_MCP_URL || `${origin}/mcp`).replace(/\/+$/, ''));
+
+// Live OpenAPI (Swagger UI) docs URL, derived from the configured API base.
+const apiDocsUrl = `${API_URL.replace(/\/+$/, '')}/docs`;
+
+// Read-only tools exposed by the server (kept in sync with docs/mcp-server.md).
+const tools = [
+  'phentrieve_search_hpo_terms',
+  'phentrieve_extract_hpo_terms',
+  'phentrieve_extract_hpo_terms_llm',
+  'phentrieve_compare_hpo_terms',
+  'phentrieve_chunk_text',
+  'phentrieve_export_phenopacket',
+  'phentrieve_get_capabilities',
+  'phentrieve_diagnostics',
+];
+
+// Connection recipes per client, verified against current (2026) official docs.
+// Steps are intentionally short; the copy-pasteable command/config lives in
+// `snippet`, and `note` carries the most important caveat. Endpoint and server
+// name are interpolated so the snippets are correct for this deployment.
+const serverName = 'phentrieve';
+const clients = computed(() => {
+  const url = mcpEndpoint.value;
+  return [
+    {
+      id: 'claude',
+      name: 'Claude (web & desktop)',
+      icon: 'mdi-creation',
+      color: 'deep-orange',
+      steps: [
+        'In Claude, open Settings → Connectors (claude.ai/settings/connectors).',
+        'Click "Add custom connector".',
+        'Paste the server address into the URL field and click Add (leave the OAuth fields empty).',
+        'In a chat, open the "+" menu → Connectors and toggle phentrieve on.',
+      ],
+      snippet: url,
+      note: 'Same steps on claude.ai and Claude Desktop. Custom connectors are in beta; the Free plan allows one.',
+    },
+    {
+      id: 'chatgpt',
+      name: 'ChatGPT',
+      icon: 'mdi-chat-processing-outline',
+      color: 'green-darken-1',
+      steps: [
+        'On chatgpt.com, open Settings → Apps & Connectors → Advanced and turn on Developer mode.',
+        'Click "Create" to add a new connector.',
+        `Set Name to "Phentrieve", MCP server URL to the address, Authentication to "No authentication", then create.`,
+        'In a chat, open the "+" menu and enable the Phentrieve app.',
+      ],
+      snippet: `Name:  Phentrieve\nURL:   ${url}\nAuth:  No authentication`,
+      note: 'Web only (chatgpt.com); Plus, Pro, Business, Enterprise, or Edu. Developer mode is in beta.',
+    },
+    {
+      id: 'claude-code',
+      name: 'Claude Code',
+      icon: 'mdi-console',
+      color: 'blue-grey-darken-1',
+      steps: [
+        'Run the command below (flags go before the server name).',
+        'For a shared/team setup, add --scope project to write it into .mcp.json.',
+        'Verify with "claude mcp list", or run "/mcp" inside a session.',
+      ],
+      snippet: `claude mcp add --transport http ${serverName} ${url}`,
+      note: `Or hand-edit .mcp.json → { "mcpServers": { "${serverName}": { "type": "http", "url": "${url}" } } }`,
+    },
+    {
+      id: 'codex',
+      name: 'Codex CLI',
+      icon: 'mdi-code-braces',
+      color: 'indigo-darken-1',
+      steps: [
+        'Add the table below to ~/.codex/config.toml (or run the shortcut command).',
+        'Verify with "codex mcp list", then start Codex.',
+        'If it does not connect, update Codex to the latest release first.',
+      ],
+      snippet: `# ~/.codex/config.toml\n[mcp_servers.${serverName}]\nurl = "${url}"\n\n# or, on current Codex releases:\ncodex mcp add ${serverName} --url ${url}`,
+      note: 'Remote Streamable-HTTP servers are first-class in current Codex releases.',
+    },
+  ];
+});
+
+// Copy confirmation snackbar state.
+const snackbar = ref(false);
+const snackbarSuccess = ref(true);
+const snackbarMessage = ref('');
+
+const showSnackbar = (message, success) => {
+  snackbarMessage.value = message;
+  snackbarSuccess.value = success;
+  snackbar.value = true;
+};
+
+/**
+ * Copy text to the clipboard and surface the outcome via the snackbar.
+ * Uses the async Clipboard API (available in secure contexts); failures and
+ * unsupported environments report an error rather than failing silently.
+ */
+const copy = (text, label) => {
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        showSnackbar(`${label} copied to clipboard`, true);
+        logService.debug('MCP page clipboard copy', { label });
+      })
+      .catch((err) => {
+        showSnackbar('Failed to copy — select and copy manually', false);
+        logService.warn('MCP page clipboard copy failed', { label, error: err.message });
+      });
+  } else {
+    showSnackbar('Copying is unavailable — select and copy manually', false);
+    logService.warn('MCP page clipboard API unavailable', { label });
+  }
+};
+</script>
+
+<style scoped>
+/* Theme-aware "code surface": faint on-surface tint that follows light/dark. */
+.card-band {
+  background-color: rgba(var(--v-theme-primary), 0.08);
+}
+
+.endpoint-code {
+  padding: 0.35rem 0.6rem;
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
+  border-radius: 6px;
+  background: rgba(var(--v-theme-on-surface), 0.04);
+  color: rgb(var(--v-theme-on-surface));
+  font-size: 0.95rem;
+  word-break: break-all;
+}
+
+.client-steps {
+  padding-left: 1.15rem;
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.snippet-wrap {
+  position: relative;
+}
+
+.snippet {
+  overflow-x: auto;
+  margin: 0;
+  padding: 0.75rem 2.25rem 0.75rem 0.85rem;
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
+  border-radius: 6px;
+  background: rgba(var(--v-theme-on-surface), 0.04);
+  color: rgb(var(--v-theme-on-surface));
+  font-size: 0.82rem;
+  line-height: 1.45;
+  white-space: pre;
+}
+
+.snippet-copy {
+  position: absolute;
+  top: 0.3rem;
+  right: 0.3rem;
+}
+</style>


### PR DESCRIPTION
## Summary

Adds two developer-integration shortcuts to the footer (lower right, set off by a divider, just before the live status indicator) and a new MCP onboarding page. Pattern adapted from the sibling `hnf1b-db` project.

- **API icon** (`mdi-api`) → live OpenAPI/Swagger docs (URL derived from the configured API base, opens in a new tab).
- **MCP icon** (`mdi-robot-outline`) → new **`/connect`** page (`views/McpAccess.vue`) explaining how to attach Phentrieve's public, read-only MCP server to **Claude (web & desktop), ChatGPT, Claude Code, and Codex CLI**, with copy-paste recipes, the read-only tool inventory, and the research-use disclaimer. Endpoint derived from `window.location.origin` (overridable via `VITE_MCP_URL`).
  - Route is `/connect`, **not** `/mcp`, because the MCP transport is proxied same-origin under the `/mcp` prefix.
  - Includes a "Back to home" affordance mirroring the FAQ view.
- Footer tooltips localized across all five locales.

### Fixed
- Anonymous **`/auth/refresh` 403 console error**: silent session restore now skips the refresh request when the readable `csrf_token` cookie is absent (no session to restore; it would 403 anyway), clearing any stale persisted user without a network call. Adds auth-store test coverage.

## Version
Bumps frontend **0.15.0 → 0.16.0** (frontend-only; CLI/API unchanged).

## Verification
- `make ci-frontend` ✅ (ESLint, Prettier check, 321 Vitest tests, prod build)
- `make security-frontend` ✅ (0 vulnerabilities)
- i18n parity ✅; verified live in the Docker dev stack (footer icons, `/connect` rendering with correct interpolated endpoints, clean console, back-nav to home).

🤖 Generated with [Claude Code](https://claude.com/claude-code)