### PR TITLE
Phase 2: extraction contract v2 (B0–B3) + precision-regression root-cause fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,51 @@ together:
 
 ## [Unreleased]
 
+## [0.25.0] — 2026-07-04 (CLI 0.25.0 / API 0.17.0 / Frontend 0.17.0)
+
+LLM extraction contract v2 (Phase 2, blocks B0–B3): the model's assertion and
+experiencer axes become load-bearing, family-history findings are partitioned
+out of the proband set, ruled-out qualifiers surface as excluded findings, and a
+canonical `absent → excluded` export vocabulary closes the long-standing
+"absent silently exports as present" trap. Includes a deep review pass that
+root-caused and eliminated a precision regression and hardened the benchmark.
+
+### Added
+
+- **Family-history findings** are partitioned from proband terms and surfaced
+  separately through the service, REST, and MCP; the Phenopacket export is guarded
+  by experiencer so family mentions never leak into the proband packet.
+- **`negated_qualifier → excluded` findings.** An "X without Y" phrase emits a
+  generated excluded finding for Y (gated by the similarity floor), surfaced
+  through REST and MCP.
+- **Ontology guard.** Resolved terms known to sit outside Phenotypic abnormality
+  (HP:0000118) — clinical modifiers/course such as "Mild", "Spatial pattern",
+  "Slowly progressive" — are dropped from the output. Fails open on unknown
+  ancestry so a real finding is never removed.
+- **Benchmark `assertion_distribution` report** so the negation/family axes the
+  contract produces (which present-only scoring projects away) stay visible,
+  including a `documents_counted` / `documents_total` under-count guard.
+
+### Changed
+
+- **A `normal` finding now exports as excluded** across every surface (REST, MCP,
+  Phenopacket, Vue). A normalcy verdict is a ruled-out abnormality; this matches
+  the LLM backend and closes the normal-exports-as-present class.
+- **Extraction benchmark is multi-vector aware** with committed strict +
+  present-only baselines as a regression fence; `assert-no-regression` now fails
+  closed on a missing gated metric or a missing `scoring_mode`.
+
+### Fixed
+
+- **Phase-2 mapping precision regression** eliminated at its root: dropped the
+  unused `experiencer`/`assertion` keys that perturbed the mapping LLM toward
+  modifier nodes, and stopped a `normal` category being promoted to `present`.
+  Restores the benchmark to baseline exactly (recall unchanged).
+- **CLI Phenopacket export** of `status`/`excluded`-keyed aggregated terms now
+  exports ruled-out findings as excluded instead of defaulting to present.
+- **Ontology-guard cache** no longer latches the fail-open empty map for the
+  process lifetime when the HPO database is briefly unavailable.
+
 ## [0.24.1] — 2026-07-03 (CLI 0.24.1 / API 0.16.1 / Frontend 0.16.1)
 
 Dependency, security, and code-scanning maintenance — consolidates the open

--- a/api/mcp/capabilities.py
+++ b/api/mcp/capabilities.py
@@ -141,6 +141,16 @@ def _descriptor_body(details: tuple[str, ...]) -> dict[str, Any]:
             "phase_timings for a per-phase breakdown.",
         },
         "extraction_backends": ["standard", "llm"],
+        "extract_output_contract": (
+            "Extract responses carry aggregated_hpo_terms (proband findings) plus "
+            "family_history_findings (terms attributed to a relative, kept "
+            "separate so a family member's finding is never conflated with the "
+            "proband's). Each aggregated/family term includes experiencer "
+            "(proband / family_history / other) and a derived excluded:bool "
+            "(true when the finding is negated/absent/ruled-out); the raw "
+            "assertion/status value is left unchanged. The family list is "
+            "budgeted independently under response_mode."
+        ),
         "llm_modes": ["two_phase"],
         "llm_internal_modes": ["whole_document_grounded", "whole_document_legacy"],
         "citation_contract": (

--- a/api/mcp/projection.py
+++ b/api/mcp/projection.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from phentrieve.assertion_vocab import is_excluded
+
 # R3: cap synonyms in the *response* (never the list used for attribution
 # matching, which lives in the retrieval/extraction layer) so include_details
 # does not dump an uncapped synonym list. Report how many were dropped.
@@ -75,6 +77,19 @@ def project_aggregated_terms_for_mcp(
         out["score"] = term.get("score", term.get("max_score_from_evidence", 0.0))
         if "evidence_count" not in out and "count" in term:
             out["evidence_count"] = term["count"]
+
+        # Derive excluded as a FALLBACK so MCP matches REST for ALL backends
+        # (B2fix). The LLM backend and family list already carry a precomputed
+        # bool -- leave those untouched (idempotent). Only the deterministic
+        # backend, which sets no excluded, needs the status-derived flag. Use
+        # status (dropped below) or the just-normalized assertion. False (not
+        # None) survives the trailing None-filter, so a present term keeps its
+        # excluded=false. experiencer is left as-is: when absent it stays absent
+        # (no misleading "proband" default).
+        if not isinstance(out.get("excluded"), bool):
+            out["excluded"] = is_excluded(
+                out.get("status") or out.get("assertion") or ""
+            )
 
         # Single 1-based chunk-index scheme.
         if term.get("source_chunk_ids") is not None:

--- a/api/mcp/projection.py
+++ b/api/mcp/projection.py
@@ -140,6 +140,12 @@ def project_extract_payload(
         out["aggregated_hpo_terms"] = project_aggregated_terms_for_mcp(
             payload["aggregated_hpo_terms"]
         )
+    # Family-history findings share the aggregated-term shape; project them the
+    # same way so experiencer / excluded survive and the identity keys normalize.
+    if isinstance(payload.get("family_history_findings"), list):
+        out["family_history_findings"] = project_aggregated_terms_for_mcp(
+            payload["family_history_findings"]
+        )
     if isinstance(payload.get("processed_chunks"), list):
         out["processed_chunks"] = project_processed_chunks_for_mcp(
             payload["processed_chunks"], include_unmatched=include_unmatched_chunks

--- a/api/mcp/schemas.py
+++ b/api/mcp/schemas.py
@@ -44,6 +44,7 @@ EXTRACT_SCHEMA = envelope_schema(
     meta=_OBJ,
     processed_chunks=_ARR,
     aggregated_hpo_terms=_ARR,
+    family_history_findings=_ARR,
 )
 COMPARE_SCHEMA = envelope_schema(
     term1_id=_STR,

--- a/api/mcp/service_adapters.py
+++ b/api/mcp/service_adapters.py
@@ -381,7 +381,14 @@ def _coerce_export_phenotype(request_cls: Any, p: dict[str, Any], idx: int) -> A
     assertion = p.get("assertion") or p.get("status") or p.get("assertion_status")
     # A family-history mention is not a proband phenotypic feature; never fold it
     # into an affirmed feature on the subject (LLM-1). Drop it from the packet.
-    if str(assertion).strip().lower() == "family_history":
+    # Experiencer (not assertion) now carries family-ness (B1 split them into
+    # separate axes); key the guard on experiencer, keeping the legacy
+    # assertion check as a defensive OR fallback (B2).
+    experiencer = str(p.get("experiencer") or "").strip().lower()
+    if (
+        experiencer == "family_history"
+        or str(assertion).strip().lower() == "family_history"
+    ):
         return None
     confidence = p.get("score")
     if confidence is None:

--- a/api/mcp/service_adapters.py
+++ b/api/mcp/service_adapters.py
@@ -24,6 +24,7 @@ from api.llm_quota import (
 )
 from api.mcp.envelope import McpToolError
 from api.mcp.projection import cap_response_synonyms
+from phentrieve.assertion_vocab import is_excluded
 from phentrieve.config import (
     DEFAULT_ASSERTION_CONFIG,
     DEFAULT_LANGUAGE,
@@ -394,7 +395,7 @@ def _coerce_export_phenotype(request_cls: Any, p: dict[str, Any], idx: int) -> A
     return request_cls(
         hpo_id=hpo_id,
         label=p.get("label") or p.get("name") or hpo_id,
-        assertion_status="negated" if assertion == "negated" else "affirmed",
+        assertion_status="negated" if is_excluded(assertion) else "affirmed",
         confidence=confidence,
         source_chunk_ids=[c for c in chunk_ids if isinstance(c, int)],
         match_method=match_method,

--- a/api/mcp/tools/retrieval.py
+++ b/api/mcp/tools/retrieval.py
@@ -171,8 +171,10 @@ def register_retrieval_tools(mcp: FastMCP) -> None:
             shaped, trunc = enforce_budget(
                 shaped, mode, list_field="aggregated_hpo_terms"
             )
-            # Budget the family list independently so it is never silently
-            # trimmed nor exempted from the mode's char budget (B2).
+            # Budget the family list after the aggregated list and toward the
+            # SAME total-payload char budget (enforce_budget measures the whole
+            # payload each call), so it is never silently trimmed nor exempted
+            # from the mode's budget (B2).
             shaped, family_trunc = enforce_budget(
                 shaped, mode, list_field="family_history_findings"
             )
@@ -255,8 +257,10 @@ def register_retrieval_tools(mcp: FastMCP) -> None:
             shaped, trunc = enforce_budget(
                 shaped, mode, list_field="aggregated_hpo_terms"
             )
-            # Budget the family list independently so it is never silently
-            # trimmed nor exempted from the mode's char budget (B2).
+            # Budget the family list after the aggregated list and toward the
+            # SAME total-payload char budget (enforce_budget measures the whole
+            # payload each call), so it is never silently trimmed nor exempted
+            # from the mode's budget (B2).
             shaped, family_trunc = enforce_budget(
                 shaped, mode, list_field="family_history_findings"
             )

--- a/api/mcp/tools/retrieval.py
+++ b/api/mcp/tools/retrieval.py
@@ -171,6 +171,11 @@ def register_retrieval_tools(mcp: FastMCP) -> None:
             shaped, trunc = enforce_budget(
                 shaped, mode, list_field="aggregated_hpo_terms"
             )
+            # Budget the family list independently so it is never silently
+            # trimmed nor exempted from the mode's char budget (B2).
+            shaped, family_trunc = enforce_budget(
+                shaped, mode, list_field="family_history_findings"
+            )
             meta: dict[str, Any] = {
                 "next_commands": after_extract(
                     shaped.get("aggregated_hpo_terms", []), mode
@@ -178,6 +183,8 @@ def register_retrieval_tools(mcp: FastMCP) -> None:
             }
             if trunc:
                 meta["truncated"] = trunc
+            if family_trunc:
+                meta["family_history_findings_truncated"] = family_trunc
             _maybe_citation(meta, mode)
             shaped["_meta"] = meta
             return shaped
@@ -248,6 +255,11 @@ def register_retrieval_tools(mcp: FastMCP) -> None:
             shaped, trunc = enforce_budget(
                 shaped, mode, list_field="aggregated_hpo_terms"
             )
+            # Budget the family list independently so it is never silently
+            # trimmed nor exempted from the mode's char budget (B2).
+            shaped, family_trunc = enforce_budget(
+                shaped, mode, list_field="family_history_findings"
+            )
             meta: dict[str, Any] = {
                 "next_commands": after_extract(
                     shaped.get("aggregated_hpo_terms", []), mode
@@ -255,6 +267,8 @@ def register_retrieval_tools(mcp: FastMCP) -> None:
             }
             if trunc:
                 meta["truncated"] = trunc
+            if family_trunc:
+                meta["family_history_findings_truncated"] = family_trunc
             _maybe_citation(meta, mode)
             shaped["_meta"] = meta
             return shaped

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -4,5 +4,5 @@
 
 [project]
 name = "phentrieve-api"
-version = "0.16.1"
+version = "0.17.0"
 description = "FastAPI backend for Phentrieve HPO term mapping"

--- a/api/schemas/text_processing_schemas.py
+++ b/api/schemas/text_processing_schemas.py
@@ -197,6 +197,22 @@ class AggregatedHPOTermAPI(BaseModel):
     status: str = Field(
         description="Aggregated assertion status (e.g., 'affirmed', 'negated')."
     )
+    experiencer: str | None = Field(
+        default=None,
+        description=(
+            "Who the finding belongs to (e.g., 'proband', 'family_history', "
+            "'other'), orthogonal to the present/negated assertion. None when "
+            "the backend does not attribute an experiencer."
+        ),
+    )
+    excluded: bool = Field(
+        default=False,
+        description=(
+            "Derived ruled-out flag: True when the aggregated status denotes a "
+            "negated/absent finding. Non-breaking companion to 'status' -- the "
+            "raw status value is left unchanged."
+        ),
+    )
     evidence_count: int
     source_chunk_ids: list[int] = Field(
         description="List of 1-based chunk_ids that provide evidence."
@@ -260,4 +276,12 @@ class TextProcessingResponseAPI(BaseModel):
     aggregated_hpo_terms: list[AggregatedHPOTermAPI] = Field(
         ...,
         description="Final list of aggregated HPO terms extracted from the document.",
+    )
+    family_history_findings: list[AggregatedHPOTermAPI] = Field(
+        default_factory=list,
+        description=(
+            "HPO terms attributed to a family member (experiencer != proband), "
+            "kept separate from aggregated_hpo_terms so a relative's finding is "
+            "never conflated with the proband's."
+        ),
     )

--- a/api/schemas/text_processing_schemas.py
+++ b/api/schemas/text_processing_schemas.py
@@ -229,6 +229,28 @@ class AggregatedHPOTermAPI(BaseModel):
         default_factory=list,
         description="Text spans in source chunks attributed to this HPO term.",
     )
+    negated_qualifier: str | None = Field(
+        default=None,
+        description=(
+            "The negated portion Y of an 'X without Y' phrase carried on the "
+            "source finding (X). None on ordinary findings."
+        ),
+    )
+    qualifier_surface_text: str | None = Field(
+        default=None,
+        description=(
+            "For a negated_qualifier-derived excluded finding (B3): the surface "
+            "text Y that was retrieved and mapped. None on ordinary findings."
+        ),
+    )
+    match_method: str | None = Field(
+        default=None,
+        description=(
+            "Provenance of how the term was resolved. "
+            "'negated_qualifier_derived' marks a generated excluded finding. "
+            "None when the backend does not report a match method."
+        ),
+    )
     # HPO term details (populated when include_details=True)
     definition: str | None = Field(
         None, description="Definition of the HPO term (when include_details=True)."

--- a/api/services/text_processing_execution.py
+++ b/api/services/text_processing_execution.py
@@ -82,6 +82,9 @@ def _build_aggregated_hpo_term(term: dict[str, Any]) -> AggregatedHPOTermAPI:
             for attr in _coerce_response_items(term.get("text_attributions"))
             if isinstance(attr, dict)
         ],
+        negated_qualifier=term.get("negated_qualifier"),
+        qualifier_surface_text=term.get("qualifier_surface_text"),
+        match_method=term.get("match_method"),
         definition=term.get("definition"),
         synonyms=term.get("synonyms"),
         score=term.get("score"),

--- a/api/services/text_processing_execution.py
+++ b/api/services/text_processing_execution.py
@@ -15,6 +15,7 @@ from api.services.text_processing_context import (
     prepare_standard_text_processing_context,
     validate_model_name,
 )
+from phentrieve.assertion_vocab import is_excluded
 from phentrieve.config import (
     DEFAULT_ASSERTION_CONFIG,
     DEFAULT_CHUNK_RETRIEVAL_THRESHOLD,
@@ -49,6 +50,42 @@ def _coerce_text_attribution_chunk_id(attr: dict[str, Any]) -> int:
         return chunk_idx + 1
 
     return 1
+
+
+def _build_aggregated_hpo_term(term: dict[str, Any]) -> AggregatedHPOTermAPI:
+    """Build an API term, carrying experiencer and deriving excluded (B2, F2).
+
+    ``excluded`` prefers a precomputed value from the shared service (the LLM
+    backend sets it) and otherwise derives it from the aggregated status via
+    ``is_excluded`` so the deterministic backend -- which has no precomputed
+    excluded -- still surfaces the actionable ruled-out flag.
+    """
+    return AggregatedHPOTermAPI(
+        hpo_id=str(term.get("hpo_id") or term.get("id") or ""),
+        name=term.get("name", ""),
+        confidence=term.get("confidence", 0.0),
+        status=term.get("status", "unknown"),
+        experiencer=term.get("experiencer"),
+        excluded=bool(term.get("excluded", is_excluded(term.get("status", "")))),
+        evidence_count=term.get("evidence_count", 0),
+        source_chunk_ids=term.get("source_chunk_ids")
+        or [chunk_idx + 1 for chunk_idx in term.get("chunks", [])],
+        max_score_from_evidence=term.get("max_score_from_evidence", term.get("score")),
+        top_evidence_chunk_id=term.get("top_evidence_chunk_id"),
+        text_attributions=[
+            TextAttributionSpanAPI(
+                chunk_id=_coerce_text_attribution_chunk_id(attr),
+                start_char=attr.get("start_char", 0),
+                end_char=attr.get("end_char", 0),
+                matched_text_in_chunk=attr.get("matched_text_in_chunk", ""),
+            )
+            for attr in _coerce_response_items(term.get("text_attributions"))
+            if isinstance(attr, dict)
+        ],
+        definition=term.get("definition"),
+        synonyms=term.get("synonyms"),
+        score=term.get("score"),
+    )
 
 
 def validate_response_chunk_references(
@@ -132,39 +169,18 @@ def adapt_shared_service_response_to_api(
             )
         )
 
-    aggregated_terms: list[AggregatedHPOTermAPI] = []
-    for term in _coerce_response_items(service_result.get("aggregated_hpo_terms")):
-        if not isinstance(term, dict):
-            continue
-
-        aggregated_terms.append(
-            AggregatedHPOTermAPI(
-                hpo_id=str(term.get("hpo_id") or term.get("id") or ""),
-                name=term.get("name", ""),
-                confidence=term.get("confidence", 0.0),
-                status=term.get("status", "unknown"),
-                evidence_count=term.get("evidence_count", 0),
-                source_chunk_ids=term.get("source_chunk_ids")
-                or [chunk_idx + 1 for chunk_idx in term.get("chunks", [])],
-                max_score_from_evidence=term.get(
-                    "max_score_from_evidence", term.get("score")
-                ),
-                top_evidence_chunk_id=term.get("top_evidence_chunk_id"),
-                text_attributions=[
-                    TextAttributionSpanAPI(
-                        chunk_id=_coerce_text_attribution_chunk_id(attr),
-                        start_char=attr.get("start_char", 0),
-                        end_char=attr.get("end_char", 0),
-                        matched_text_in_chunk=attr.get("matched_text_in_chunk", ""),
-                    )
-                    for attr in _coerce_response_items(term.get("text_attributions"))
-                    if isinstance(attr, dict)
-                ],
-                definition=term.get("definition"),
-                synonyms=term.get("synonyms"),
-                score=term.get("score"),
-            )
+    aggregated_terms = [
+        _build_aggregated_hpo_term(term)
+        for term in _coerce_response_items(service_result.get("aggregated_hpo_terms"))
+        if isinstance(term, dict)
+    ]
+    family_history_findings = [
+        _build_aggregated_hpo_term(term)
+        for term in _coerce_response_items(
+            service_result.get("family_history_findings")
         )
+        if isinstance(term, dict)
+    ]
 
     if standard_context is not None:
         meta.update(
@@ -188,6 +204,7 @@ def adapt_shared_service_response_to_api(
             "meta": meta,
             "processed_chunks": processed_chunks,
             "aggregated_hpo_terms": aggregated_terms,
+            "family_history_findings": family_history_findings,
         }
     )
 

--- a/api/services/text_processing_execution.py
+++ b/api/services/text_processing_execution.py
@@ -212,6 +212,11 @@ def adapt_shared_service_response_to_api(
         validate_response_chunk_references(
             response.processed_chunks, response.aggregated_hpo_terms
         )
+        # Family terms share the aggregated-term shape and the same chunk index
+        # space, so give them the same dangling-chunk-ref sanity check (B2fix).
+        validate_response_chunk_references(
+            response.processed_chunks, response.family_history_findings
+        )
 
     return response
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "phentrieve-frontend",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "phentrieve-frontend",
-      "version": "0.16.1",
+      "version": "0.17.0",
       "dependencies": {
         "@berntpopp/phenopackets-js": "^1.0.2",
         "axios": "^1.17.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phentrieve-frontend",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/composables/usePhenotypeCollection.js
+++ b/frontend/src/composables/usePhenotypeCollection.js
@@ -3,10 +3,19 @@ import { useConversationStore } from '../stores/conversation';
 import { useFileDownload } from './useFileDownload';
 import { logService } from '../services/logService';
 
-// Mirrors the Python 6-value `_NEGATED` / `is_excluded` set (B0 contract,
-// phentrieve/assertion_vocab.py) so an assertion_status of 'absent' (not only
-// literal 'negated') exports as excluded: true in the Phenopacket.
-const EXCLUDED_ASSERTIONS = new Set(['negated', 'negative', 'absent', 'excluded', 'no', 'denied']);
+// Mirrors the Python `is_excluded` set (B0 contract, phentrieve/assertion_vocab.py)
+// so an assertion_status of 'absent' -- and 'normal', a normalcy verdict that is a
+// ruled-out abnormality -- exports as excluded: true in the Phenopacket, not only
+// literal 'negated'.
+const EXCLUDED_ASSERTIONS = new Set([
+  'negated',
+  'negative',
+  'absent',
+  'excluded',
+  'no',
+  'denied',
+  'normal',
+]);
 const isExcluded = (a) =>
   EXCLUDED_ASSERTIONS.has(
     String(a ?? '')

--- a/frontend/src/composables/usePhenotypeCollection.js
+++ b/frontend/src/composables/usePhenotypeCollection.js
@@ -6,15 +6,13 @@ import { logService } from '../services/logService';
 // Mirrors the Python 6-value `_NEGATED` / `is_excluded` set (B0 contract,
 // phentrieve/assertion_vocab.py) so an assertion_status of 'absent' (not only
 // literal 'negated') exports as excluded: true in the Phenopacket.
-const EXCLUDED_ASSERTIONS = new Set([
-  'negated',
-  'negative',
-  'absent',
-  'excluded',
-  'no',
-  'denied',
-]);
-const isExcluded = (a) => EXCLUDED_ASSERTIONS.has(String(a ?? '').trim().toLowerCase());
+const EXCLUDED_ASSERTIONS = new Set(['negated', 'negative', 'absent', 'excluded', 'no', 'denied']);
+const isExcluded = (a) =>
+  EXCLUDED_ASSERTIONS.has(
+    String(a ?? '')
+      .trim()
+      .toLowerCase()
+  );
 
 /**
  * Composable for managing phenotype collection state and actions.

--- a/frontend/src/composables/usePhenotypeCollection.js
+++ b/frontend/src/composables/usePhenotypeCollection.js
@@ -3,6 +3,19 @@ import { useConversationStore } from '../stores/conversation';
 import { useFileDownload } from './useFileDownload';
 import { logService } from '../services/logService';
 
+// Mirrors the Python 6-value `_NEGATED` / `is_excluded` set (B0 contract,
+// phentrieve/assertion_vocab.py) so an assertion_status of 'absent' (not only
+// literal 'negated') exports as excluded: true in the Phenopacket.
+const EXCLUDED_ASSERTIONS = new Set([
+  'negated',
+  'negative',
+  'absent',
+  'excluded',
+  'no',
+  'denied',
+]);
+const isExcluded = (a) => EXCLUDED_ASSERTIONS.has(String(a ?? '').trim().toLowerCase());
+
 /**
  * Composable for managing phenotype collection state and actions.
  * Extracted from QueryInterface.vue to reduce component size.
@@ -145,7 +158,7 @@ export function usePhenotypeCollection() {
       phenotypes.forEach((cp) => {
         phenopacket.phenotypicFeatures.push({
           type: { id: cp.hpo_id, label: cp.label },
-          excluded: cp.assertion_status === 'negated',
+          excluded: isExcluded(cp.assertion_status),
         });
       });
       const filename = `phentrieve_phenopacket_${new Date().toISOString().replace(/[:.]/g, '-')}.json`;

--- a/frontend/src/test/composables/usePhenotypeCollection.test.js
+++ b/frontend/src/test/composables/usePhenotypeCollection.test.js
@@ -144,6 +144,19 @@ describe('usePhenotypeCollection', () => {
       expect(phenopacket.phenotypicFeatures[0].excluded).toBe(true);
     });
 
+    it('exports assertion_status "normal" as excluded: true (normalcy verdict)', () => {
+      const store = useConversationStore();
+      store.addPhenotype({
+        hpo_id: 'HP:0100543',
+        label: 'Cognitive impairment',
+        assertion_status: 'normal',
+      });
+      const { exportAsPhenopacket } = usePhenotypeCollection();
+      exportAsPhenopacket();
+      const [phenopacket] = downloadJsonMock.mock.calls[0];
+      expect(phenopacket.phenotypicFeatures[0].excluded).toBe(true);
+    });
+
     it('exports assertion_status "present" as excluded: false', () => {
       const store = useConversationStore();
       store.addPhenotype({

--- a/frontend/src/test/composables/usePhenotypeCollection.test.js
+++ b/frontend/src/test/composables/usePhenotypeCollection.test.js
@@ -104,5 +104,57 @@ describe('usePhenotypeCollection', () => {
       const { exportAsPhenopacket } = usePhenotypeCollection();
       expect(() => exportAsPhenopacket()).toThrow(/disk full/);
     });
+
+    it('exports assertion_status "absent" as excluded: true (B0 mirror)', () => {
+      const store = useConversationStore();
+      store.addPhenotype({
+        hpo_id: 'HP:0001250',
+        label: 'Seizure',
+        assertion_status: 'absent',
+      });
+      const { exportAsPhenopacket } = usePhenotypeCollection();
+      exportAsPhenopacket();
+      const [phenopacket] = downloadJsonMock.mock.calls[0];
+      expect(phenopacket.phenotypicFeatures[0].excluded).toBe(true);
+    });
+
+    it('exports assertion_status "negative" as excluded: true (Python 6-value mirror)', () => {
+      const store = useConversationStore();
+      store.addPhenotype({
+        hpo_id: 'HP:0001250',
+        label: 'Seizure',
+        assertion_status: 'negative',
+      });
+      const { exportAsPhenopacket } = usePhenotypeCollection();
+      exportAsPhenopacket();
+      const [phenopacket] = downloadJsonMock.mock.calls[0];
+      expect(phenopacket.phenotypicFeatures[0].excluded).toBe(true);
+    });
+
+    it('exports assertion_status "negated" as excluded: true', () => {
+      const store = useConversationStore();
+      store.addPhenotype({
+        hpo_id: 'HP:0001250',
+        label: 'Seizure',
+        assertion_status: 'negated',
+      });
+      const { exportAsPhenopacket } = usePhenotypeCollection();
+      exportAsPhenopacket();
+      const [phenopacket] = downloadJsonMock.mock.calls[0];
+      expect(phenopacket.phenotypicFeatures[0].excluded).toBe(true);
+    });
+
+    it('exports assertion_status "present" as excluded: false', () => {
+      const store = useConversationStore();
+      store.addPhenotype({
+        hpo_id: 'HP:0001250',
+        label: 'Seizure',
+        assertion_status: 'present',
+      });
+      const { exportAsPhenopacket } = usePhenotypeCollection();
+      exportAsPhenopacket();
+      const [phenopacket] = downloadJsonMock.mock.calls[0];
+      expect(phenopacket.phenotypicFeatures[0].excluded).toBe(false);
+    });
   });
 });

--- a/phentrieve/assertion_vocab.py
+++ b/phentrieve/assertion_vocab.py
@@ -7,6 +7,10 @@ its own present/negated/uncertain vocabulary -- do not use this inside the pipel
 
 from __future__ import annotations
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 AFFIRMED = "affirmed"
 NEGATED = "negated"
 NORMAL = "normal"
@@ -15,6 +19,10 @@ UNCERTAIN = "uncertain"
 _NEGATED = {"negated", "negative", "absent", "excluded", "no", "denied"}
 _UNCERTAIN = {"uncertain", "possible", "suspected", "probable"}
 _NORMAL = {"normal"}
+# Recognized affirmed-polarity synonyms. Anything outside every known set falls
+# through to AFFIRMED (fail open) -- log those so a new/typo assertion value that
+# silently exports as present is observable rather than invisible.
+_AFFIRMED = {"affirmed", "present", "yes", "positive", "confirmed"}
 
 
 def canonicalize_assertion(raw: str | None) -> str:
@@ -25,6 +33,11 @@ def canonicalize_assertion(raw: str | None) -> str:
         return UNCERTAIN
     if normalized in _NORMAL:
         return NORMAL
+    if normalized and normalized not in _AFFIRMED:
+        logger.debug(
+            "canonicalize_assertion: unknown assertion %r -> affirmed (fail open)",
+            normalized,
+        )
     return AFFIRMED
 
 

--- a/phentrieve/assertion_vocab.py
+++ b/phentrieve/assertion_vocab.py
@@ -42,5 +42,14 @@ def canonicalize_assertion(raw: str | None) -> str:
 
 
 def is_excluded(raw: str | None) -> bool:
-    """True iff ``raw`` denotes a ruled-out finding (``excluded: true``)."""
-    return canonicalize_assertion(raw) == NEGATED
+    """True iff ``raw`` denotes a ruled-out finding (``excluded: true``).
+
+    Both an explicitly negated finding AND a ``normal`` finding (a normalcy
+    verdict, e.g. "structure normal" / "normal intellectual abilities") are
+    ruled-out abnormalities and export as excluded; only ``affirmed``/
+    ``uncertain`` stay present. This matches the LLM backend (a ``Normal``
+    category maps to the pipeline ``negated`` polarity) and closes the
+    normal-exports-as-present class B0 exists to eliminate. ``NORMAL`` is kept as
+    a distinct canonical assertion value; only this export projection folds it in.
+    """
+    return canonicalize_assertion(raw) in (NEGATED, NORMAL)

--- a/phentrieve/assertion_vocab.py
+++ b/phentrieve/assertion_vocab.py
@@ -1,0 +1,33 @@
+"""Canonical EXPORT assertion vocabulary (affirmed / negated / normal / uncertain).
+
+Used only at the export boundaries (MCP/REST/Vue) so an LLM ``assertion="absent"``
+can never silently export as an affirmed (present) feature. The LLM pipeline keeps
+its own present/negated/uncertain vocabulary -- do not use this inside the pipeline.
+"""
+
+from __future__ import annotations
+
+AFFIRMED = "affirmed"
+NEGATED = "negated"
+NORMAL = "normal"
+UNCERTAIN = "uncertain"
+
+_NEGATED = {"negated", "negative", "absent", "excluded", "no", "denied"}
+_UNCERTAIN = {"uncertain", "possible", "suspected", "probable"}
+_NORMAL = {"normal"}
+
+
+def canonicalize_assertion(raw: str | None) -> str:
+    normalized = str(raw).strip().lower() if raw is not None else ""
+    if normalized in _NEGATED:
+        return NEGATED
+    if normalized in _UNCERTAIN:
+        return UNCERTAIN
+    if normalized in _NORMAL:
+        return NORMAL
+    return AFFIRMED
+
+
+def is_excluded(raw: str | None) -> bool:
+    """True iff ``raw`` denotes a ruled-out finding (``excluded: true``)."""
+    return canonicalize_assertion(raw) == NEGATED

--- a/phentrieve/benchmark/extraction_cli.py
+++ b/phentrieve/benchmark/extraction_cli.py
@@ -177,8 +177,20 @@ def _regressions(
     """Return a human-readable line per metric that dropped beyond tolerance."""
     out: list[str] = []
     for key in _GATED_METRICS:
-        base = float(baseline.get(key, 0.0))
-        cand = float(candidate.get(key, 0.0))
+        # Fail closed on a MISSING gated key on either side. Defaulting a missing
+        # baseline metric to 0.0 would wave any non-negative candidate through
+        # (0.0 - tol is never exceeded), silently passing a total regression when
+        # the gate is pointed at a wrong-shape/legacy summary (e.g. the nested
+        # extraction_results.json instead of the flat extraction_summary.json).
+        if key not in baseline or key not in candidate:
+            out.append(
+                f"{key}: MISSING "
+                f"(baseline={'present' if key in baseline else 'absent'}, "
+                f"candidate={'present' if key in candidate else 'absent'})"
+            )
+            continue
+        base = float(baseline[key])
+        cand = float(candidate[key])
         # Fail closed: a NaN on either side makes the comparison meaningless, so
         # treat it as a regression rather than let it slip through (NaN < x is False).
         if math.isnan(base) or math.isnan(cand) or cand < base - tolerance:
@@ -197,9 +209,21 @@ def assert_no_regression(
     cand = json.loads(candidate.read_text())
     # Refuse to gate across scoring modes (e.g. present-only candidate vs strict
     # baseline): the metrics are not comparable and the gate would be meaningless.
+    # Fail closed when EITHER file omits ``scoring_mode`` -- a missing mode makes
+    # comparability unverifiable, and present-only metrics are systematically
+    # higher than strict, so a mode-stripped present-only candidate would
+    # otherwise pass a strict baseline. The golden path writes scoring_mode
+    # unconditionally, so requiring it only rejects legacy/hand-edited summaries.
     base_mode = base.get("scoring_mode")
     cand_mode = cand.get("scoring_mode")
-    if base_mode is not None and cand_mode is not None and base_mode != cand_mode:
+    if base_mode is None or cand_mode is None:
+        console.print(
+            f"[red]SCORING MODE MISSING[/red] baseline={base_mode!r} "
+            f"candidate={cand_mode!r} -- both summaries must declare scoring_mode; "
+            "regenerate them."
+        )
+        raise typer.Exit(2)
+    if base_mode != cand_mode:
         console.print(
             f"[red]SCORING MODE MISMATCH[/red] baseline={base_mode!r} "
             f"candidate={cand_mode!r} -- regenerate one in the other's mode."

--- a/phentrieve/benchmark/llm_benchmark.py
+++ b/phentrieve/benchmark/llm_benchmark.py
@@ -1200,13 +1200,23 @@ def _assertion_distribution(pipeline_result: Any, *, dataset: str) -> dict[str, 
 def _aggregate_assertion_distribution(
     prediction_records: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    """Sum per-document ``assertion_distribution`` blocks into a corpus total."""
+    """Sum per-document ``assertion_distribution`` blocks into a corpus total.
+
+    ``documents_counted`` vs ``documents_total`` makes an undercount VISIBLE:
+    records restored from a checkpoint written before this field existed carry no
+    block and contribute nothing, so a resumed cross-version run would otherwise
+    silently report a distribution for only the post-upgrade documents.
+    """
     by_assertion: dict[str, int] = {}
     scored = 0
     dropped = 0
     family = 0
+    counted = 0
     for record in prediction_records:
-        dist = record.get("assertion_distribution") or {}
+        dist = record.get("assertion_distribution")
+        if not dist:
+            continue
+        counted += 1
         for key, value in (dist.get("proband_by_assertion") or {}).items():
             by_assertion[key] = by_assertion.get(key, 0) + int(value)
         scored += int(dist.get("proband_scored", 0) or 0)
@@ -1217,6 +1227,8 @@ def _aggregate_assertion_distribution(
         "proband_scored": scored,
         "proband_dropped_by_projection": dropped,
         "family_history_findings": family,
+        "documents_counted": counted,
+        "documents_total": len(prediction_records),
     }
 
 

--- a/phentrieve/benchmark/llm_benchmark.py
+++ b/phentrieve/benchmark/llm_benchmark.py
@@ -956,6 +956,11 @@ def _build_benchmark_payload(
         "estimated_energy_cost": estimated_energy_cost,
         "prediction_records": list(prediction_records),
         "results": list(results),
+        # Corpus-level visibility into how much of the contract-v2 deliverable
+        # (negated/absent/family findings) the present-only scoring drops.
+        "assertion_distribution": _aggregate_assertion_distribution(
+            list(prediction_records)
+        ),
     }
     if metrics is not None:
         payload["metrics"] = metrics
@@ -1091,6 +1096,12 @@ def _build_prediction_record(
             }
             for term in pipeline_result.terms
         ],
+        # Additive visibility into the contract-v2 deliverable: how many findings
+        # were produced per RAW assertion and how many the dataset's present-only
+        # projection drops from scoring. Does not change any metric.
+        "assertion_distribution": _assertion_distribution(
+            pipeline_result, dataset=dataset
+        ),
         "metadata": {
             "llm_provider": pipeline_result.meta.llm_provider,
             "model": config.model,
@@ -1150,6 +1161,63 @@ def _serialize_predicted_terms(
             }
         )
     return predicted_terms
+
+
+def _assertion_distribution(pipeline_result: Any, *, dataset: str) -> dict[str, Any]:
+    """Count predicted findings by RAW assertion (pre-projection).
+
+    The LLM benchmark scores a dataset-specific present-only projection (see
+    ``DATASET_ASSERTION_PROJECTION``), which drops ``negated``/``absent``/
+    ``family_history``. That silently hides the negation/family/qualifier axes
+    the extraction contract exists to produce. This report surfaces them without
+    changing any score: ``proband_dropped_by_projection`` is exactly the count of
+    contract findings the present-only metric cannot see.
+    """
+    by_assertion: dict[str, int] = {}
+    scored = 0
+    dropped = 0
+    for term in pipeline_result.terms:
+        raw = str(getattr(term, "assertion", "") or "").lower()
+        by_assertion[raw] = by_assertion.get(raw, 0) + 1
+        if (
+            _project_assertion_for_dataset(
+                dataset=dataset, assertion=getattr(term, "assertion", None)
+            )
+            is None
+        ):
+            dropped += 1
+        else:
+            scored += 1
+    family = list(getattr(pipeline_result, "family_history_findings", []) or [])
+    return {
+        "proband_by_assertion": by_assertion,
+        "proband_scored": scored,
+        "proband_dropped_by_projection": dropped,
+        "family_history_findings": len(family),
+    }
+
+
+def _aggregate_assertion_distribution(
+    prediction_records: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Sum per-document ``assertion_distribution`` blocks into a corpus total."""
+    by_assertion: dict[str, int] = {}
+    scored = 0
+    dropped = 0
+    family = 0
+    for record in prediction_records:
+        dist = record.get("assertion_distribution") or {}
+        for key, value in (dist.get("proband_by_assertion") or {}).items():
+            by_assertion[key] = by_assertion.get(key, 0) + int(value)
+        scored += int(dist.get("proband_scored", 0) or 0)
+        dropped += int(dist.get("proband_dropped_by_projection", 0) or 0)
+        family += int(dist.get("family_history_findings", 0) or 0)
+    return {
+        "proband_by_assertion": by_assertion,
+        "proband_scored": scored,
+        "proband_dropped_by_projection": dropped,
+        "family_history_findings": family,
+    }
 
 
 def _build_observability_counts(

--- a/phentrieve/llm/ontology_guard.py
+++ b/phentrieve/llm/ontology_guard.py
@@ -15,41 +15,72 @@ loaded) is kept, so incomplete data never silently drops a real finding.
 from __future__ import annotations
 
 import logging
-from functools import lru_cache
 
 from phentrieve.config import DEFAULT_HPO_DB_FILENAME, PHENOTYPE_ROOT
 from phentrieve.utils import get_default_data_dir, resolve_data_path
 
 logger = logging.getLogger(__name__)
 
+# Path-keyed cache of SUCCESSFUL, non-empty ancestry loads only. A failed or
+# empty load is deliberately NOT memoized so the guard recovers on a later call
+# once ``hpo_data.db`` becomes available (e.g. an API process that starts before
+# the data bundle is present) instead of latching the fail-open ``{}`` for the
+# whole process lifetime. Keying by resolved DB path also re-loads when the data
+# root changes in-process rather than serving a stale map.
+_ANCESTORS_CACHE: dict[str, dict[str, frozenset[str]]] = {}
 
-@lru_cache(maxsize=1)
+
+def _load_ancestors_map(db_path) -> dict[str, frozenset[str]]:
+    from phentrieve.data_processing.hpo_database import HPODatabase
+
+    with HPODatabase(db_path) as db:
+        ancestors, _ = db.load_graph_data()
+    return {term: frozenset(anc) for term, anc in ancestors.items()}
+
+
 def _ancestors_map() -> dict[str, frozenset[str]]:
-    """Load and cache ``{term_id: frozenset(ancestor_ids)}`` from the HPO graph.
+    """Return ``{term_id: frozenset(ancestor_ids)}`` from the HPO graph.
 
     Returns an empty map (guard disabled, fail open) when the database is
-    unavailable so the pipeline never hard-depends on graph data at runtime.
+    unavailable so the pipeline never hard-depends on graph data at runtime; the
+    empty result is not cached, so a later call retries.
     """
     try:
         data_dir = resolve_data_path(None, "data_dir", get_default_data_dir)
         db_path = data_dir / DEFAULT_HPO_DB_FILENAME
-        if not db_path.exists():
-            logger.warning(
-                "HPO database not found: %s; ontology guard disabled (fail open).",
-                db_path,
-            )
-            return {}
-        from phentrieve.data_processing.hpo_database import HPODatabase
-
-        with HPODatabase(db_path) as db:
-            ancestors, _ = db.load_graph_data()
-        return {term: frozenset(anc) for term, anc in ancestors.items()}
+        cache_key = str(db_path)
     except Exception as exc:  # pragma: no cover - defensive
         logger.warning(
-            "Ontology guard could not load HPO graph (%s); disabled (fail open).",
+            "Ontology guard could not resolve HPO db path (%s); disabled (fail open).",
             exc,
         )
         return {}
+
+    cached = _ANCESTORS_CACHE.get(cache_key)
+    if cached:
+        return cached
+
+    try:
+        if not db_path.exists():
+            logger.warning(
+                "HPO database not found: %s; ontology guard disabled "
+                "(fail open, will retry).",
+                db_path,
+            )
+            return {}
+        loaded = _load_ancestors_map(db_path)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning(
+            "Ontology guard could not load HPO graph (%s); disabled "
+            "(fail open, will retry).",
+            exc,
+        )
+        return {}
+
+    # Only memoize a successful, non-empty load.
+    if loaded:
+        _ANCESTORS_CACHE[cache_key] = loaded
+    return loaded
 
 
 def is_non_phenotypic_abnormality(term_id: str) -> bool:

--- a/phentrieve/llm/ontology_guard.py
+++ b/phentrieve/llm/ontology_guard.py
@@ -1,0 +1,67 @@
+"""Ontology guard: reject resolved terms that are not phenotypic abnormalities.
+
+Retrieval can drift into non-phenotype HPO branches -- Clinical modifier
+(HP:0012823), Clinical course (HP:0031797), Mode of inheritance (HP:0000005),
+Frequency, Blood group, Past medical history. For example a bare ``normal``
+qualifier retrieves "Mild" (HP:0012825), and a "visuospatial" fragment can
+retrieve "Spatial pattern" (HP:0012836). Patient phenotype annotations live
+under Phenotypic abnormality (HP:0000118), so a resolved term KNOWN to sit
+outside that subtree is not a valid standalone phenotype and is dropped.
+
+Fail open: a term whose ancestry is unknown (or when the HPO graph cannot be
+loaded) is kept, so incomplete data never silently drops a real finding.
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+
+from phentrieve.config import DEFAULT_HPO_DB_FILENAME, PHENOTYPE_ROOT
+from phentrieve.utils import get_default_data_dir, resolve_data_path
+
+logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=1)
+def _ancestors_map() -> dict[str, frozenset[str]]:
+    """Load and cache ``{term_id: frozenset(ancestor_ids)}`` from the HPO graph.
+
+    Returns an empty map (guard disabled, fail open) when the database is
+    unavailable so the pipeline never hard-depends on graph data at runtime.
+    """
+    try:
+        data_dir = resolve_data_path(None, "data_dir", get_default_data_dir)
+        db_path = data_dir / DEFAULT_HPO_DB_FILENAME
+        if not db_path.exists():
+            logger.warning(
+                "HPO database not found: %s; ontology guard disabled (fail open).",
+                db_path,
+            )
+            return {}
+        from phentrieve.data_processing.hpo_database import HPODatabase
+
+        with HPODatabase(db_path) as db:
+            ancestors, _ = db.load_graph_data()
+        return {term: frozenset(anc) for term, anc in ancestors.items()}
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning(
+            "Ontology guard could not load HPO graph (%s); disabled (fail open).",
+            exc,
+        )
+        return {}
+
+
+def is_non_phenotypic_abnormality(term_id: str) -> bool:
+    """True iff ``term_id`` is KNOWN to sit outside the Phenotypic abnormality
+    (HP:0000118) subtree (a clinical modifier / course / inheritance / etc.).
+
+    Unknown terms and the phenotype root itself return ``False`` (kept).
+    """
+    term_id = (term_id or "").strip()
+    if not term_id or term_id == PHENOTYPE_ROOT:
+        return False
+    ancestors = _ancestors_map().get(term_id)
+    if ancestors is None:
+        return False  # unknown ancestry -> keep (fail open)
+    return PHENOTYPE_ROOT not in ancestors

--- a/phentrieve/llm/pipeline.py
+++ b/phentrieve/llm/pipeline.py
@@ -591,7 +591,20 @@ class TwoPhaseLLMPipeline:
                     "start_char": getattr(phenotype, "start_char", None),
                     "end_char": getattr(phenotype, "end_char", None),
                     "experiencer": getattr(phenotype, "experiencer", None),
-                    "assertion": getattr(phenotype, "assertion", None),
+                    # Thread the model's assertion ONLY when the model actually
+                    # emitted it. The wire schema declares assertion with a
+                    # default of "present", so a category-only finding (e.g.
+                    # Normal/Suspected) always has a non-None attribute; keying
+                    # on ``model_fields_set`` distinguishes a model-emitted
+                    # assertion from the schema default. When unset we thread
+                    # None so the downstream category fallback re-engages and a
+                    # ruled-out/uncertain finding does not silently flip to
+                    # present (B1).
+                    "assertion": (
+                        phenotype.assertion
+                        if "assertion" in phenotype.model_fields_set
+                        else None
+                    ),
                 }
             )
         debug_payload: dict[str, Any] | None = None

--- a/phentrieve/llm/pipeline.py
+++ b/phentrieve/llm/pipeline.py
@@ -590,6 +590,8 @@ class TwoPhaseLLMPipeline:
                     "evidence_text": getattr(phenotype, "evidence_text", None),
                     "start_char": getattr(phenotype, "start_char", None),
                     "end_char": getattr(phenotype, "end_char", None),
+                    "experiencer": getattr(phenotype, "experiencer", None),
+                    "assertion": getattr(phenotype, "assertion", None),
                 }
             )
         debug_payload: dict[str, Any] | None = None
@@ -1234,6 +1236,8 @@ class TwoPhaseLLMPipeline:
             shared_result["negated_qualifier"] = item.get("negated_qualifier")
             shared_result["start_char"] = item.get("start_char")
             shared_result["end_char"] = item.get("end_char")
+            shared_result["experiencer"] = item.get("experiencer")
+            shared_result["assertion"] = item.get("assertion")
             shared_result["grounded_context"] = self._build_grounded_context(
                 item=item,
                 grounded_chunks=grounded_chunks,

--- a/phentrieve/llm/pipeline.py
+++ b/phentrieve/llm/pipeline.py
@@ -24,6 +24,7 @@ from phentrieve.llm.config import (
     NEGATED_ASSERTION,
     PRESENT_ASSERTION,
 )
+from phentrieve.llm.ontology_guard import is_non_phenotypic_abnormality
 from phentrieve.llm.pipeline_phase1 import (
     ACTIONABLE_CATEGORIES,
 )
@@ -574,8 +575,12 @@ class TwoPhaseLLMPipeline:
         )
 
         return LLMExtractionResult(
-            terms=self._deduplicate_terms(resolved_terms + qualifier_exclusions),
-            family_history_findings=self._deduplicate_terms(resolved_family),
+            terms=self._deduplicate_terms(
+                self._drop_non_phenotypic(resolved_terms + qualifier_exclusions)
+            ),
+            family_history_findings=self._deduplicate_terms(
+                self._drop_non_phenotypic(resolved_family)
+            ),
             meta=LLMMeta(
                 llm_provider=config.provider,
                 llm_model=config.model,
@@ -2088,3 +2093,24 @@ class TwoPhaseLLMPipeline:
     @staticmethod
     def _deduplicate_terms(terms: list[LLMPhenotype]) -> list[LLMPhenotype]:
         return deduplicate_terms(terms)
+
+    @staticmethod
+    def _drop_non_phenotypic(terms: list[LLMPhenotype]) -> list[LLMPhenotype]:
+        """Drop resolved terms that are KNOWN to sit outside the Phenotypic
+        abnormality (HP:0000118) subtree -- clinical modifiers / course /
+        inheritance nodes (e.g. "Mild" HP:0012825, "Spatial pattern" HP:0012836,
+        "Slowly progressive" HP:0003677). These are qualifiers, never standalone
+        phenotypes, so they are not valid annotations. Fail open: terms with
+        unknown ancestry (or when the HPO graph is unavailable) are kept, so a
+        real finding is never silently dropped."""
+        kept: list[LLMPhenotype] = []
+        for term in terms:
+            if is_non_phenotypic_abnormality(term.term_id):
+                logger.debug(
+                    "ontology guard dropped non-phenotype term %s (%s)",
+                    term.term_id,
+                    term.label,
+                )
+                continue
+            kept.append(term)
+        return kept

--- a/phentrieve/llm/pipeline.py
+++ b/phentrieve/llm/pipeline.py
@@ -193,9 +193,6 @@ class TwoPhaseLLMPipeline:
         self.max_unique_candidates = max_unique_candidates
         self.local_match_threshold = local_match_threshold
         self.mapping_batch_size = max(int(mapping_batch_size), 1)
-        # Task-6 test hook for the B2 family-resolution set; Task 7 will attach
-        # ``resolved_family`` to the result object and this can be removed.
-        self._last_resolved_family: list[LLMPhenotype] = []
 
     def run(
         self,
@@ -560,12 +557,9 @@ class TwoPhaseLLMPipeline:
                 family_trace["phase2b_llm"] = family_outcome.phase2b_llm_trace
             trace["family"] = family_trace
 
-        # Task-6 test hook: Task 7 attaches ``resolved_family`` to the result
-        # object; until then this exposes the family set for independent tests.
-        self._last_resolved_family = resolved_family
-
         return LLMExtractionResult(
             terms=self._deduplicate_terms(resolved_terms),
+            family_history_findings=self._deduplicate_terms(resolved_family),
             meta=LLMMeta(
                 llm_provider=config.provider,
                 llm_model=config.model,

--- a/phentrieve/llm/pipeline.py
+++ b/phentrieve/llm/pipeline.py
@@ -21,6 +21,7 @@ from phentrieve.llm.config import (
     DEFAULT_PHASE1_SMALL_GROUP_MAX_CHUNKS,
     DEFAULT_QUERY_RESULTS_PER_PHRASE,
     DEFAULT_SIMILARITY_THRESHOLD,
+    NEGATED_ASSERTION,
     PRESENT_ASSERTION,
 )
 from phentrieve.llm.pipeline_phase1 import (
@@ -557,8 +558,23 @@ class TwoPhaseLLMPipeline:
                 family_trace["phase2b_llm"] = family_outcome.phase2b_llm_trace
             trace["family"] = family_trace
 
+        # B3: map each resolved proband finding's negated qualifier Y (the
+        # absent portion of an "X without Y" phrase) to a GENERATED excluded
+        # finding. Y is retrieved through the SAME retrieval path as any phrase;
+        # when its top candidate scores at or above the confidence floor
+        # (``self.similarity_threshold``) an excluded ``LLMPhenotype`` is emitted
+        # for Y. Below the floor (or when nothing is retrieved) no term is
+        # generated and the source finding's ``negated_qualifier`` metadata
+        # string is retained. This runs AFTER proband resolution and BEFORE the
+        # final dedup so the generated terms flow through the same dedup key.
+        qualifier_exclusions = self._build_qualifier_exclusions(
+            resolved_terms=resolved_terms,
+            grounded_chunks=grounded_chunks,
+            language=language,
+        )
+
         return LLMExtractionResult(
-            terms=self._deduplicate_terms(resolved_terms),
+            terms=self._deduplicate_terms(resolved_terms + qualifier_exclusions),
             family_history_findings=self._deduplicate_terms(resolved_family),
             meta=LLMMeta(
                 llm_provider=config.provider,
@@ -580,6 +596,86 @@ class TwoPhaseLLMPipeline:
                 trace=trace,
             ),
         )
+
+    def _build_qualifier_exclusions(
+        self,
+        *,
+        resolved_terms: list[LLMPhenotype],
+        grounded_chunks: list[dict[str, Any]],
+        language: str,
+    ) -> list[LLMPhenotype]:
+        """Generate an excluded finding for each proband finding's negated
+        qualifier Y that maps at or above the confidence floor (B3).
+
+        For every resolved proband finding carrying a truthy
+        ``negated_qualifier``, retrieve Y through the shared retrieval path and,
+        when the top candidate scores ``>= self.similarity_threshold``, emit a
+        generated excluded ``LLMPhenotype`` for Y. Below the floor (or when
+        nothing is retrieved) no term is generated and the source finding's
+        ``negated_qualifier`` metadata string is left untouched.
+
+        F5: the generated term INHERITS the source finding's evidence records so
+        it carries valid ``chunk_ids`` (the "X without Y" span lives in the same
+        chunk as X). A generated term with empty/invalid chunk refs is silently
+        dropped at the aggregation service boundary
+        (``full_text_service.py``)."""
+        exclusions: list[LLMPhenotype] = []
+        for finding in resolved_terms:
+            qualifier = (finding.negated_qualifier or "").strip()
+            if not qualifier:
+                continue
+
+            # Inherit the source finding's chunk ids so the retrieval item and
+            # the generated term stay anchored to the source span (F5).
+            source_chunk_ids: list[int] = []
+            for record in finding.evidence_records:
+                source_chunk_ids.extend(record.chunk_ids)
+
+            synthetic_item: dict[str, Any] = {
+                "phrase": qualifier,
+                "category": "Abnormal",
+                "chunk_ids": list(source_chunk_ids),
+                "evidence_text": qualifier,
+                "negated_qualifier": None,
+                "start_char": None,
+                "end_char": None,
+                "experiencer": "proband",
+                "assertion": None,
+            }
+            retrieved = self._retrieve_candidates(
+                actionable=[synthetic_item],
+                grounded_chunks=grounded_chunks,
+                language=language,
+            )
+            candidates = retrieved[0].get("candidates", []) if retrieved else []
+            if not candidates:
+                continue
+            top = candidates[0]
+            top_score = float(top.get("score", 0.0) or 0.0)
+            if top_score < self.similarity_threshold:
+                continue
+
+            # F5: copy the source finding's evidence records so the generated
+            # term carries at least one valid chunk reference.
+            inherited_records = [
+                record.model_copy(deep=True) for record in finding.evidence_records
+            ]
+            exclusions.append(
+                LLMPhenotype(
+                    term_id=str(top["hpo_id"]),
+                    label=str(top.get("term_name", "") or ""),
+                    evidence=qualifier,
+                    assertion=NEGATED_ASSERTION,
+                    experiencer="proband",
+                    negated_qualifier=None,
+                    qualifier_surface_text=qualifier,
+                    match_method="negated_qualifier_derived",
+                    confidence=top_score,
+                    score=top_score,
+                    evidence_records=inherited_records,
+                )
+            )
+        return exclusions
 
     def _resolve_items(
         self,

--- a/phentrieve/llm/pipeline.py
+++ b/phentrieve/llm/pipeline.py
@@ -1616,6 +1616,19 @@ class TwoPhaseLLMPipeline:
         existing: dict[str, Any],
         incoming: dict[str, Any],
     ) -> bool:
+        # ``experiencer`` and ``assertion`` are orthogonal axes (B1). The fuzzy
+        # merge exists only to consolidate fragments/duplicates of the SAME
+        # finding; a differing experiencer (proband vs family_history) or
+        # assertion (present vs absent) marks a genuinely DIFFERENT finding, so
+        # refuse the merge before any span/evidence heuristics run. This runs
+        # BEFORE the B2 family partition, so collapsing here would silently drop
+        # a co-located family or opposite-polarity mention.
+        for axis in ("experiencer", "assertion"):
+            if (
+                str(existing.get(axis) or "").strip().lower()
+                != str(incoming.get(axis) or "").strip().lower()
+            ):
+                return False
         if (
             str(existing.get("phrase", "")).strip().lower()
             != str(incoming.get("phrase", "")).strip().lower()

--- a/phentrieve/llm/pipeline.py
+++ b/phentrieve/llm/pipeline.py
@@ -4,7 +4,7 @@ import logging
 import re
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from typing import Any
 
 from phentrieve.llm.config import (
@@ -139,6 +139,39 @@ from phentrieve.llm.utils import token_sort_similarity
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class _ItemResolutionOutcome:
+    """Result of running one item set through the shared phase-2 resolution
+    path (retrieve -> route -> map).
+
+    The helper is PURE: it computes every accounting delta and returns it here
+    instead of mutating ``run()`` state, so ``run()`` can merge the proband
+    outcome into the canonical meta keys (byte-identical to the pre-B2 inline
+    block) and the family outcome into a distinct ``family_*`` / ``trace["family"]``
+    namespace without either overwriting the other (B2)."""
+
+    resolved: list[LLMPhenotype]
+    phase2a_seconds: float
+    phase2b_local_seconds: float
+    phase2b_llm_seconds: float
+    candidate_sets: int
+    routing_counts: dict[str, int]
+    unresolved_phrases: int
+    local_matches: int
+    local_fallbacks: int
+    llm_mapped_phrases: int
+    prompt_tokens: int
+    completion_tokens: int
+    token_usage: dict[str, int]
+    request_count: int
+    phase2b_llm_requests: int
+    mapping_prompt_version: str | None
+    phase2a_trace: dict[str, Any]
+    phase2b_local_trace: dict[str, Any]
+    phase2b_llm_trace: dict[str, Any] | None
+    mapping_ran: bool
+
+
 class TwoPhaseLLMPipeline:
     def __init__(
         self,
@@ -160,6 +193,9 @@ class TwoPhaseLLMPipeline:
         self.max_unique_candidates = max_unique_candidates
         self.local_match_threshold = local_match_threshold
         self.mapping_batch_size = max(int(mapping_batch_size), 1)
+        # Task-6 test hook for the B2 family-resolution set; Task 7 will attach
+        # ``resolved_family`` to the result object and this can be removed.
+        self._last_resolved_family: list[LLMPhenotype] = []
 
     def run(
         self,
@@ -337,9 +373,39 @@ class TwoPhaseLLMPipeline:
         extracted = self._deduplicate_phase1_extractions(
             _expand_combined_phase1_extractions(extracted)
         )
+        # B2 partition: split family-experiencer phrases out of the proband set
+        # BEFORE the actionable filter. A single-pass split by predicate avoids
+        # the value-equality pitfall of ``item not in family_items`` when two
+        # items share identical content. A finding is family when the model
+        # tagged its experiencer as family_history OR it carries the legacy
+        # Family_History category (the latter clause catches a category-only
+        # finding whose experiencer defaulted to proband, and the former catches
+        # a family finding wearing a legacy Abnormal category that would
+        # otherwise leak into the proband path).
+        family_items: list[dict[str, Any]] = []
+        proband_items: list[dict[str, Any]] = []
+        for item in extracted:
+            is_family = (
+                str(item.get("experiencer") or "").strip().lower() == "family_history"
+                or _normalize_category(str(item.get("category", "")))
+                == "family_history"
+            )
+            if is_family:
+                # A family finding may have been expressed only via the legacy
+                # Family_History category while its experiencer axis stayed at
+                # the B1 schema default ("proband", threaded unconditionally).
+                # Since the partition has classified it as family, normalize the
+                # experiencer on a copy so the resolved phenotype is internally
+                # consistent (experiencer=family_history) rather than a
+                # self-contradictory family term tagged proband.
+                family_item = dict(item)
+                family_item["experiencer"] = "family_history"
+                family_items.append(family_item)
+            else:
+                proband_items.append(item)
         actionable = [
             item
-            for item in extracted
+            for item in proband_items
             if _normalize_category(str(item["category"])) in ACTIONABLE_CATEGORIES
         ]
 
@@ -396,102 +462,107 @@ class TwoPhaseLLMPipeline:
                 phase_counts["phase1_failed_groups"] > 0
                 and phase_counts["phase1_completed_groups"] > 0
             )
+        resolved_family: list[LLMPhenotype] = []
         if actionable:
-            logger.debug(
-                "Phase 2A: retrieving candidates for actionable_phrases=%d",
-                len(actionable),
-            )
-            phase2a_start = time.perf_counter()
-            phrase_candidates = self._retrieve_candidates(
-                actionable=actionable,
+            # Proband path: merge the outcome into the CANONICAL meta keys so the
+            # result stays byte-identical to the pre-B2 inline block. The gated
+            # ``mapping_ran`` branch mirrors the old ``if unresolved:`` guard
+            # exactly (phase2b_llm_* keys otherwise keep their initialized zeros).
+            proband_outcome = self._resolve_items(
+                actionable,
                 grounded_chunks=grounded_chunks,
                 language=language,
             )
-            phase_timings["phase2a_seconds"] = round(
-                time.perf_counter() - phase2a_start, 6
+            resolved_terms.extend(proband_outcome.resolved)
+            phase_timings["phase2a_seconds"] = proband_outcome.phase2a_seconds
+            phase_timings["phase2b_local_seconds"] = (
+                proband_outcome.phase2b_local_seconds
             )
-            phase_counts["candidate_sets"] = len(phrase_candidates)
-            trace["phase2a"] = build_phase2a_trace(phrase_candidates)
-            logger.debug(
-                "Phase 2A complete: candidate_sets=%d",
-                len(phrase_candidates),
-            )
-            logger.debug(
-                "Phase 2B-local: resolving local matches for candidate_sets=%d",
-                len(phrase_candidates),
-            )
-            phase2b_local_start = time.perf_counter()
-            (
-                locally_resolved,
-                unresolved,
-                routing_counts,
-            ) = self._route_phase2_candidates(
-                phrase_candidates=phrase_candidates,
-                language=language,
-            )
-            phase_timings["phase2b_local_seconds"] = round(
-                time.perf_counter() - phase2b_local_start, 6
-            )
-            phase_counts["unresolved_phrases"] = len(unresolved)
-            phase_counts["local_matches"] = len(locally_resolved)
-            phase_counts.update(routing_counts)
-            resolved_terms.extend(locally_resolved)
-            trace["phase2b_local"] = build_phase2b_local_trace(
-                locally_resolved=locally_resolved,
-                unresolved=unresolved,
-            )
-            logger.debug(
-                "Phase 2B-local complete: matched=%d unresolved=%d",
-                len(locally_resolved),
-                len(unresolved),
-            )
-            if unresolved:
-                mapping_prompt = (
-                    get_batch_mapping_prompt(language)
-                    if len(unresolved) > 1 and self.mapping_batch_size > 1
-                    else get_mapping_prompt(language)
+            phase_counts["candidate_sets"] = proband_outcome.candidate_sets
+            phase_counts["unresolved_phrases"] = proband_outcome.unresolved_phrases
+            phase_counts["local_matches"] = proband_outcome.local_matches
+            phase_counts.update(proband_outcome.routing_counts)
+            trace["phase2a"] = proband_outcome.phase2a_trace
+            trace["phase2b_local"] = proband_outcome.phase2b_local_trace
+            if proband_outcome.mapping_ran:
+                phase_timings["phase2b_llm_seconds"] = (
+                    proband_outcome.phase2b_llm_seconds
                 )
-                prompt_version = f"{prompt_version}+{mapping_prompt.version}"
-                logger.debug(
-                    "Phase 2B-llm: mapping unresolved phrases=%d",
-                    len(unresolved),
+                prompt_version = (
+                    f"{prompt_version}+{proband_outcome.mapping_prompt_version}"
                 )
-                phase2b_llm_start = time.perf_counter()
-                (
-                    mapped_terms,
-                    mapping_prompt_tokens,
-                    mapping_completion_tokens,
-                    mapping_token_usage,
-                    mapping_request_count,
-                    local_fallback_count,
-                    mapping_trace,
-                ) = self._resolve_with_mapping_prompt(
-                    unresolved=unresolved,
-                    mapping_prompt=mapping_prompt,
-                )
-                phase_timings["phase2b_llm_seconds"] = round(
-                    time.perf_counter() - phase2b_llm_start, 6
-                )
-                prompt_tokens_total += mapping_prompt_tokens
-                completion_tokens_total += mapping_completion_tokens
+                prompt_tokens_total += proband_outcome.prompt_tokens
+                completion_tokens_total += proband_outcome.completion_tokens
                 token_usage_total = _sum_usage_dicts(
                     token_usage_total,
-                    mapping_token_usage,
+                    proband_outcome.token_usage,
                 )
-                request_count_total += mapping_request_count
-                phase_request_counts["phase2b_llm_requests"] = mapping_request_count
-                resolved_terms.extend(mapped_terms)
-                phase_counts["local_fallbacks"] = local_fallback_count
-                phase_counts["llm_mapped_phrases"] = (
-                    len(mapped_terms) - local_fallback_count
+                request_count_total += proband_outcome.request_count
+                phase_request_counts["phase2b_llm_requests"] = (
+                    proband_outcome.phase2b_llm_requests
                 )
-                trace["phase2b_llm"] = {"resolved": mapping_trace}
-                logger.debug(
-                    "Phase 2B-llm complete: mapped=%d prompt_tokens=%d completion_tokens=%d",
-                    phase_counts["llm_mapped_phrases"],
-                    mapping_prompt_tokens,
-                    mapping_completion_tokens,
+                phase_counts["local_fallbacks"] = proband_outcome.local_fallbacks
+                phase_counts["llm_mapped_phrases"] = proband_outcome.llm_mapped_phrases
+                trace["phase2b_llm"] = proband_outcome.phase2b_llm_trace
+
+        if family_items:
+            # Family path: resolve ALL family phrases through the SAME retrieve
+            # -> route -> map path (they are phenotype phrases regardless of the
+            # legacy category; they must NOT be re-dropped via
+            # ACTIONABLE_CATEGORIES). Family results land in the separate
+            # ``resolved_family`` list (Task 7 attaches it to the result); they
+            # are NEVER merged into ``resolved_terms``. Family cost ALWAYS folds
+            # into the shared token/request accumulators so a family LLM pass is
+            # not underreported; family-specific breakdowns use a ``family_*`` /
+            # ``trace["family"]`` namespace so proband metrics are never
+            # overwritten.
+            family_outcome = self._resolve_items(
+                family_items,
+                grounded_chunks=grounded_chunks,
+                language=language,
+            )
+            resolved_family.extend(family_outcome.resolved)
+            prompt_tokens_total += family_outcome.prompt_tokens
+            completion_tokens_total += family_outcome.completion_tokens
+            token_usage_total = _sum_usage_dicts(
+                token_usage_total,
+                family_outcome.token_usage,
+            )
+            request_count_total += family_outcome.request_count
+            phase_timings["family_phase2a_seconds"] = family_outcome.phase2a_seconds
+            phase_timings["family_phase2b_local_seconds"] = (
+                family_outcome.phase2b_local_seconds
+            )
+            phase_counts["family_phrases"] = len(family_items)
+            phase_counts["family_candidate_sets"] = family_outcome.candidate_sets
+            phase_counts["family_unresolved_phrases"] = (
+                family_outcome.unresolved_phrases
+            )
+            phase_counts["family_local_matches"] = family_outcome.local_matches
+            phase_counts["family_resolved_phrases"] = len(family_outcome.resolved)
+            for key, value in family_outcome.routing_counts.items():
+                phase_counts[f"family_{key}"] = value
+            family_trace: dict[str, Any] = {
+                "phase2a": family_outcome.phase2a_trace,
+                "phase2b_local": family_outcome.phase2b_local_trace,
+            }
+            if family_outcome.mapping_ran:
+                phase_timings["family_phase2b_llm_seconds"] = (
+                    family_outcome.phase2b_llm_seconds
                 )
+                phase_request_counts["family_phase2b_llm_requests"] = (
+                    family_outcome.phase2b_llm_requests
+                )
+                phase_counts["family_local_fallbacks"] = family_outcome.local_fallbacks
+                phase_counts["family_llm_mapped_phrases"] = (
+                    family_outcome.llm_mapped_phrases
+                )
+                family_trace["phase2b_llm"] = family_outcome.phase2b_llm_trace
+            trace["family"] = family_trace
+
+        # Task-6 test hook: Task 7 attaches ``resolved_family`` to the result
+        # object; until then this exposes the family set for independent tests.
+        self._last_resolved_family = resolved_family
 
         return LLMExtractionResult(
             terms=self._deduplicate_terms(resolved_terms),
@@ -514,6 +585,141 @@ class TwoPhaseLLMPipeline:
                 phase_request_counts=phase_request_counts,
                 trace=trace,
             ),
+        )
+
+    def _resolve_items(
+        self,
+        items: list[dict[str, Any]],
+        *,
+        grounded_chunks: list[dict[str, Any]],
+        language: str,
+    ) -> _ItemResolutionOutcome:
+        """Run one item set through the shared phase-2 path (retrieve -> route
+        -> map) and return every accounting delta as a pure outcome.
+
+        Extracted verbatim from the pre-B2 inline ``run()`` resolution block so
+        both the proband set and the family set flow through IDENTICAL retrieval,
+        routing, and mapping logic. The method never mutates ``run()`` state;
+        ``run()`` merges the returned deltas into the appropriate meta
+        namespace."""
+        resolved: list[LLMPhenotype] = []
+        logger.debug(
+            "Phase 2A: retrieving candidates for actionable_phrases=%d",
+            len(items),
+        )
+        phase2a_start = time.perf_counter()
+        phrase_candidates = self._retrieve_candidates(
+            actionable=items,
+            grounded_chunks=grounded_chunks,
+            language=language,
+        )
+        phase2a_seconds = round(time.perf_counter() - phase2a_start, 6)
+        candidate_sets = len(phrase_candidates)
+        phase2a_trace = build_phase2a_trace(phrase_candidates)
+        logger.debug(
+            "Phase 2A complete: candidate_sets=%d",
+            len(phrase_candidates),
+        )
+        logger.debug(
+            "Phase 2B-local: resolving local matches for candidate_sets=%d",
+            len(phrase_candidates),
+        )
+        phase2b_local_start = time.perf_counter()
+        (
+            locally_resolved,
+            unresolved,
+            routing_counts,
+        ) = self._route_phase2_candidates(
+            phrase_candidates=phrase_candidates,
+            language=language,
+        )
+        phase2b_local_seconds = round(time.perf_counter() - phase2b_local_start, 6)
+        resolved.extend(locally_resolved)
+        phase2b_local_trace = build_phase2b_local_trace(
+            locally_resolved=locally_resolved,
+            unresolved=unresolved,
+        )
+        logger.debug(
+            "Phase 2B-local complete: matched=%d unresolved=%d",
+            len(locally_resolved),
+            len(unresolved),
+        )
+
+        phase2b_llm_seconds = 0.0
+        prompt_tokens = 0
+        completion_tokens = 0
+        token_usage: dict[str, int] = {}
+        request_count = 0
+        phase2b_llm_requests = 0
+        local_fallbacks = 0
+        llm_mapped_phrases = 0
+        mapping_prompt_version: str | None = None
+        phase2b_llm_trace: dict[str, Any] | None = None
+        mapping_ran = False
+
+        if unresolved:
+            mapping_ran = True
+            mapping_prompt = (
+                get_batch_mapping_prompt(language)
+                if len(unresolved) > 1 and self.mapping_batch_size > 1
+                else get_mapping_prompt(language)
+            )
+            mapping_prompt_version = mapping_prompt.version
+            logger.debug(
+                "Phase 2B-llm: mapping unresolved phrases=%d",
+                len(unresolved),
+            )
+            phase2b_llm_start = time.perf_counter()
+            (
+                mapped_terms,
+                mapping_prompt_tokens,
+                mapping_completion_tokens,
+                mapping_token_usage,
+                mapping_request_count,
+                local_fallback_count,
+                mapping_trace,
+            ) = self._resolve_with_mapping_prompt(
+                unresolved=unresolved,
+                mapping_prompt=mapping_prompt,
+            )
+            phase2b_llm_seconds = round(time.perf_counter() - phase2b_llm_start, 6)
+            prompt_tokens = mapping_prompt_tokens
+            completion_tokens = mapping_completion_tokens
+            token_usage = mapping_token_usage
+            request_count = mapping_request_count
+            phase2b_llm_requests = mapping_request_count
+            resolved.extend(mapped_terms)
+            local_fallbacks = local_fallback_count
+            llm_mapped_phrases = len(mapped_terms) - local_fallback_count
+            phase2b_llm_trace = {"resolved": mapping_trace}
+            logger.debug(
+                "Phase 2B-llm complete: mapped=%d prompt_tokens=%d completion_tokens=%d",
+                llm_mapped_phrases,
+                mapping_prompt_tokens,
+                mapping_completion_tokens,
+            )
+
+        return _ItemResolutionOutcome(
+            resolved=resolved,
+            phase2a_seconds=phase2a_seconds,
+            phase2b_local_seconds=phase2b_local_seconds,
+            phase2b_llm_seconds=phase2b_llm_seconds,
+            candidate_sets=candidate_sets,
+            routing_counts=routing_counts,
+            unresolved_phrases=len(unresolved),
+            local_matches=len(locally_resolved),
+            local_fallbacks=local_fallbacks,
+            llm_mapped_phrases=llm_mapped_phrases,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            token_usage=token_usage,
+            request_count=request_count,
+            phase2b_llm_requests=phase2b_llm_requests,
+            mapping_prompt_version=mapping_prompt_version,
+            phase2a_trace=phase2a_trace,
+            phase2b_local_trace=phase2b_local_trace,
+            phase2b_llm_trace=phase2b_llm_trace,
+            mapping_ran=mapping_ran,
         )
 
     def warmup(self, *, language: str) -> None:

--- a/phentrieve/llm/pipeline_phase1.py
+++ b/phentrieve/llm/pipeline_phase1.py
@@ -215,6 +215,11 @@ def phase1_extraction_dedup_key(item: dict[str, Any]) -> tuple[Any, ...]:
         item.get("start_char"),
         item.get("end_char"),
         str(item.get("experiencer") or "").strip().lower(),
+        # ``assertion`` is an orthogonal axis (B1): two mentions identical except
+        # for polarity (present vs absent) are DIFFERENT findings and must not
+        # collapse. A model-silent item contributes a uniform "" so pre-existing
+        # tuples' relative equality is unchanged (backward-compatible).
+        str(item.get("assertion") or "").strip().lower(),
     )
 
 

--- a/phentrieve/llm/pipeline_phase1.py
+++ b/phentrieve/llm/pipeline_phase1.py
@@ -214,6 +214,7 @@ def phase1_extraction_dedup_key(item: dict[str, Any]) -> tuple[Any, ...]:
         item.get("evidence_text"),
         item.get("start_char"),
         item.get("end_char"),
+        str(item.get("experiencer") or "").strip().lower(),
     )
 
 

--- a/phentrieve/llm/pipeline_phase2.py
+++ b/phentrieve/llm/pipeline_phase2.py
@@ -22,7 +22,7 @@ from phentrieve.llm.types import (
     LLMPhenotype,
     LLMPhenotypeEvidence,
 )
-from phentrieve.llm.utils import token_sort_similarity
+from phentrieve.llm.utils import parse_assertion, token_sort_similarity
 
 CATEGORY_TO_ASSERTION = {
     "abnormal": PRESENT_ASSERTION,
@@ -31,6 +31,36 @@ CATEGORY_TO_ASSERTION = {
     "family_history": "family_history",
     "other": "other",
 }
+
+# Project the PIPELINE assertion vocabulary (present | negated | uncertain) back
+# onto the legacy proband category enum, so the derived-compat category reflects
+# the (experiencer, assertion) axes rather than the raw legacy value (D3).
+ASSERTION_TO_CATEGORY = {
+    PRESENT_ASSERTION: "abnormal",
+    NEGATED_ASSERTION: "normal",
+    UNCERTAIN_ASSERTION: "suspected",
+}
+
+
+def derive_category_from_axes(
+    experiencer: str | None,
+    assertion: str | None,
+    fallback_category: str,
+) -> str:
+    """Derive the legacy-compat category from the orthogonal axes (D3).
+
+    The category enum conflates experiencer and assertion; this rebuilds it from
+    the resolved axes so the stored ``category`` stays consistent with the
+    model-driven ``assertion``. Non-proband experiencers dominate; otherwise the
+    pipeline assertion projects back onto the proband category enum. When the
+    axes are absent or the assertion is not a proband-polarity value, the
+    supplied ``fallback_category`` is preserved for backward compatibility.
+    """
+    if experiencer == "family_history":
+        return "family_history"
+    if experiencer == "other":
+        return "other"
+    return ASSERTION_TO_CATEGORY.get(assertion or "", fallback_category)
 
 
 def prepare_retrieval_queries(phrase: str) -> list[str]:
@@ -268,17 +298,32 @@ def phenotype_from_candidate(
         end_char=item.get("end_char"),
         match_method=match_method,
     )
+    normalized_category = normalize_category(str(item.get("category", "")))
+    # Model WINS: when the model supplied its own raw wire assertion, map it to
+    # the pipeline vocabulary (present | negated | uncertain); otherwise fall
+    # back to the legacy category derivation for backward compatibility (B1/D2).
+    resolved_assertion = (
+        parse_assertion(item["assertion"]).value
+        if item.get("assertion") is not None
+        else CATEGORY_TO_ASSERTION.get(normalized_category, PRESENT_ASSERTION)
+    )
+    resolved_experiencer = (
+        item["experiencer"]
+        if item.get("experiencer")
+        else experiencer_for_category(str(item.get("category", "")))
+    )
     return LLMPhenotype(
         term_id=candidate["hpo_id"],
         label=candidate["term_name"],
         evidence=item["phrase"],
-        assertion=CATEGORY_TO_ASSERTION.get(
-            normalize_category(str(item.get("category", ""))),
-            PRESENT_ASSERTION,
-        ),
-        experiencer=experiencer_for_category(str(item.get("category", ""))),
+        assertion=resolved_assertion,
+        experiencer=resolved_experiencer,
         negated_qualifier=(item.get("negated_qualifier") or None),
-        category=normalize_category(str(item.get("category", ""))),
+        # Derived-compat: store the category projected from the resolved axes,
+        # not the raw legacy value (D3).
+        category=derive_category_from_axes(
+            resolved_experiencer, resolved_assertion, normalized_category
+        ),
         confidence=(
             optional_float(candidate.get("confidence"))
             if candidate.get("confidence") is not None

--- a/phentrieve/llm/pipeline_phase2.py
+++ b/phentrieve/llm/pipeline_phase2.py
@@ -106,6 +106,8 @@ def compact_mapping_item(
         "neighbor_chunk_texts": neighbor_texts,
         "phrase": str(item["phrase"]).lower().replace("-", " ").strip(),
         "category": item["category"],
+        "experiencer": item.get("experiencer"),
+        "assertion": item.get("assertion"),
         "candidates": [],
     }
     for candidate in item["candidates"]:

--- a/phentrieve/llm/pipeline_phase2.py
+++ b/phentrieve/llm/pipeline_phase2.py
@@ -129,6 +129,16 @@ def compact_mapping_item(
         for text in grounded_context.get("neighbor_chunk_texts", [])
         if normalize_grounded_text(text)
     ]
+    # NOTE: ``experiencer`` and ``assertion`` are deliberately NOT serialized into
+    # the mapping payload. The mapping task is phrase->HPO-id selection; the axes
+    # are orthogonal to *which* term a phrase maps to and the mapping templates
+    # (en_mapping*.yaml) never reference them. Including them only perturbed the
+    # LLM's near-deterministic candidate pick (flipping bare fragments toward
+    # top-scored *modifier* nodes, e.g. "visuospatial"->HP:0012836), causing a
+    # measured precision regression. The axes still reach the resolver via the
+    # ORIGINAL item in ``phenotype_from_candidate`` (model-assertion-wins, B1),
+    # so dropping them here is behavior-preserving for the contract and only
+    # restores the baseline mapping input.
     compact_item: dict[str, Any] = {
         "primary_chunk_text": normalize_grounded_text(
             grounded_context.get("primary_chunk_text")
@@ -136,8 +146,6 @@ def compact_mapping_item(
         "neighbor_chunk_texts": neighbor_texts,
         "phrase": str(item["phrase"]).lower().replace("-", " ").strip(),
         "category": item["category"],
-        "experiencer": item.get("experiencer"),
-        "assertion": item.get("assertion"),
         "candidates": [],
     }
     for candidate in item["candidates"]:
@@ -299,14 +307,29 @@ def phenotype_from_candidate(
         match_method=match_method,
     )
     normalized_category = normalize_category(str(item.get("category", "")))
-    # Model WINS: when the model supplied its own raw wire assertion, map it to
-    # the pipeline vocabulary (present | negated | uncertain); otherwise fall
-    # back to the legacy category derivation for backward compatibility (B1/D2).
-    resolved_assertion = (
+    model_assertion = (
         parse_assertion(item["assertion"]).value
         if item.get("assertion") is not None
-        else CATEGORY_TO_ASSERTION.get(normalized_category, PRESENT_ASSERTION)
+        else None
     )
+    # Model WINS on polarity (present | negated | uncertain), EXCEPT it may not
+    # promote an explicit ``normal`` category to ``present``. A "normal" category
+    # is a normalcy verdict (e.g. "normal intellectual abilities" is NOT
+    # Cognitive impairment); the phase-1 model sometimes co-emits a contradictory
+    # ``assertion="present"`` (or leaks the schema default), which B1's plain
+    # model-wins rule would flip a ruled-out finding to present. That specific
+    # contradiction resolves to the normalcy category's ``negated`` instead. A
+    # model ``negated``/``uncertain`` on a normal category is consistent and is
+    # still honored; every other category keeps model-wins / category-fallback
+    # (B1/D2).
+    if normalized_category == "normal" and model_assertion == PRESENT_ASSERTION:
+        resolved_assertion = CATEGORY_TO_ASSERTION["normal"]
+    elif model_assertion is not None:
+        resolved_assertion = model_assertion
+    else:
+        resolved_assertion = CATEGORY_TO_ASSERTION.get(
+            normalized_category, PRESENT_ASSERTION
+        )
     resolved_experiencer = (
         item["experiencer"]
         if item.get("experiencer")

--- a/phentrieve/llm/types.py
+++ b/phentrieve/llm/types.py
@@ -198,6 +198,7 @@ class LLMPipelineConfig(BaseModel):
 
 class LLMExtractionResult(BaseModel):
     terms: list[LLMPhenotype] = Field(default_factory=list)
+    family_history_findings: list[LLMPhenotype] = Field(default_factory=list)
     meta: LLMMeta
 
 

--- a/phentrieve/llm/types.py
+++ b/phentrieve/llm/types.py
@@ -65,6 +65,14 @@ class LLMPhenotype(BaseModel):
     # only the qualifier Y is absent. None when the phrase is not partially
     # negated.
     negated_qualifier: str | None = None
+    # For a GENERATED excluded finding derived from a source finding's
+    # ``negated_qualifier`` (B3): the surface text Y that was retrieved and
+    # mapped. None on ordinary (non-derived) findings.
+    qualifier_surface_text: str | None = None
+    # Provenance of how the term was resolved. Set to
+    # ``"negated_qualifier_derived"`` on a B3-generated excluded finding so
+    # downstream consumers can distinguish it from a directly-extracted term.
+    match_method: str | None = None
     category: str | None = None
     confidence: float | None = None
     score: float | None = None

--- a/phentrieve/phenopackets/export_models.py
+++ b/phentrieve/phenopackets/export_models.py
@@ -32,6 +32,28 @@ def _normalize_assertion(value: str | None) -> AssertionValue:
     return _ASSERTION_ALIASES.get(normalized, "unknown")
 
 
+def _resolve_legacy_assertion(legacy: Mapping[str, Any]) -> str:
+    """Pick the assertion source from a legacy dict (B0 export contract).
+
+    The canonical export fields (``assertion`` / ``assertion_status``) win when
+    present, but the shared full-text service emits aggregated terms keyed on the
+    raw pipeline ``status`` (present | negated | normal | ...) plus a derived
+    ``excluded`` bool, and carries NEITHER canonical field. Reading ``status``
+    and then the ``excluded`` flag here ensures a ruled-out finding routed
+    through the aggregated phenopacket/sidecar path exports as ``negated`` rather
+    than silently defaulting to ``affirmed`` (present)."""
+    explicit = (
+        legacy.get("assertion")
+        or legacy.get("assertion_status")
+        or legacy.get("status")
+    )
+    if explicit:
+        return str(explicit)
+    if legacy.get("excluded"):
+        return "negated"
+    return "affirmed"
+
+
 def _normalize_chunk_ids(value: Any) -> list[int]:
     if value is None:
         return []
@@ -240,13 +262,7 @@ class NormalizedPhenotypeExportRecord:
         return cls(
             hpo_id=str(hpo_id),
             label=str(label),
-            assertion=_normalize_assertion(
-                str(
-                    legacy.get("assertion")
-                    or legacy.get("assertion_status")
-                    or "affirmed"
-                )
-            ),
+            assertion=_normalize_assertion(_resolve_legacy_assertion(legacy)),
             certainty=str(certainty) if certainty is not None else None,
             confidence=float(confidence) if confidence is not None else None,
             evidence_text=str(evidence_text) if evidence_text is not None else None,

--- a/phentrieve/phenopackets/export_models.py
+++ b/phentrieve/phenopackets/export_models.py
@@ -19,6 +19,8 @@ _ASSERTION_ALIASES: dict[str, AssertionValue] = {
     "affirmed": "affirmed",
     "negated": "negated",
     "absent": "negated",
+    # A normalcy verdict is a ruled-out abnormality -> excluded in the packet.
+    "normal": "negated",
     "uncertain": "uncertain",
     "suspected": "uncertain",
     "family_history": "family_history",

--- a/phentrieve/text_processing/full_text_service.py
+++ b/phentrieve/text_processing/full_text_service.py
@@ -483,6 +483,16 @@ def _adapt_llm_aggregated_terms(
         match_method = getattr(term, "match_method", None)
         if match_method:
             adapted_terms[-1]["match_method"] = match_method
+            if match_method == "negated_qualifier_derived":
+                # B3 coherence fix: the generated term INHERITS the source
+                # finding's evidence records verbatim (F5) purely to carry
+                # valid ``source_chunk_ids`` past the drop guard above. Those
+                # evidence records' text belongs to the SOURCE finding X (the
+                # "rash" in "rash without fever"), not to this generated
+                # excluded term Y ("fever") -- so the ``text_attributions``
+                # computed from them would highlight the wrong span. Suppress
+                # the highlight while leaving chunk provenance untouched.
+                adapted_terms[-1]["text_attributions"] = []
         qualifier_surface_text = getattr(term, "qualifier_surface_text", None)
         if qualifier_surface_text:
             adapted_terms[-1]["qualifier_surface_text"] = qualifier_surface_text

--- a/phentrieve/text_processing/full_text_service.py
+++ b/phentrieve/text_processing/full_text_service.py
@@ -13,6 +13,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import asdict, dataclass
 from typing import Any
 
+from phentrieve.assertion_vocab import is_excluded
 from phentrieve.config import (
     DEFAULT_ASSERTION_CONFIG,
     DEFAULT_CHUNK_RETRIEVAL_THRESHOLD,
@@ -152,6 +153,7 @@ def adapt_full_text_response(
     meta: dict[str, Any] = {}
     processed_chunks: list[Any] = []
     aggregated_hpo_terms: list[Any] = []
+    family_history_findings: list[Any] = []
 
     if response is not None:
         response_meta = response.get("meta")
@@ -164,12 +166,17 @@ def adapt_full_text_response(
         aggregated_hpo_terms = _coerce_list(
             response.get("aggregated_hpo_terms") or response.get("aggregated_results")
         )
+        # Family-history findings are a distinct list keyed by experiencer; carry
+        # them through normalization so both the direct LLM payload path and the
+        # generic path preserve them (B2, F4).
+        family_history_findings = _coerce_list(response.get("family_history_findings"))
 
     meta["extraction_backend"] = extraction_backend
     return {
         "meta": meta,
         "processed_chunks": processed_chunks,
         "aggregated_hpo_terms": aggregated_hpo_terms,
+        "family_history_findings": family_history_findings,
     }
 
 
@@ -437,6 +444,14 @@ def _adapt_llm_aggregated_terms(
                 "name": term.label,
                 "evidence": term.evidence,
                 "status": term.assertion,
+                # Who the finding belongs to (proband / family_history / other),
+                # orthogonal to the present/negated assertion. Shared by proband
+                # and family terms since both flow through this adapter.
+                "experiencer": getattr(term, "experiencer", None),
+                # Derived, non-breaking excluded signal (F2): the extract surface
+                # still reports the raw pipeline ``status`` (present/negated/...),
+                # but a consumer gets the actionable ruled-out flag here too.
+                "excluded": is_excluded(term.assertion),
                 "evidence_records": evidence_records,
                 "confidence": (
                     term_confidence
@@ -864,6 +879,10 @@ def run_llm_backend(*, text: str, **kwargs: Any) -> StableBackendResponse:
         result.terms,
         grounded_chunks=grounded_chunks,
     )
+    adapted_family = _adapt_llm_aggregated_terms(
+        getattr(result, "family_history_findings", []),
+        grounded_chunks=grounded_chunks,
+    )
     adapted_chunks = _adapt_llm_processed_chunks(grounded_chunks, adapted_terms)
 
     result_payload = {
@@ -919,6 +938,7 @@ def run_llm_backend(*, text: str, **kwargs: Any) -> StableBackendResponse:
         },
         "processed_chunks": adapted_chunks,
         "aggregated_hpo_terms": adapted_terms,
+        "family_history_findings": adapted_family,
     }
 
     logger.info(

--- a/phentrieve/text_processing/full_text_service.py
+++ b/phentrieve/text_processing/full_text_service.py
@@ -476,6 +476,16 @@ def _adapt_llm_aggregated_terms(
         negated_qualifier = getattr(term, "negated_qualifier", None)
         if negated_qualifier:
             adapted_terms[-1]["negated_qualifier"] = negated_qualifier
+        # B3/F5: carry the negated_qualifier-derived excluded finding's shape.
+        # ``match_method="negated_qualifier_derived"`` marks a generated term;
+        # ``qualifier_surface_text`` is the retrieved-and-mapped surface Y. Both
+        # are truthy-gated so ordinary (non-derived) terms surface unchanged.
+        match_method = getattr(term, "match_method", None)
+        if match_method:
+            adapted_terms[-1]["match_method"] = match_method
+        qualifier_surface_text = getattr(term, "qualifier_surface_text", None)
+        if qualifier_surface_text:
+            adapted_terms[-1]["qualifier_surface_text"] = qualifier_surface_text
 
     return adapted_terms
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "phentrieve"
-version = "0.24.1"
+version = "0.25.0"
 description = "A CLI tool for retrieving Human Phenotype Ontology (HPO) terms from clinical text using multilingual embeddings."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/unit/api/test_family_findings_surface.py
+++ b/tests/unit/api/test_family_findings_surface.py
@@ -1,0 +1,178 @@
+"""B2 Task 9: family_history_findings + per-term experiencer + derived excluded.
+
+Drives the REAL adapter chain -- run_llm_backend() -> adapt_full_text_response()
+-> adapt_shared_service_response_to_api() -- rather than a bare model_validate,
+so the field is exercised at every surface boundary it must survive (F4). Also
+covers the deterministic-backend fallback where ``excluded`` is derived from the
+pipeline ``status`` via ``is_excluded`` (F2).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from api.schemas.text_processing_schemas import (
+    TextProcessingRequest,
+    TextProcessingResponseAPI,
+)
+from api.services.text_processing_execution import (
+    adapt_shared_service_response_to_api,
+)
+from phentrieve.llm.types import (
+    LLMExtractionResult,
+    LLMMeta,
+    LLMPhenotype,
+)
+from phentrieve.text_processing.full_text_service import (
+    adapt_full_text_response,
+    run_llm_backend,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _extraction_result() -> LLMExtractionResult:
+    """A proband present term, a proband negated term, and a family finding."""
+    return LLMExtractionResult(
+        terms=[
+            LLMPhenotype(
+                term_id="HP:0001250",
+                label="Seizure",
+                assertion="present",
+                experiencer="proband",
+                evidence="recurrent seizures",
+            ),
+            LLMPhenotype(
+                term_id="HP:0001945",
+                label="Fever",
+                assertion="negated",
+                experiencer="proband",
+                evidence="no fever",
+            ),
+        ],
+        family_history_findings=[
+            LLMPhenotype(
+                term_id="HP:0002076",
+                label="Migraine",
+                assertion="present",
+                experiencer="family_history",
+                evidence="mother has migraine",
+            ),
+        ],
+        meta=LLMMeta(llm_model="stub", llm_mode="two_phase"),
+    )
+
+
+def _run_backend(result: LLMExtractionResult) -> dict:
+    """Run the real LLM backend with a stubbed provider + pipeline (no model)."""
+    provider = SimpleNamespace(
+        provider_name="ollama", model_name="stub", base_url="http://localhost"
+    )
+    pipeline = SimpleNamespace(run=lambda **_kwargs: result)
+    return run_llm_backend(
+        text="Patient had recurrent seizures but no fever. Mother has migraine.",
+        llm_model="stub",
+        llm_mode="two_phase",
+        # legacy mode skips grounding preprocessing (no retrieval / data needed).
+        llm_internal_mode="whole_document_legacy",
+        provider_factory=lambda **_kw: provider,
+        pipeline_factory=lambda **_kw: pipeline,
+    )
+
+
+def _find(terms: list[dict], hpo_id: str) -> dict:
+    return next(term for term in terms if term.get("id") == hpo_id)
+
+
+def test_run_llm_backend_emits_family_findings_and_derived_excluded():
+    payload = _run_backend(_extraction_result())
+
+    family = payload["family_history_findings"]
+    assert len(family) == 1
+    assert family[0]["id"] == "HP:0002076"
+    assert family[0]["experiencer"] == "family_history"
+    assert family[0]["excluded"] is False
+
+    seizure = _find(payload["aggregated_hpo_terms"], "HP:0001250")
+    fever = _find(payload["aggregated_hpo_terms"], "HP:0001945")
+    assert seizure["experiencer"] == "proband"
+    assert seizure["excluded"] is False
+    assert fever["experiencer"] == "proband"
+    # ``negated`` (pipeline vocab) canonicalizes to excluded (F2).
+    assert fever["excluded"] is True
+
+
+def test_adapt_full_text_response_preserves_family_findings():
+    payload = _run_backend(_extraction_result())
+
+    normalized = adapt_full_text_response(payload, extraction_backend="llm")
+
+    assert "family_history_findings" in normalized
+    assert [term["id"] for term in normalized["family_history_findings"]] == [
+        "HP:0002076"
+    ]
+    # Existing keys are untouched.
+    assert {term["id"] for term in normalized["aggregated_hpo_terms"]} == {
+        "HP:0001250",
+        "HP:0001945",
+    }
+
+
+def test_full_chain_surfaces_family_experiencer_and_excluded_on_api():
+    payload = _run_backend(_extraction_result())
+    normalized = adapt_full_text_response(payload, extraction_backend="llm")
+
+    response = adapt_shared_service_response_to_api(
+        normalized, request=TextProcessingRequest(text="x")
+    )
+
+    assert isinstance(response, TextProcessingResponseAPI)
+    assert len(response.family_history_findings) == 1
+    family_term = response.family_history_findings[0]
+    assert family_term.id == "HP:0002076"
+    assert family_term.experiencer == "family_history"
+    assert family_term.excluded is False
+
+    by_id = {term.id: term for term in response.aggregated_hpo_terms}
+    assert by_id["HP:0001250"].experiencer == "proband"
+    assert by_id["HP:0001250"].excluded is False
+    assert by_id["HP:0001945"].experiencer == "proband"
+    assert by_id["HP:0001945"].excluded is True
+    # status is NOT rewritten -- only the derived excluded signal is added (F2).
+    assert by_id["HP:0001945"].status == "negated"
+
+
+def test_api_builder_derives_excluded_from_status_when_absent():
+    """Deterministic backend lacks a precomputed ``excluded``; derive it (F2)."""
+    service_result = {
+        "meta": {"extraction_backend": "standard"},
+        "processed_chunks": [],
+        "aggregated_hpo_terms": [
+            {
+                "id": "HP:0001250",
+                "name": "Seizure",
+                "confidence": 0.9,
+                "status": "affirmed",
+                "evidence_count": 1,
+                "source_chunk_ids": [],
+            },
+            {
+                "id": "HP:0001945",
+                "name": "Fever",
+                "confidence": 0.8,
+                "status": "negated",
+                "evidence_count": 1,
+                "source_chunk_ids": [],
+            },
+        ],
+        "family_history_findings": [],
+    }
+
+    response = adapt_shared_service_response_to_api(
+        service_result, request=TextProcessingRequest(text="x")
+    )
+
+    by_id = {term.id: term for term in response.aggregated_hpo_terms}
+    assert by_id["HP:0001250"].excluded is False
+    assert by_id["HP:0001945"].excluded is True
+    assert response.family_history_findings == []

--- a/tests/unit/api/test_qualifier_excluded_surface.py
+++ b/tests/unit/api/test_qualifier_excluded_surface.py
@@ -1,0 +1,169 @@
+"""B3 Task 11: surface negated_qualifier-derived excluded findings (REST + MCP).
+
+Two concerns:
+
+  (a) round-trip -- a service-payload term dict carrying
+      ``match_method="negated_qualifier_derived"``, ``qualifier_surface_text``,
+      and ``negated_qualifier`` survives ``adapt_shared_service_response_to_api``
+      / ``AggregatedHPOTermAPI`` (REST) and ``project_aggregated_terms_for_mcp``
+      / ``project_extract_payload`` (MCP) with the fields populated.
+
+  (b) F5 service-survival -- a GENERATED excluded ``LLMPhenotype`` whose
+      inherited evidence records carry VALID chunk ids survives the REAL
+      ``_adapt_llm_aggregated_terms``, while an otherwise-identical term whose
+      evidence records reference an invalid chunk id is DROPPED at the
+      ``if raw_source_chunk_ids and not source_chunk_ids: continue`` guard in
+      ``full_text_service.py``. The present-vs-absent contrast proves the
+      inherited valid chunk ids are what keep the generated term alive.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from api.mcp.projection import (
+    project_aggregated_terms_for_mcp,
+    project_extract_payload,
+)
+from api.schemas.text_processing_schemas import TextProcessingRequest
+from api.services.text_processing_execution import (
+    adapt_shared_service_response_to_api,
+)
+from phentrieve.llm.config import NEGATED_ASSERTION
+from phentrieve.llm.types import LLMPhenotype, LLMPhenotypeEvidence
+from phentrieve.text_processing.full_text_service import _adapt_llm_aggregated_terms
+
+pytestmark = pytest.mark.unit
+
+
+def _excluded_service_payload() -> dict:
+    """Shared-service payload for a negated_qualifier-derived excluded finding."""
+    return {
+        "meta": {"extraction_backend": "llm"},
+        "processed_chunks": [
+            {
+                "chunk_id": 1,
+                "text": "recurrent seizures but no fever",
+                "status": "affirmed",
+                "hpo_matches": [],
+            }
+        ],
+        "aggregated_hpo_terms": [
+            {
+                "id": "HP:0001945",
+                "name": "Fever",
+                "confidence": 0.91,
+                "status": "negated",
+                "experiencer": "proband",
+                "excluded": True,
+                "negated_qualifier": "fever",
+                "qualifier_surface_text": "fever",
+                "match_method": "negated_qualifier_derived",
+                "evidence_count": 1,
+                "source_chunk_ids": [1],
+                "top_evidence_chunk_id": 1,
+                "text_attributions": [],
+            }
+        ],
+        "family_history_findings": [],
+    }
+
+
+def test_excluded_finding_round_trips_through_rest():
+    """REST: AggregatedHPOTermAPI carries the three derived-exclusion fields."""
+    response = adapt_shared_service_response_to_api(
+        _excluded_service_payload(), request=TextProcessingRequest(text="x")
+    )
+
+    term = response.aggregated_hpo_terms[0]
+    assert term.id == "HP:0001945"
+    assert term.excluded is True
+    # status is NOT rewritten -- only the derived signals ride alongside it.
+    assert term.status == "negated"
+    assert term.negated_qualifier == "fever"
+    assert term.qualifier_surface_text == "fever"
+    assert term.match_method == "negated_qualifier_derived"
+
+
+def test_excluded_finding_survives_mcp_projection():
+    """MCP: the projection carries qualifier_surface_text / match_method."""
+    payload = _excluded_service_payload()
+
+    projected = project_aggregated_terms_for_mcp(payload["aggregated_hpo_terms"])[0]
+    assert projected["hpo_id"] == "HP:0001945"
+    assert projected["excluded"] is True
+    assert projected["qualifier_surface_text"] == "fever"
+    assert projected["match_method"] == "negated_qualifier_derived"
+    assert projected["negated_qualifier"] == "fever"
+
+    out = project_extract_payload(payload)
+    agg = out["aggregated_hpo_terms"][0]
+    assert agg["qualifier_surface_text"] == "fever"
+    assert agg["match_method"] == "negated_qualifier_derived"
+    assert agg["negated_qualifier"] == "fever"
+
+
+def _grounded_chunks() -> list[dict]:
+    return [
+        {"chunk_id": 1, "text": "recurrent seizures but no fever"},
+        {"chunk_id": 2, "text": "mother has migraine"},
+    ]
+
+
+def _generated_excluded_term(*, term_id: str, chunk_ids: list[int]) -> LLMPhenotype:
+    """A B3-generated excluded term inheriting a source finding's evidence.
+
+    ``qualifier_surface_text`` / ``match_method`` mirror what
+    ``_build_qualifier_exclusions`` emits; ``negated_qualifier`` is None on the
+    generated term. ``chunk_ids`` are the INHERITED source-finding chunk refs.
+    """
+    return LLMPhenotype(
+        term_id=term_id,
+        label="Fever",
+        evidence="fever",
+        assertion=NEGATED_ASSERTION,
+        experiencer="proband",
+        negated_qualifier=None,
+        qualifier_surface_text="fever",
+        match_method="negated_qualifier_derived",
+        confidence=0.9,
+        score=0.9,
+        evidence_records=[
+            LLMPhenotypeEvidence(
+                phrase="fever", evidence_text="fever", chunk_ids=chunk_ids
+            )
+        ],
+    )
+
+
+def test_generated_excluded_term_survives_when_inherited_chunk_refs_are_valid():
+    """F5: valid inherited chunk ids keep the generated term alive; invalid drop.
+
+    Both terms are byte-for-byte identical in shape apart from the chunk id
+    their evidence record references. The only removal path in
+    ``_adapt_llm_aggregated_terms`` is the ``raw_source_chunk_ids`` guard, so the
+    present-vs-absent contrast isolates that guard: the valid-ref term survives,
+    the invalid-ref term is dropped.
+    """
+    valid = _generated_excluded_term(term_id="HP:0001945", chunk_ids=[1])
+    invalid = _generated_excluded_term(term_id="HP:0000252", chunk_ids=[999])
+
+    adapted = _adapt_llm_aggregated_terms(
+        [valid, invalid], grounded_chunks=_grounded_chunks()
+    )
+
+    by_id = {term["id"]: term for term in adapted}
+    # Inherited VALID chunk id (1 is in grounded_chunks) keeps it alive.
+    assert "HP:0001945" in by_id
+    # Invalid ref (999 not in grounded_chunks) hits the drop guard.
+    assert "HP:0000252" not in by_id
+
+    survivor = by_id["HP:0001945"]
+    assert survivor["excluded"] is True
+    assert survivor["status"] == NEGATED_ASSERTION
+    assert survivor["source_chunk_ids"] == [1]
+    # The B3 provenance fields ride through the service adapter unchanged.
+    assert survivor["match_method"] == "negated_qualifier_derived"
+    assert survivor["qualifier_surface_text"] == "fever"
+    # Generated term carries no negated_qualifier of its own (None -> omitted).
+    assert "negated_qualifier" not in survivor

--- a/tests/unit/api/test_qualifier_excluded_surface.py
+++ b/tests/unit/api/test_qualifier_excluded_surface.py
@@ -167,3 +167,72 @@ def test_generated_excluded_term_survives_when_inherited_chunk_refs_are_valid():
     assert survivor["qualifier_surface_text"] == "fever"
     # Generated term carries no negated_qualifier of its own (None -> omitted).
     assert "negated_qualifier" not in survivor
+
+
+def test_generated_excluded_term_suppresses_inherited_text_attributions():
+    """B3 coherence fix: a negated_qualifier-derived term must not surface
+    ``text_attributions`` pointing at the SOURCE finding's span.
+
+    "rash without fever": the source finding X ("rash") has evidence text
+    "rash" anchored to chunk 1. Per F5, the generated excluded finding for Y
+    ("fever") INHERITS X's evidence records verbatim -- valid chunk_ids so it
+    survives the drop guard, but the evidence_text is still "rash", not
+    "fever". Before the fix, ``_adapt_llm_aggregated_terms`` derived
+    ``text_attributions`` from those inherited records, so the excluded FEVER
+    term wrongly highlighted the "rash" span. The fix suppresses the
+    highlight for derived terms while leaving ``source_chunk_ids`` (and thus
+    survival) untouched.
+    """
+    grounded_chunks = [{"chunk_id": 1, "text": "rash without fever"}]
+
+    source_evidence = LLMPhenotypeEvidence(
+        phrase="rash", evidence_text="rash", chunk_ids=[1]
+    )
+    ordinary_term = LLMPhenotype(
+        term_id="HP:0000988",
+        label="Skin rash",
+        evidence="rash",
+        assertion="present",
+        experiencer="proband",
+        negated_qualifier="fever",
+        confidence=0.95,
+        score=0.95,
+        evidence_records=[source_evidence],
+    )
+    generated_excluded_term = LLMPhenotype(
+        term_id="HP:0001945",
+        label="Fever",
+        evidence="fever",
+        assertion=NEGATED_ASSERTION,
+        experiencer="proband",
+        negated_qualifier=None,
+        qualifier_surface_text="fever",
+        match_method="negated_qualifier_derived",
+        confidence=0.9,
+        score=0.9,
+        # F5: inherited verbatim from the source finding -- evidence_text is
+        # still "rash", the SOURCE's span, not "fever".
+        evidence_records=[source_evidence.model_copy(deep=True)],
+    )
+
+    adapted = _adapt_llm_aggregated_terms(
+        [ordinary_term, generated_excluded_term], grounded_chunks=grounded_chunks
+    )
+    by_id = {term["id"]: term for term in adapted}
+
+    # Survival is unaffected: the generated term is still present, with its
+    # excluded flag and inherited chunk provenance intact.
+    assert "HP:0001945" in by_id
+    survivor = by_id["HP:0001945"]
+    assert survivor["excluded"] is True
+    assert survivor["source_chunk_ids"] == [1]
+    assert survivor["match_method"] == "negated_qualifier_derived"
+
+    # The wrong-provenance highlight is suppressed.
+    assert survivor["text_attributions"] == []
+
+    # An ordinary term in the same call is unaffected: it still surfaces its
+    # own (correct) text_attributions.
+    rash_term = by_id["HP:0000988"]
+    assert rash_term["text_attributions"] != []
+    assert rash_term["text_attributions"][0]["matched_text_in_chunk"] == "rash"

--- a/tests/unit/api/test_text_processing_router.py
+++ b/tests/unit/api/test_text_processing_router.py
@@ -1128,7 +1128,8 @@ class TestTextProcessingModelValidation:
                 ) as mock_validate:
                     await _process_text_via_shared_service(request)
 
-        mock_validate.assert_called_once()
+        # Invariant check runs for BOTH the aggregated and the family lists (B2fix).
+        assert mock_validate.call_count == 2
 
 
 class TestValidateResponseChunkReferences:

--- a/tests/unit/benchmark/test_assert_no_regression.py
+++ b/tests/unit/benchmark/test_assert_no_regression.py
@@ -72,3 +72,30 @@ def test_cli_scoring_mode_mismatch_exits_two(tmp_path):
     )
     assert result.exit_code == 2
     assert "MODE MISMATCH" in result.stdout
+
+
+def test_regressions_fail_closed_on_missing_baseline_key():
+    # A baseline missing a gated key must NOT default to 0.0 and pass anything.
+    base = {"micro_precision": 0.80, "micro_recall": 0.80}  # no micro_f1
+    cand = {"micro_f1": 0.01, "micro_precision": 0.80, "micro_recall": 0.80}
+    out = _regressions(base, cand, tolerance=0.0)
+    assert any("micro_f1" in r and "MISSING" in r for r in out)
+
+
+def test_regressions_fail_closed_on_missing_candidate_key():
+    base = {"micro_f1": 0.80, "micro_precision": 0.80, "micro_recall": 0.80}
+    cand = {"micro_precision": 0.80, "micro_recall": 0.80}  # no micro_f1
+    out = _regressions(base, cand, tolerance=0.0)
+    assert any("micro_f1" in r and "MISSING" in r for r in out)
+
+
+def test_cli_missing_scoring_mode_exits_two(tmp_path):
+    # A summary lacking scoring_mode is not gateable: comparability is unverifiable
+    # and a mode-stripped present-only candidate could otherwise pass a strict base.
+    b = _write_summary(tmp_path / "b.json")  # no scoring_mode
+    c = _write_summary(tmp_path / "c.json", scoring_mode="strict")
+    result = runner.invoke(
+        app, ["assert-no-regression", "--baseline", str(b), "--candidate", str(c)]
+    )
+    assert result.exit_code == 2
+    assert "MODE MISSING" in result.stdout

--- a/tests/unit/cli/test_text_commands.py
+++ b/tests/unit/cli/test_text_commands.py
@@ -425,6 +425,8 @@ def test_run_llm_backend_uses_pipeline_and_provider(monkeypatch):
             "name": "Seizure",
             "evidence": "Patient had recurrent seizures.",
             "status": "present",
+            "experiencer": "proband",
+            "excluded": False,
             "evidence_records": [],
             "confidence": 0.0,
             "evidence_count": 0,

--- a/tests/unit/llm/test_axis_threading.py
+++ b/tests/unit/llm/test_axis_threading.py
@@ -1,0 +1,134 @@
+"""Axis threading tests (extraction contract v2, block B1).
+
+These tests pin the requirement that the model's own RAW WIRE ``experiencer``
+(proband | family_history | other) and ``assertion`` (present | absent |
+uncertain) survive the phase-1 -> retrieve -> mapping-payload chain unchanged,
+so a later task can consume the model's assertion as polarity.
+
+The retriever and the LLM provider are stubbed, so no model / Gemini / network
+is required.
+"""
+
+from __future__ import annotations
+
+import phentrieve.llm.pipeline as pipeline_module
+from phentrieve.llm.pipeline_phase1 import phase1_extraction_dedup_key
+from phentrieve.llm.pipeline_phase2 import compact_mapping_item
+from phentrieve.llm.provider import LLMProvider
+
+TwoPhaseLLMPipeline = pipeline_module.TwoPhaseLLMPipeline
+
+
+class _StubProvider(LLMProvider):
+    """Minimal provider stub; the axis-threading tests never call the model."""
+
+    def complete(self, messages):  # pragma: no cover - never invoked here
+        raise AssertionError("provider.complete must not be called")
+
+    def run_structured_prompt(
+        self,
+        *,
+        system_prompt,
+        user_prompt,
+        response_model,
+        max_output_tokens=None,
+    ):  # pragma: no cover - never invoked here
+        raise AssertionError("provider.run_structured_prompt must not be called")
+
+
+class _StubToolExecutor:
+    """Retriever stub that returns no candidates.
+
+    The axes are attached from the parsed item itself in the per-item rebuild
+    loop of ``_retrieve_candidates``; they do not depend on retrieval output, so
+    an empty batch keeps the test focused purely on axis threading.
+    """
+
+    def __init__(self):
+        self.queries = []
+
+    def query_batch_hpo_terms(self, *, phrases, language, n_results):
+        self.queries.append(
+            {"phrases": list(phrases), "language": language, "n_results": n_results}
+        )
+        return []
+
+
+def _actionable_item(**overrides):
+    item = {
+        "phrase": "seizures",
+        "category": "abnormal",
+        "negated_qualifier": None,
+        "chunk_ids": [1],
+        "evidence_text": "recurrent seizures",
+        "start_char": 0,
+        "end_char": 10,
+        "experiencer": "family_history",
+        "assertion": "absent",
+    }
+    item.update(overrides)
+    return item
+
+
+def test_retrieve_candidates_preserves_experiencer_and_assertion():
+    """Crux: the per-item rebuild in ``_retrieve_candidates`` must keep the
+    model's raw experiencer + assertion on every emerging candidate dict."""
+    pipeline = TwoPhaseLLMPipeline(
+        provider=_StubProvider(),
+        tool_executor=_StubToolExecutor(),
+    )
+
+    results = pipeline._retrieve_candidates(
+        actionable=[_actionable_item()],
+        grounded_chunks=[],
+        language="en",
+    )
+
+    assert len(results) == 1
+    rebuilt = results[0]
+    assert rebuilt["experiencer"] == "family_history"
+    assert rebuilt["assertion"] == "absent"
+
+
+def test_compact_mapping_item_includes_experiencer_and_assertion():
+    """Mapping payload must carry the axes so the phase-2 LLM (and Task 5's
+    ``phenotype_from_candidate``) can read the model's assertion + experiencer."""
+    item = {
+        "phrase": "seizures",
+        "category": "abnormal",
+        "grounded_context": {},
+        "candidates": [],
+        "experiencer": "family_history",
+        "assertion": "absent",
+    }
+
+    compact = compact_mapping_item(item)
+
+    assert compact["experiencer"] == "family_history"
+    assert compact["assertion"] == "absent"
+
+
+def test_phase1_dedup_key_separates_experiencer():
+    """A proband vs family mention of an otherwise-identical phrase must not
+    collapse into one item before retrieval: differing experiencer -> different
+    dedup key."""
+    proband = _actionable_item(experiencer="proband")
+    family = _actionable_item(experiencer="family_history")
+
+    assert phase1_extraction_dedup_key(proband) != phase1_extraction_dedup_key(family)
+
+
+def test_phase1_dedup_key_backward_compatible_without_experiencer():
+    """Determinism guardrail: items with no experiencer axis (deterministic
+    extractor path) still produce identical dedup keys, so existing behavior is
+    unchanged."""
+    a = _actionable_item()
+    b = _actionable_item()
+    a.pop("experiencer")
+    b.pop("experiencer")
+
+    assert phase1_extraction_dedup_key(a) == phase1_extraction_dedup_key(b)
+
+    # None and absent must key identically to a blank string too.
+    c = _actionable_item(experiencer=None)
+    assert phase1_extraction_dedup_key(a) == phase1_extraction_dedup_key(c)

--- a/tests/unit/llm/test_axis_threading.py
+++ b/tests/unit/llm/test_axis_threading.py
@@ -13,8 +13,13 @@ from __future__ import annotations
 
 import phentrieve.llm.pipeline as pipeline_module
 from phentrieve.llm.pipeline_phase1 import phase1_extraction_dedup_key
-from phentrieve.llm.pipeline_phase2 import compact_mapping_item
+from phentrieve.llm.pipeline_phase2 import (
+    compact_mapping_item,
+    phenotype_from_candidate,
+)
+from phentrieve.llm.prompts.loader import get_prompt
 from phentrieve.llm.provider import LLMProvider
+from phentrieve.llm.types import AnnotationMode, LLMExtractedPhenotype
 
 TwoPhaseLLMPipeline = pipeline_module.TwoPhaseLLMPipeline
 
@@ -132,3 +137,109 @@ def test_phase1_dedup_key_backward_compatible_without_experiencer():
     # None and absent must key identically to a blank string too.
     c = _actionable_item(experiencer=None)
     assert phase1_extraction_dedup_key(a) == phase1_extraction_dedup_key(c)
+
+
+class _CannedPhase1Provider(LLMProvider):
+    """Provider stub whose structured prompt returns preset phase-1 phenotype
+    objects, so the parse step in ``_extract_phase1_phenotypes`` can be driven
+    without a model.
+
+    Crucially it returns the constructed Pydantic phenotypes verbatim, so each
+    phenotype's ``model_fields_set`` is preserved -- that set is what
+    distinguishes a MODEL-EMITTED assertion from a SCHEMA-DEFAULTED one.
+    """
+
+    class _Response:
+        def __init__(self, phenotypes):
+            self.phenotypes = list(phenotypes)
+
+    def __init__(self, phenotypes):
+        super().__init__()
+        self._phenotypes = list(phenotypes)
+        self.last_usage = {
+            "prompt_tokens": 1,
+            "completion_tokens": 1,
+            "total_tokens": 2,
+        }
+        self.last_request_count = 1
+
+    def complete(self, messages):  # pragma: no cover - never invoked here
+        raise AssertionError("provider.complete must not be called")
+
+    def run_structured_prompt(
+        self,
+        *,
+        system_prompt,
+        user_prompt,
+        response_model,
+        max_output_tokens=None,
+    ):
+        return self._Response(self._phenotypes)
+
+
+def _parse_phase1(*phenotypes):
+    """Drive the phase-1 parse step over the given wire phenotype objects and
+    return the parsed item dicts (the first element of the method's tuple)."""
+    pipeline = TwoPhaseLLMPipeline(
+        provider=_CannedPhase1Provider(phenotypes),
+        tool_executor=_StubToolExecutor(),
+    )
+    parsed, _usage, _requests, _debug = pipeline._extract_phase1_phenotypes(
+        text="clinical note",
+        grounded_chunks=[],
+        extraction_prompt=get_prompt(AnnotationMode.TWO_PHASE, "en"),
+    )
+    return parsed
+
+
+def test_parse_threads_explicit_model_assertion():
+    """(a) The model EXPLICITLY emitted ``assertion="absent"`` -> it IS in
+    ``model_fields_set`` -> the parsed item threads the raw wire value so the
+    downstream model-wins resolution honors it."""
+    explicit = LLMExtractedPhenotype(
+        phrase="hearing loss", category="Abnormal", assertion="absent"
+    )
+    assert "assertion" in explicit.model_fields_set
+
+    parsed = _parse_phase1(explicit)
+
+    assert len(parsed) == 1
+    assert parsed[0]["assertion"] == "absent"
+
+
+def test_parse_treats_schema_default_assertion_as_unset():
+    """(b) B1 regression crux: the model OMITTED assertion (a category-only
+    ``Normal`` finding, as the extraction few-shots teach it to emit) -> the
+    schema default ``"present"`` is NOT in ``model_fields_set`` -> the parsed
+    item must thread ``None``, NOT the defaulted ``"present"``.
+
+    Threading the defaulted ``"present"`` is the bug: it makes the downstream
+    ``item.get("assertion") is not None`` model-wins guard flip a ruled-out
+    finding to present."""
+    silent = LLMExtractedPhenotype(phrase="normal vision", category="Normal")
+    # The default is materialised on the attribute, but the field was never
+    # explicitly set by the "model".
+    assert silent.assertion == "present"
+    assert "assertion" not in silent.model_fields_set
+
+    parsed = _parse_phase1(silent)
+
+    assert len(parsed) == 1
+    assert parsed[0]["assertion"] is None
+
+
+def test_model_silent_normal_finding_falls_back_to_negated_end_to_end():
+    """End-to-end: a category-``Normal`` model-silent finding, parsed and then
+    run through ``phenotype_from_candidate``, resolves to the pipeline polarity
+    ``negated`` via the category fallback -- NOT ``present``. This is the
+    behavior the B1 fix restores versus the silent present-flip regression."""
+    silent = LLMExtractedPhenotype(phrase="normal vision", category="Normal")
+
+    parsed = _parse_phase1(silent)
+    phenotype = phenotype_from_candidate(
+        item=parsed[0],
+        candidate={"hpo_id": "HP:0000001", "term_name": "All", "score": 0.9},
+    )
+
+    assert phenotype.assertion == "negated"
+    assert phenotype.category == "normal"

--- a/tests/unit/llm/test_axis_threading.py
+++ b/tests/unit/llm/test_axis_threading.py
@@ -95,9 +95,17 @@ def test_retrieve_candidates_preserves_experiencer_and_assertion():
     assert rebuilt["assertion"] == "absent"
 
 
-def test_compact_mapping_item_includes_experiencer_and_assertion():
-    """Mapping payload must carry the axes so the phase-2 LLM (and Task 5's
-    ``phenotype_from_candidate``) can read the model's assertion + experiencer."""
+def test_compact_mapping_item_omits_experiencer_and_assertion():
+    """The mapping payload must NOT carry the axes.
+
+    Regression guard: serializing ``experiencer``/``assertion`` into the mapping
+    LLM payload perturbed its near-deterministic candidate pick (flipping bare
+    fragments toward top-scored *modifier* nodes) and measurably dropped
+    precision, while the mapping templates never reference the keys. The axes are
+    orthogonal to phrase->HPO-id selection and reach the resolver via the
+    ORIGINAL item in ``phenotype_from_candidate`` (see the companion assert
+    below), so they must stay out of the payload.
+    """
     item = {
         "phrase": "seizures",
         "category": "abnormal",
@@ -109,8 +117,28 @@ def test_compact_mapping_item_includes_experiencer_and_assertion():
 
     compact = compact_mapping_item(item)
 
-    assert compact["experiencer"] == "family_history"
-    assert compact["assertion"] == "absent"
+    assert "experiencer" not in compact
+    assert "assertion" not in compact
+
+
+def test_axes_still_reach_resolver_via_original_item():
+    """Dropping the axes from the mapping payload must NOT weaken B1: the model's
+    raw assertion/experiencer still win at ``phenotype_from_candidate``, which
+    reads the ORIGINAL item, not the compacted mapping payload."""
+    item = {
+        "phrase": "seizures",
+        "category": "abnormal",
+        "chunk_ids": [1],
+        "evidence_text": "no seizures in the mother",
+        "experiencer": "family_history",
+        "assertion": "absent",
+    }
+    candidate = {"hpo_id": "HP:0001250", "term_name": "Seizure", "score": 0.9}
+
+    phenotype = phenotype_from_candidate(item=item, candidate=candidate)
+
+    assert phenotype.assertion == "negated"  # absent -> negated (model wins)
+    assert phenotype.experiencer == "family_history"
 
 
 def test_phase1_dedup_key_separates_experiencer():

--- a/tests/unit/llm/test_family_resolve.py
+++ b/tests/unit/llm/test_family_resolve.py
@@ -19,10 +19,13 @@ The retriever and the phase-2 LLM mapping provider are stubbed, so no model /
 Gemini / network is required (mirrors the existing tests/unit/llm pipeline
 stubs).
 
-``resolved_family`` is exposed for Task 6 via the pipeline test hook
-``TwoPhaseLLMPipeline._last_resolved_family`` (a list[LLMPhenotype] set at the
-end of ``run()``). Task 7 will attach the same local list to the result object;
-until then this hook keeps Task 6 independently testable.
+``resolved_family`` is exposed on the result object as
+``LLMExtractionResult.family_history_findings`` (a list[LLMPhenotype] attached
+at the end of ``run()``). Task 6 originally exposed it via a temporary
+instance attribute (``TwoPhaseLLMPipeline._last_resolved_family``); Task 7
+attached it to the result and removed that instance-attribute test seam (a
+reviewer flagged it as a concurrency race if the pipeline instance were
+reused across concurrent ``run()`` calls).
 """
 
 from __future__ import annotations
@@ -153,9 +156,9 @@ def test_family_experiencer_phrase_resolved_off_the_proband_set() -> None:
     """A phrase the model tags ``experiencer="family_history"`` (even with a
     legacy ``Abnormal`` category that WOULD otherwise pass the actionable
     filter) is partitioned to the family path: it resolves into
-    ``_last_resolved_family`` and is ABSENT from the proband ``result.terms``.
-    The proband phrase still resolves into ``result.terms``. The family mapping
-    LLM pass is counted in the meta accounting.
+    ``result.family_history_findings`` and is ABSENT from the proband
+    ``result.terms``. The proband phrase still resolves into ``result.terms``.
+    The family mapping LLM pass is counted in the meta accounting.
     """
     provider = FakeProvider(
         responses=[
@@ -226,8 +229,8 @@ def test_family_experiencer_phrase_resolved_off_the_proband_set() -> None:
     assert "HP:0001250" in proband_ids
 
     # Family phrase resolved via the SAME retrieval + mapping path, into the
-    # separate resolved_family list (exposed via the Task-6 test hook).
-    resolved_family = pipeline._last_resolved_family
+    # separate ``family_history_findings`` list on the result.
+    resolved_family = result.family_history_findings
     family_ids = {term.term_id for term in resolved_family}
     assert family_ids == {"HP:0001657"}
     family_term = next(term for term in resolved_family if term.term_id == "HP:0001657")
@@ -295,10 +298,10 @@ def test_category_only_family_finding_is_partitioned_and_resolved() -> None:
     assert proband_ids == {"HP:0001250"}
     assert "HP:0000365" not in proband_ids
 
-    family_ids = {term.term_id for term in pipeline._last_resolved_family}
+    family_ids = {term.term_id for term in result.family_history_findings}
     assert family_ids == {"HP:0000365"}
     family_term = next(
-        term for term in pipeline._last_resolved_family if term.term_id == "HP:0000365"
+        term for term in result.family_history_findings if term.term_id == "HP:0000365"
     )
     assert family_term.experiencer == "family_history"
     assert family_term.category == "family_history"
@@ -358,8 +361,9 @@ def test_resolve_items_helper_resolves_family_items_directly() -> None:
 
 
 def test_proband_only_run_leaves_family_hook_empty() -> None:
-    """No-regression guard: a proband-only run produces an EMPTY resolved_family
-    hook and adds no family_* meta keys, so proband meta stays byte-identical."""
+    """No-regression guard: a proband-only run produces an EMPTY
+    ``family_history_findings`` list and adds no family_* meta keys, so proband
+    meta stays byte-identical."""
     provider = FakeProvider(
         responses=[
             {
@@ -392,7 +396,7 @@ def test_proband_only_run_leaves_family_hook_empty() -> None:
     )
 
     assert {term.term_id for term in result.terms} == {"HP:0001250"}
-    assert pipeline._last_resolved_family == []
+    assert result.family_history_findings == []
     assert not any(
         key.startswith("family_") for key in result.meta.phase_request_counts
     )

--- a/tests/unit/llm/test_family_resolve.py
+++ b/tests/unit/llm/test_family_resolve.py
@@ -1,0 +1,400 @@
+"""Family-experiencer resolution tests (extraction contract v2, block B2).
+
+These tests pin the requirement that phrases the model attributes to a relative
+(``experiencer == "family_history"``) -- or that carry the legacy
+``Family_History`` category -- are PARTITIONED out of the proband set BEFORE the
+actionable filter and resolved through the SAME retrieval + mapping path as
+proband phrases, producing a SEPARATE ``resolved_family`` list.
+
+Two invariants matter:
+
+1. Family phenotypes must NOT leak into ``result.terms`` (the proband set). A
+   relative's mention mapped as a proband HPO term is the exact
+   assertion/experiencer-boundary bug this effort targets.
+2. The family LLM mapping pass must be COUNTED in the meta accounting
+   (``request_count`` and ``phase_request_counts``); a family pass that silently
+   escapes the accumulators underreports cost.
+
+The retriever and the phase-2 LLM mapping provider are stubbed, so no model /
+Gemini / network is required (mirrors the existing tests/unit/llm pipeline
+stubs).
+
+``resolved_family`` is exposed for Task 6 via the pipeline test hook
+``TwoPhaseLLMPipeline._last_resolved_family`` (a list[LLMPhenotype] set at the
+end of ``run()``). Task 7 will attach the same local list to the result object;
+until then this hook keeps Task 6 independently testable.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import phentrieve.llm.pipeline as pipeline_module
+from phentrieve.llm.provider import LLMProvider
+from phentrieve.llm.types import (
+    LLMExtractionResult,
+    LLMPipelineConfig,
+)
+
+TwoPhaseLLMPipeline = pipeline_module.TwoPhaseLLMPipeline
+
+
+class FakeProvider(LLMProvider):
+    """Structured-prompt provider stub (mirrors tests/unit/llm/test_pipeline)."""
+
+    def __init__(self, responses: list[dict[str, Any]]) -> None:
+        super().__init__()
+        self.responses = list(responses)
+        self.structured_calls: list[dict[str, Any]] = []
+        self.last_request_count = 0
+
+    def complete(self, messages):  # pragma: no cover - never invoked here
+        raise AssertionError("provider.complete must not be called")
+
+    def run_structured_prompt(
+        self,
+        *,
+        system_prompt,
+        user_prompt,
+        response_model,
+        max_output_tokens=None,
+    ):
+        self.structured_calls.append(
+            {
+                "system_prompt": system_prompt,
+                "user_prompt": user_prompt,
+                "response_model": response_model,
+                "max_output_tokens": max_output_tokens,
+            }
+        )
+        response = self.responses.pop(0)
+        self.last_usage = response.get(
+            "usage",
+            {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        )
+        self.last_request_count = int(response.get("request_count", 1))
+        if "exception" in response:
+            raise response["exception"]
+        parsed = response_model.model_validate(response["parsed"])
+        self.last_structured_payload = parsed.model_dump(mode="json")
+        return parsed
+
+    def count_tokens(self, *, system_prompt: str, user_prompt: str) -> dict[str, int]:
+        return {"prompt_tokens": 1, "completion_tokens": 0, "total_tokens": 1}
+
+
+class PhraseAwareToolExecutor:
+    """Retriever stub that returns candidates keyed by the queried phrase.
+
+    ``_retrieve_candidates`` aligns the returned batch results positionally to
+    the expanded query list, so returning ``{"phrase": phrase, "candidates":
+    ...}`` per input phrase lets a proband phrase and a family phrase retrieve
+    DIFFERENT candidate sets (unlike a single canned batch shared across every
+    call).
+    """
+
+    def __init__(self, candidates_by_phrase: dict[str, list[dict[str, Any]]]) -> None:
+        self.candidates_by_phrase = candidates_by_phrase
+        self.queries: list[dict[str, Any]] = []
+
+    def query_batch_hpo_terms(self, *, phrases, language, n_results):
+        self.queries.append(
+            {"phrases": list(phrases), "language": language, "n_results": n_results}
+        )
+        return [
+            {
+                "phrase": phrase,
+                "candidates": list(self.candidates_by_phrase.get(phrase, [])),
+            }
+            for phrase in phrases
+        ]
+
+
+def _grounded_phenotype(
+    phrase: str,
+    category: str,
+    *,
+    chunk_id: int,
+    experiencer: str | None = None,
+) -> dict[str, Any]:
+    phenotype: dict[str, Any] = {
+        "phrase": phrase,
+        "category": category,
+        "chunk_ids": [chunk_id],
+        "evidence_text": phrase,
+    }
+    if experiencer is not None:
+        phenotype["experiencer"] = experiencer
+    return phenotype
+
+
+def _config() -> LLMPipelineConfig:
+    return LLMPipelineConfig(
+        provider="fake",
+        model="fake",
+        mode="two_phase",
+        language="en",
+    )
+
+
+PROBAND_CANDIDATE = {
+    "hpo_id": "HP:0001250",
+    "term_name": "Seizure",
+    "score": 0.9,
+}
+FAMILY_CANDIDATE = {
+    "hpo_id": "HP:0001657",
+    "term_name": "Prolonged QT interval",
+    "score": 0.88,
+}
+
+
+def test_family_experiencer_phrase_resolved_off_the_proband_set() -> None:
+    """A phrase the model tags ``experiencer="family_history"`` (even with a
+    legacy ``Abnormal`` category that WOULD otherwise pass the actionable
+    filter) is partitioned to the family path: it resolves into
+    ``_last_resolved_family`` and is ABSENT from the proband ``result.terms``.
+    The proband phrase still resolves into ``result.terms``. The family mapping
+    LLM pass is counted in the meta accounting.
+    """
+    provider = FakeProvider(
+        responses=[
+            # Phase 1: one proband phrase + one family-history phrase. The
+            # family phrase carries category "Abnormal" on purpose -- absent a
+            # partition it would pass the actionable filter and leak into the
+            # proband set.
+            {
+                "parsed": {
+                    "phenotypes": [
+                        _grounded_phenotype(
+                            "recurrent seizures",
+                            "Abnormal",
+                            chunk_id=1,
+                            experiencer="proband",
+                        ),
+                        _grounded_phenotype(
+                            "long QT syndrome",
+                            "Abnormal",
+                            chunk_id=2,
+                            experiencer="family_history",
+                        ),
+                    ]
+                },
+                "request_count": 1,
+            },
+            # Proband mapping pass (batch size 1 -> single-item mapping).
+            {
+                "parsed": {"phrase": "recurrent seizures", "hpo_id": "HP:0001250"},
+                "request_count": 1,
+            },
+            # Family mapping pass -- MUST be counted in the accounting.
+            {
+                "parsed": {"phrase": "long qt syndrome", "hpo_id": "HP:0001657"},
+                "request_count": 1,
+            },
+        ]
+    )
+    tool_executor = PhraseAwareToolExecutor(
+        {
+            "recurrent seizures": [PROBAND_CANDIDATE],
+            "long QT syndrome": [FAMILY_CANDIDATE],
+        }
+    )
+    # mapping_batch_size=1 forces one single-item mapping prompt per unresolved
+    # phrase, so the proband and family passes are directly comparable.
+    pipeline = TwoPhaseLLMPipeline(
+        provider=provider,
+        tool_executor=tool_executor,
+        mapping_batch_size=1,
+    )
+
+    result = pipeline.run(
+        text="Patient had recurrent seizures. Mother has long QT syndrome.",
+        grounded_chunks=[
+            {"chunk_id": 1, "text": "Patient had recurrent seizures."},
+            {"chunk_id": 2, "text": "Mother has long QT syndrome."},
+        ],
+        config=_config(),
+    )
+
+    assert isinstance(result, LLMExtractionResult)
+
+    proband_ids = {term.term_id for term in result.terms}
+    # No proband leakage: the family HPO id must NOT be in the proband set.
+    assert "HP:0001657" not in proband_ids
+    # The proband phrase still resolves into result.terms.
+    assert "HP:0001250" in proband_ids
+
+    # Family phrase resolved via the SAME retrieval + mapping path, into the
+    # separate resolved_family list (exposed via the Task-6 test hook).
+    resolved_family = pipeline._last_resolved_family
+    family_ids = {term.term_id for term in resolved_family}
+    assert family_ids == {"HP:0001657"}
+    family_term = next(term for term in resolved_family if term.term_id == "HP:0001657")
+    assert family_term.experiencer == "family_history"
+
+    # ACCOUNTING: request_count covers phase 1 (1) + proband mapping (1) +
+    # family mapping (1); phase_request_counts records BOTH mapping passes.
+    assert result.meta.request_count == 3
+    assert result.meta.phase_request_counts["phase2b_llm_requests"] == 1
+    assert result.meta.phase_request_counts["family_phase2b_llm_requests"] == 1
+
+
+def test_category_only_family_finding_is_partitioned_and_resolved() -> None:
+    """A category-only ``Family_History`` finding (experiencer left at the schema
+    default "proband") is caught by the partition's CATEGORY clause. It was
+    previously DROPPED by the actionable filter (family_history is not
+    actionable); B2 now resolves it into ``resolved_family`` while keeping it out
+    of the proband ``result.terms``.
+    """
+    provider = FakeProvider(
+        responses=[
+            {
+                "parsed": {
+                    "phenotypes": [
+                        _grounded_phenotype(
+                            "recurrent seizures", "Abnormal", chunk_id=1
+                        ),
+                        # Category-only family finding; no experiencer set.
+                        _grounded_phenotype(
+                            "hearing loss", "Family_History", chunk_id=2
+                        ),
+                    ]
+                },
+                "request_count": 1,
+            },
+        ]
+    )
+    tool_executor = PhraseAwareToolExecutor(
+        {
+            # Exact term match -> both resolve LOCALLY (no mapping LLM call).
+            "recurrent seizures": [
+                {
+                    "hpo_id": "HP:0001250",
+                    "term_name": "recurrent seizures",
+                    "score": 0.95,
+                }
+            ],
+            "hearing loss": [
+                {"hpo_id": "HP:0000365", "term_name": "hearing loss", "score": 0.95}
+            ],
+        }
+    )
+    pipeline = TwoPhaseLLMPipeline(provider=provider, tool_executor=tool_executor)
+
+    result = pipeline.run(
+        text="Patient had recurrent seizures. The mother has hearing loss.",
+        grounded_chunks=[
+            {"chunk_id": 1, "text": "Patient had recurrent seizures."},
+            {"chunk_id": 2, "text": "The mother has hearing loss."},
+        ],
+        config=_config(),
+    )
+
+    proband_ids = {term.term_id for term in result.terms}
+    assert proband_ids == {"HP:0001250"}
+    assert "HP:0000365" not in proband_ids
+
+    family_ids = {term.term_id for term in pipeline._last_resolved_family}
+    assert family_ids == {"HP:0000365"}
+    family_term = next(
+        term for term in pipeline._last_resolved_family if term.term_id == "HP:0000365"
+    )
+    assert family_term.experiencer == "family_history"
+    assert family_term.category == "family_history"
+
+    # The family retrieval happened through the real retrieval path: a SECOND
+    # query batch scoped to the family phrase.
+    assert tool_executor.queries[0]["phrases"] == ["recurrent seizures"]
+    assert tool_executor.queries[1]["phrases"] == ["hearing loss"]
+
+
+def test_resolve_items_helper_resolves_family_items_directly() -> None:
+    """The shared resolver helper ``_resolve_items`` resolves family items the
+    same way it resolves proband items, so Task 6 can drive the family path
+    directly without the full run() wrapper."""
+    provider = FakeProvider(
+        responses=[
+            {
+                "parsed": {"phrase": "long qt syndrome", "hpo_id": "HP:0001657"},
+                "request_count": 1,
+            },
+        ]
+    )
+    tool_executor = PhraseAwareToolExecutor({"long QT syndrome": [FAMILY_CANDIDATE]})
+    pipeline = TwoPhaseLLMPipeline(
+        provider=provider,
+        tool_executor=tool_executor,
+        mapping_batch_size=1,
+    )
+
+    family_items = [
+        {
+            "phrase": "long QT syndrome",
+            "category": "abnormal",
+            "negated_qualifier": None,
+            "chunk_ids": [2],
+            "evidence_text": "long QT syndrome",
+            "start_char": None,
+            "end_char": None,
+            "experiencer": "family_history",
+            "assertion": None,
+        }
+    ]
+
+    outcome = pipeline._resolve_items(
+        family_items,
+        grounded_chunks=[{"chunk_id": 2, "text": "Mother has long QT syndrome."}],
+        language="en",
+    )
+
+    resolved_ids = {term.term_id for term in outcome.resolved}
+    assert resolved_ids == {"HP:0001657"}
+    assert outcome.resolved[0].experiencer == "family_history"
+    # The helper reports the mapping LLM request so run() can fold it into the
+    # shared accounting.
+    assert outcome.request_count == 1
+    assert outcome.phase2b_llm_requests == 1
+
+
+def test_proband_only_run_leaves_family_hook_empty() -> None:
+    """No-regression guard: a proband-only run produces an EMPTY resolved_family
+    hook and adds no family_* meta keys, so proband meta stays byte-identical."""
+    provider = FakeProvider(
+        responses=[
+            {
+                "parsed": {
+                    "phenotypes": [
+                        _grounded_phenotype(
+                            "recurrent seizures", "Abnormal", chunk_id=1
+                        )
+                    ]
+                },
+                "request_count": 1,
+            },
+            {
+                "parsed": {"phrase": "recurrent seizures", "hpo_id": "HP:0001250"},
+                "request_count": 1,
+            },
+        ]
+    )
+    tool_executor = PhraseAwareToolExecutor({"recurrent seizures": [PROBAND_CANDIDATE]})
+    pipeline = TwoPhaseLLMPipeline(
+        provider=provider,
+        tool_executor=tool_executor,
+        mapping_batch_size=1,
+    )
+
+    result = pipeline.run(
+        text="Patient had recurrent seizures.",
+        grounded_chunks=[{"chunk_id": 1, "text": "Patient had recurrent seizures."}],
+        config=_config(),
+    )
+
+    assert {term.term_id for term in result.terms} == {"HP:0001250"}
+    assert pipeline._last_resolved_family == []
+    assert not any(
+        key.startswith("family_") for key in result.meta.phase_request_counts
+    )
+    assert not any(key.startswith("family_") for key in result.meta.phase_counts)
+    assert "family" not in result.meta.trace

--- a/tests/unit/llm/test_llm_result_family_field.py
+++ b/tests/unit/llm/test_llm_result_family_field.py
@@ -1,0 +1,242 @@
+"""Tests for `LLMExtractionResult.family_history_findings` (extraction contract
+v2, block B2).
+
+Task 6 built a local ``resolved_family: list[LLMPhenotype]`` inside
+``TwoPhaseLLMPipeline.run()`` and exposed it ONLY via a temporary instance
+attribute (``pipeline._last_resolved_family``) as a test seam. Task 7 attaches
+that same list to the result object as ``family_history_findings`` and removes
+the instance-attribute seam (a reviewer flagged it as a concurrency race if the
+pipeline instance is reused across concurrent ``run()`` calls).
+
+These tests pin two things:
+
+1. ``LLMExtractionResult`` accepts and defaults ``family_history_findings`` to
+   an empty list when constructed with only ``terms`` + ``meta`` (schema-level
+   contract, independent of the pipeline).
+2. Using the same stubs as ``test_family_resolve.py``, a family-history phrase
+   lands in ``result.family_history_findings`` and NOT in ``result.terms``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import phentrieve.llm.pipeline as pipeline_module
+from phentrieve.llm.provider import LLMProvider
+from phentrieve.llm.types import (
+    LLMExtractionResult,
+    LLMMeta,
+    LLMPipelineConfig,
+)
+
+TwoPhaseLLMPipeline = pipeline_module.TwoPhaseLLMPipeline
+
+
+def test_llm_extraction_result_defaults_family_history_findings_to_empty_list() -> None:
+    """Constructing with only ``terms`` + ``meta`` defaults the new field to
+    an empty list, matching the existing ``default_factory=list`` style used
+    by ``terms``."""
+    result = LLMExtractionResult(
+        terms=[], meta=LLMMeta(llm_model="fake", llm_mode="two_phase")
+    )
+
+    assert result.family_history_findings == []
+
+
+class FakeProvider(LLMProvider):
+    """Structured-prompt provider stub (mirrors tests/unit/llm/test_pipeline)."""
+
+    def __init__(self, responses: list[dict[str, Any]]) -> None:
+        super().__init__()
+        self.responses = list(responses)
+
+    def complete(self, messages):  # pragma: no cover - never invoked here
+        raise AssertionError("provider.complete must not be called")
+
+    def run_structured_prompt(
+        self,
+        *,
+        system_prompt,
+        user_prompt,
+        response_model,
+        max_output_tokens=None,
+    ):
+        response = self.responses.pop(0)
+        self.last_usage = response.get(
+            "usage",
+            {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        )
+        self.last_request_count = int(response.get("request_count", 1))
+        if "exception" in response:
+            raise response["exception"]
+        parsed = response_model.model_validate(response["parsed"])
+        self.last_structured_payload = parsed.model_dump(mode="json")
+        return parsed
+
+    def count_tokens(self, *, system_prompt: str, user_prompt: str) -> dict[str, int]:
+        return {"prompt_tokens": 1, "completion_tokens": 0, "total_tokens": 1}
+
+
+class PhraseAwareToolExecutor:
+    """Retriever stub that returns candidates keyed by the queried phrase."""
+
+    def __init__(self, candidates_by_phrase: dict[str, list[dict[str, Any]]]) -> None:
+        self.candidates_by_phrase = candidates_by_phrase
+        self.queries: list[dict[str, Any]] = []
+
+    def query_batch_hpo_terms(self, *, phrases, language, n_results):
+        self.queries.append(
+            {"phrases": list(phrases), "language": language, "n_results": n_results}
+        )
+        return [
+            {
+                "phrase": phrase,
+                "candidates": list(self.candidates_by_phrase.get(phrase, [])),
+            }
+            for phrase in phrases
+        ]
+
+
+def _grounded_phenotype(
+    phrase: str,
+    category: str,
+    *,
+    chunk_id: int,
+    experiencer: str | None = None,
+) -> dict[str, Any]:
+    phenotype: dict[str, Any] = {
+        "phrase": phrase,
+        "category": category,
+        "chunk_ids": [chunk_id],
+        "evidence_text": phrase,
+    }
+    if experiencer is not None:
+        phenotype["experiencer"] = experiencer
+    return phenotype
+
+
+def _config() -> LLMPipelineConfig:
+    return LLMPipelineConfig(
+        provider="fake",
+        model="fake",
+        mode="two_phase",
+        language="en",
+    )
+
+
+PROBAND_CANDIDATE = {
+    "hpo_id": "HP:0001250",
+    "term_name": "Seizure",
+    "score": 0.9,
+}
+FAMILY_CANDIDATE = {
+    "hpo_id": "HP:0001657",
+    "term_name": "Prolonged QT interval",
+    "score": 0.88,
+}
+
+
+def test_family_phrase_lands_in_result_family_history_findings_not_terms() -> None:
+    """A phrase tagged ``experiencer="family_history"`` resolves into
+    ``result.family_history_findings`` and is ABSENT from ``result.terms``."""
+    provider = FakeProvider(
+        responses=[
+            {
+                "parsed": {
+                    "phenotypes": [
+                        _grounded_phenotype(
+                            "recurrent seizures",
+                            "Abnormal",
+                            chunk_id=1,
+                            experiencer="proband",
+                        ),
+                        _grounded_phenotype(
+                            "long QT syndrome",
+                            "Abnormal",
+                            chunk_id=2,
+                            experiencer="family_history",
+                        ),
+                    ]
+                },
+                "request_count": 1,
+            },
+            {
+                "parsed": {"phrase": "recurrent seizures", "hpo_id": "HP:0001250"},
+                "request_count": 1,
+            },
+            {
+                "parsed": {"phrase": "long qt syndrome", "hpo_id": "HP:0001657"},
+                "request_count": 1,
+            },
+        ]
+    )
+    tool_executor = PhraseAwareToolExecutor(
+        {
+            "recurrent seizures": [PROBAND_CANDIDATE],
+            "long QT syndrome": [FAMILY_CANDIDATE],
+        }
+    )
+    pipeline = TwoPhaseLLMPipeline(
+        provider=provider,
+        tool_executor=tool_executor,
+        mapping_batch_size=1,
+    )
+
+    result = pipeline.run(
+        text="Patient had recurrent seizures. Mother has long QT syndrome.",
+        grounded_chunks=[
+            {"chunk_id": 1, "text": "Patient had recurrent seizures."},
+            {"chunk_id": 2, "text": "Mother has long QT syndrome."},
+        ],
+        config=_config(),
+    )
+
+    proband_ids = {term.term_id for term in result.terms}
+    family_ids = {term.term_id for term in result.family_history_findings}
+
+    assert "HP:0001657" not in proband_ids
+    assert "HP:0001250" in proband_ids
+    assert family_ids == {"HP:0001657"}
+
+    family_term = next(
+        term for term in result.family_history_findings if term.term_id == "HP:0001657"
+    )
+    assert family_term.experiencer == "family_history"
+
+
+def test_proband_only_run_leaves_family_history_findings_empty() -> None:
+    """No-regression guard: a proband-only run produces an EMPTY
+    ``family_history_findings`` list on the result."""
+    provider = FakeProvider(
+        responses=[
+            {
+                "parsed": {
+                    "phenotypes": [
+                        _grounded_phenotype(
+                            "recurrent seizures", "Abnormal", chunk_id=1
+                        )
+                    ]
+                },
+                "request_count": 1,
+            },
+            {
+                "parsed": {"phrase": "recurrent seizures", "hpo_id": "HP:0001250"},
+                "request_count": 1,
+            },
+        ]
+    )
+    tool_executor = PhraseAwareToolExecutor({"recurrent seizures": [PROBAND_CANDIDATE]})
+    pipeline = TwoPhaseLLMPipeline(
+        provider=provider,
+        tool_executor=tool_executor,
+        mapping_batch_size=1,
+    )
+
+    result = pipeline.run(
+        text="Patient had recurrent seizures.",
+        grounded_chunks=[{"chunk_id": 1, "text": "Patient had recurrent seizures."}],
+        config=_config(),
+    )
+
+    assert {term.term_id for term in result.terms} == {"HP:0001250"}
+    assert result.family_history_findings == []

--- a/tests/unit/llm/test_ontology_guard.py
+++ b/tests/unit/llm/test_ontology_guard.py
@@ -42,6 +42,30 @@ def test_fails_open_on_unknown_or_root(monkeypatch):
     assert ontology_guard.is_non_phenotypic_abnormality("") is False
 
 
+def test_empty_load_is_not_cached_and_recovers(monkeypatch, tmp_path):
+    """Regression guard (Codex High): a fail-open empty/failed load must NOT be
+    memoized -- otherwise the first call before hpo_data.db is present latches the
+    guard OFF for the whole process. It must recover once the DB appears."""
+    og = ontology_guard
+    og._ANCESTORS_CACHE.clear()
+    monkeypatch.setattr(og, "resolve_data_path", lambda *a, **k: tmp_path)
+
+    db_file = tmp_path / "hpo_data.db"
+    # 1) DB absent -> fail open, and DO NOT cache.
+    assert og._ancestors_map() == {}
+    assert og._ANCESTORS_CACHE == {}
+
+    # 2) DB now present -> loads and caches by path.
+    db_file.write_text("")
+    monkeypatch.setattr(
+        og,
+        "_load_ancestors_map",
+        lambda path: {"HP:0012825": frozenset({"HP:0012823"})},
+    )
+    assert og._ancestors_map() == {"HP:0012825": frozenset({"HP:0012823"})}
+    assert str(db_file) in og._ANCESTORS_CACHE
+
+
 def test_pipeline_drops_non_phenotypic_terms(monkeypatch):
     _guard_with_map(
         monkeypatch,

--- a/tests/unit/llm/test_ontology_guard.py
+++ b/tests/unit/llm/test_ontology_guard.py
@@ -1,0 +1,59 @@
+"""Ontology guard tests (extraction contract v2 hardening).
+
+The guard drops resolved terms KNOWN to sit outside Phenotypic abnormality
+(HP:0000118) -- clinical modifiers / course / inheritance -- which are never
+valid standalone phenotype annotations, while failing open on unknown ancestry
+so a real finding is never dropped.
+"""
+
+from __future__ import annotations
+
+import phentrieve.llm.ontology_guard as ontology_guard
+from phentrieve.llm.pipeline import TwoPhaseLLMPipeline
+from phentrieve.llm.types import LLMPhenotype
+
+
+def _guard_with_map(monkeypatch, ancestors: dict[str, set[str]]) -> None:
+    monkeypatch.setattr(
+        ontology_guard,
+        "_ancestors_map",
+        lambda: {t: frozenset(a) for t, a in ancestors.items()},
+    )
+
+
+def test_flags_clinical_modifier_and_keeps_phenotype(monkeypatch):
+    _guard_with_map(
+        monkeypatch,
+        {
+            "HP:0012825": {"HP:0000001", "HP:0012823"},  # Mild -> Clinical modifier
+            "HP:0001250": {"HP:0000001", "HP:0000118"},  # Seizure -> phenotype
+        },
+    )
+    assert ontology_guard.is_non_phenotypic_abnormality("HP:0012825") is True
+    assert ontology_guard.is_non_phenotypic_abnormality("HP:0001250") is False
+
+
+def test_fails_open_on_unknown_or_root(monkeypatch):
+    _guard_with_map(monkeypatch, {})
+    # Unknown ancestry -> kept (never silently drop a real finding).
+    assert ontology_guard.is_non_phenotypic_abnormality("HP:9999999") is False
+    # The phenotype root itself is kept.
+    assert ontology_guard.is_non_phenotypic_abnormality("HP:0000118") is False
+    assert ontology_guard.is_non_phenotypic_abnormality("") is False
+
+
+def test_pipeline_drops_non_phenotypic_terms(monkeypatch):
+    _guard_with_map(
+        monkeypatch,
+        {
+            "HP:0012825": {"HP:0000001", "HP:0012823"},  # Mild (modifier) -> drop
+            "HP:0001250": {"HP:0000001", "HP:0000118"},  # Seizure -> keep
+        },
+    )
+    terms = [
+        LLMPhenotype(term_id="HP:0001250", label="Seizure", evidence="seizures"),
+        LLMPhenotype(term_id="HP:0012825", label="Mild", evidence="normal"),
+    ]
+    kept = TwoPhaseLLMPipeline._drop_non_phenotypic(terms)
+
+    assert [t.term_id for t in kept] == ["HP:0001250"]

--- a/tests/unit/llm/test_phase1_dedup_axes.py
+++ b/tests/unit/llm/test_phase1_dedup_axes.py
@@ -1,0 +1,246 @@
+"""Phase-1 dedup + fuzzy-merge must be experiencer/assertion-aware (B2).
+
+B1 made ``experiencer`` and ``assertion`` orthogonal axes (polarity and
+family-ness no longer live in ``category``). The Phase-1 dedup+merge runs
+BEFORE the B2 family partition, so if it is axis-blind it can silently
+collapse two genuinely DIFFERENT findings that share phrase/category/chunk/
+evidence but differ only in experiencer (proband vs family_history) or in
+assertion (present vs absent). These tests fence that behavior.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import phentrieve.llm.pipeline as pipeline_module
+from phentrieve.llm.pipeline_phase1 import phase1_extraction_dedup_key
+from phentrieve.llm.provider import LLMProvider, ToolExecutor
+from phentrieve.llm.types import LLMPipelineConfig
+
+TwoPhaseLLMPipeline = pipeline_module.TwoPhaseLLMPipeline
+
+
+class _StructuredProvider(LLMProvider):
+    """Minimal provider stub driving the ungrouped structured phase-1 path."""
+
+    provider_name = "gemini"
+
+    def __init__(self, responses: list[dict[str, Any]]) -> None:
+        super().__init__()
+        self.responses = list(responses)
+        self.last_usage: dict[str, int] = {}
+        self.last_request_count = 0
+
+    def complete(self, messages):  # pragma: no cover - not used on this path
+        raise RuntimeError("unused")
+
+    def run_structured_prompt(
+        self,
+        *,
+        system_prompt,
+        user_prompt,
+        response_model,
+        max_output_tokens=None,
+    ):
+        response = self.responses.pop(0)
+        self.last_usage = {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+        }
+        self.last_request_count = 1
+        parsed = response_model.model_validate(response["parsed"])
+        self.last_structured_payload = parsed.model_dump(mode="json")
+        return parsed
+
+    def count_tokens(self, *, system_prompt: str, user_prompt: str) -> dict[str, int]:
+        chunk_count = max(user_prompt.count("chunk_id="), 1)
+        return {
+            "prompt_tokens": chunk_count * 10,
+            "completion_tokens": 0,
+            "total_tokens": chunk_count * 10,
+        }
+
+
+class _PhraseKeyedToolExecutor(ToolExecutor):
+    """Retriever stub returning candidates keyed by the queried phrase."""
+
+    def __init__(self, candidates_by_phrase: dict[str, list[dict[str, Any]]]) -> None:
+        self.candidates_by_phrase = candidates_by_phrase
+        self.queries: list[dict[str, Any]] = []
+
+    def query_batch_hpo_terms(self, *, phrases, language, n_results):
+        self.queries.append(
+            {"phrases": list(phrases), "language": language, "n_results": n_results}
+        )
+        return [
+            {
+                "phrase": phrase,
+                "candidates": list(self.candidates_by_phrase.get(phrase, [])),
+            }
+            for phrase in phrases
+        ]
+
+
+def _phase1_item(
+    *,
+    phrase: str = "hearing loss",
+    category: str = "abnormal",
+    chunk_ids: list[int] | None = None,
+    evidence_text: str = "hearing loss",
+    start_char: int | None = None,
+    end_char: int | None = None,
+    experiencer: str | None = "proband",
+    assertion: str | None = None,
+) -> dict[str, Any]:
+    """Build a phase-1 extraction dict as produced after structured parsing."""
+    return {
+        "phrase": phrase,
+        "category": category,
+        "chunk_ids": list(chunk_ids or [1]),
+        "evidence_text": evidence_text,
+        "start_char": start_char,
+        "end_char": end_char,
+        "experiencer": experiencer,
+        "assertion": assertion,
+    }
+
+
+# ---------------------------------------------------------------------------
+# (a) EXACT-DUP KEY: the dedup key must separate the assertion + experiencer axes
+# ---------------------------------------------------------------------------
+
+
+def test_dedup_key_separates_differing_assertion() -> None:
+    present = _phase1_item(assertion="present")
+    absent = _phase1_item(assertion="absent")
+    assert phase1_extraction_dedup_key(present) != phase1_extraction_dedup_key(absent)
+
+
+def test_dedup_key_separates_differing_experiencer() -> None:
+    proband = _phase1_item(experiencer="proband")
+    family = _phase1_item(experiencer="family_history")
+    assert phase1_extraction_dedup_key(proband) != phase1_extraction_dedup_key(family)
+
+
+def test_dedup_key_is_stable_for_identical_axes() -> None:
+    first = _phase1_item(experiencer="proband", assertion="present")
+    second = _phase1_item(experiencer="proband", assertion="present")
+    assert phase1_extraction_dedup_key(first) == phase1_extraction_dedup_key(second)
+
+
+def test_dedup_key_silent_assertion_is_uniform() -> None:
+    # Backward-compat: two items with no explicit assertion contribute a uniform
+    # "" for the assertion slot, so their relative equality is unchanged.
+    first = _phase1_item(assertion=None)
+    second = _phase1_item(assertion=None)
+    assert phase1_extraction_dedup_key(first) == phase1_extraction_dedup_key(second)
+
+
+# ---------------------------------------------------------------------------
+# (b) FUZZY MERGE REFUSAL: _should_merge refuses when an axis differs
+# ---------------------------------------------------------------------------
+
+
+def test_should_merge_refuses_differing_experiencer() -> None:
+    proband = _phase1_item(experiencer="proband")
+    family = _phase1_item(experiencer="family_history")
+    assert not TwoPhaseLLMPipeline._should_merge_phase1_extractions(proband, family)
+
+
+def test_should_merge_refuses_differing_assertion() -> None:
+    present = _phase1_item(assertion="present")
+    absent = _phase1_item(assertion="absent")
+    assert not TwoPhaseLLMPipeline._should_merge_phase1_extractions(present, absent)
+
+
+def test_should_merge_allows_identical_axes() -> None:
+    # Genuine fragments of the SAME finding (same axes) must still merge so the
+    # common dedup/consolidation case is unchanged.
+    existing = _phase1_item(
+        evidence_text="hearing loss", experiencer="proband", assertion="present"
+    )
+    incoming = _phase1_item(
+        evidence_text="bilateral hearing loss",
+        experiencer="proband",
+        assertion="present",
+    )
+    assert TwoPhaseLLMPipeline._should_merge_phase1_extractions(existing, incoming)
+
+
+def test_should_merge_allows_silent_assertion_duplicates() -> None:
+    # A genuine silent (None) duplicate pair -- same phrase/experiencer, both
+    # model-silent on assertion -- still merges.
+    existing = _phase1_item(assertion=None)
+    incoming = _phase1_item(assertion=None)
+    assert TwoPhaseLLMPipeline._should_merge_phase1_extractions(existing, incoming)
+
+
+# ---------------------------------------------------------------------------
+# (c) END-TO-END: co-located proband + family "hearing loss" both survive
+# ---------------------------------------------------------------------------
+
+
+def test_colocated_proband_and_family_mentions_are_not_collapsed() -> None:
+    """A proband "hearing loss" and a family "hearing loss" co-located in ONE
+    chunk (no spans, equal evidence, same phrase/category) differ ONLY in
+    experiencer. The axis-blind fuzzy merge would drop one; the axis-aware
+    merge keeps both so the proband finding lands in ``result.terms`` and the
+    family finding in ``result.family_history_findings``.
+    """
+    provider = _StructuredProvider(
+        responses=[
+            {
+                "parsed": {
+                    "phenotypes": [
+                        {
+                            "phrase": "hearing loss",
+                            "category": "Abnormal",
+                            "chunk_ids": [1],
+                            "evidence_text": "hearing loss",
+                            "experiencer": "proband",
+                        },
+                        {
+                            "phrase": "hearing loss",
+                            "category": "Abnormal",
+                            "chunk_ids": [1],
+                            "evidence_text": "hearing loss",
+                            "experiencer": "family_history",
+                        },
+                    ]
+                }
+            }
+        ]
+    )
+    tool_executor = _PhraseKeyedToolExecutor(
+        {
+            "hearing loss": [
+                {"hpo_id": "HP:0000365", "term_name": "hearing loss", "score": 0.95}
+            ]
+        }
+    )
+    pipeline = TwoPhaseLLMPipeline(provider=provider, tool_executor=tool_executor)
+
+    result = pipeline.run(
+        text="the patient has hearing loss; his mother also has hearing loss",
+        grounded_chunks=[
+            {
+                "chunk_id": 1,
+                "text": "the patient has hearing loss; his mother also has hearing loss",
+            }
+        ],
+        config=LLMPipelineConfig(model="gemini-2.5-flash", mode="two_phase"),
+    )
+
+    proband_terms = {term.term_id: term for term in result.terms}
+    family_terms = {term.term_id: term for term in result.family_history_findings}
+
+    # The proband mention survives as a proband term.
+    assert "HP:0000365" in proband_terms
+    assert proband_terms["HP:0000365"].experiencer == "proband"
+
+    # The family mention survives as a family-history finding (NOT dropped, NOT
+    # re-tagged into result.terms).
+    assert "HP:0000365" in family_terms
+    assert family_terms["HP:0000365"].experiencer == "family_history"
+    assert family_terms["HP:0000365"].category == "family_history"

--- a/tests/unit/llm/test_phase2_assertion_source.py
+++ b/tests/unit/llm/test_phase2_assertion_source.py
@@ -81,6 +81,29 @@ def test_conflicting_axes_store_derived_compat_category() -> None:
     assert phenotype.category == "normal"
 
 
+def test_normal_category_blocks_contradictory_present_assertion() -> None:
+    """B1 hardening: a ``normal`` category is a normalcy verdict, so a
+    contradictory model ``assertion="present"`` must NOT promote the finding to
+    present (e.g. "normal intellectual abilities" is not Cognitive impairment).
+    The contradiction resolves to the normalcy category's ``negated``."""
+    item = _item(category="normal", assertion="present")
+
+    phenotype = phenotype_from_candidate(item=item, candidate=_candidate())
+
+    assert phenotype.assertion == "negated"
+    assert phenotype.category == "normal"
+
+
+def test_normal_category_still_honors_model_uncertain() -> None:
+    """The block is narrow: only present is refused on a normal category. A model
+    ``uncertain`` is consistent and still honored."""
+    item = _item(category="normal", assertion="uncertain")
+
+    phenotype = phenotype_from_candidate(item=item, candidate=_candidate())
+
+    assert phenotype.assertion == "uncertain"
+
+
 def test_uncertain_model_assertion_maps_to_suspected_category() -> None:
     """A model ``assertion="uncertain"`` for a proband phrase resolves to the
     pipeline ``uncertain`` and a stored compat category of ``"suspected"``."""

--- a/tests/unit/llm/test_phase2_assertion_source.py
+++ b/tests/unit/llm/test_phase2_assertion_source.py
@@ -1,0 +1,130 @@
+"""Phase-2 assertion source tests (extraction contract v2, block B1).
+
+These tests pin the requirement that ``phenotype_from_candidate`` treats the
+model's own RAW WIRE ``assertion`` (present | absent | uncertain) as the source
+of truth for the pipeline polarity, mapping it through ``parse_assertion`` to
+the pipeline vocabulary (present | negated | uncertain). The model WINS over the
+legacy category; the legacy ``category`` becomes a DERIVED-compat field
+projected back from the (experiencer, assertion) axes (D3).
+
+The retriever and the LLM provider are never invoked here: these are direct
+unit tests of ``phenotype_from_candidate`` / ``derive_category_from_axes``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from phentrieve.llm.pipeline_phase2 import (
+    derive_category_from_axes,
+    phenotype_from_candidate,
+)
+
+
+def _candidate(**overrides: Any) -> dict[str, Any]:
+    candidate = {
+        "hpo_id": "HP:0001250",
+        "term_name": "Seizure",
+        "score": 0.9,
+    }
+    candidate.update(overrides)
+    return candidate
+
+
+def _item(**overrides: Any) -> dict[str, Any]:
+    item = {
+        "phrase": "seizures",
+        "category": "abnormal",
+        "negated_qualifier": None,
+        "chunk_ids": [1],
+        "evidence_text": "recurrent seizures",
+        "start_char": 0,
+        "end_char": 10,
+    }
+    item.update(overrides)
+    return item
+
+
+def test_model_assertion_wins_over_category() -> None:
+    """(a) MODEL WINS: category "abnormal" would map to ``present`` via
+    ``CATEGORY_TO_ASSERTION``, but the model's ``assertion="absent"`` must win
+    and resolve to the pipeline vocabulary ``negated``."""
+    item = _item(category="abnormal", assertion="absent")
+
+    phenotype = phenotype_from_candidate(item=item, candidate=_candidate())
+
+    assert phenotype.assertion == "negated"
+
+
+def test_missing_assertion_falls_back_to_category() -> None:
+    """(b) FALLBACK: with no ``assertion`` key the resolved assertion is derived
+    from the legacy category (backward compatible). "normal" -> ``negated``."""
+    item = _item(category="normal")
+    item.pop("assertion", None)
+    assert "assertion" not in item
+
+    phenotype = phenotype_from_candidate(item=item, candidate=_candidate())
+
+    assert phenotype.assertion == "negated"
+
+
+def test_conflicting_axes_store_derived_compat_category() -> None:
+    """(c) CONFLICT/COMPAT-CATEGORY: ``assertion="absent"`` with the raw legacy
+    ``category="Abnormal"`` -> pipeline ``assertion == "negated"`` AND the STORED
+    category is the axis-derived compat value ``"normal"`` (NOT the raw
+    "Abnormal"), proving ``derive_category_from_axes`` result is stored."""
+    item = _item(category="Abnormal", assertion="absent")
+
+    phenotype = phenotype_from_candidate(item=item, candidate=_candidate())
+
+    assert phenotype.assertion == "negated"
+    assert phenotype.category == "normal"
+
+
+def test_uncertain_model_assertion_maps_to_suspected_category() -> None:
+    """A model ``assertion="uncertain"`` for a proband phrase resolves to the
+    pipeline ``uncertain`` and a stored compat category of ``"suspected"``."""
+    item = _item(category="abnormal", assertion="uncertain")
+
+    phenotype = phenotype_from_candidate(item=item, candidate=_candidate())
+
+    assert phenotype.assertion == "uncertain"
+    assert phenotype.category == "suspected"
+
+
+def test_model_experiencer_wins_over_category() -> None:
+    """The model's own ``experiencer`` is preserved and, being family_history,
+    the stored compat category collapses to ``"family_history"``."""
+    item = _item(
+        category="abnormal",
+        assertion="present",
+        experiencer="family_history",
+    )
+
+    phenotype = phenotype_from_candidate(item=item, candidate=_candidate())
+
+    assert phenotype.experiencer == "family_history"
+    assert phenotype.category == "family_history"
+
+
+def test_derive_category_from_axes_projection() -> None:
+    """Direct unit coverage of ``derive_category_from_axes`` across all axes."""
+    # Experiencer wins for the two non-proband axes.
+    assert (
+        derive_category_from_axes("family_history", "present", "abnormal")
+        == "family_history"
+    )
+    assert derive_category_from_axes("other", "present", "abnormal") == "other"
+
+    # Proband: pipeline assertion projects back onto the category enum.
+    assert derive_category_from_axes("proband", "present", "abnormal") == "abnormal"
+    assert derive_category_from_axes("proband", "negated", "abnormal") == "normal"
+    assert derive_category_from_axes("proband", "uncertain", "abnormal") == "suspected"
+
+    # Axes absent / unmappable assertion -> fallback category is preserved.
+    assert derive_category_from_axes(None, None, "other") == "other"
+    assert derive_category_from_axes("proband", None, "abnormal") == "abnormal"
+    assert (
+        derive_category_from_axes("proband", "family_history", "family_history")
+        == "family_history"
+    )

--- a/tests/unit/llm/test_pipeline.py
+++ b/tests/unit/llm/test_pipeline.py
@@ -751,7 +751,12 @@ def test_grouped_phase1_debug_capture_is_additive_and_opt_in() -> None:
             "start_char": None,
             "end_char": None,
             "experiencer": "proband",
-            "assertion": "present",
+            # The model omitted assertion, so the parsed shape threads None
+            # (unset) not the schema default "present". Note the raw
+            # structured_response above still dumps the defaulted "present"
+            # because it is the full model dump; only the parsed item keys on
+            # model_fields_set (B1).
+            "assertion": None,
         }
     ]
 
@@ -3130,7 +3135,9 @@ def test_two_phase_pipeline_batch_mapping_disambiguates_duplicate_phrase_text() 
             "phrase": "motor issues",
             "category": "abnormal",
             "experiencer": "proband",
-            "assertion": "present",
+            # Model omitted assertion for this item -> unset (None); category
+            # fallback still resolves the final term to present (B1).
+            "assertion": None,
             "candidates": [
                 {
                     "id": "HP:0001251",
@@ -3786,7 +3793,9 @@ def test_two_phase_pipeline_uses_single_mapping_prompt_for_final_one_item_slice(
                 "phrase": "frequent falls",
                 "category": "abnormal",
                 "experiencer": "proband",
-                "assertion": "present",
+                # Model omitted assertion -> unset (None); category fallback
+                # resolves the final term to present downstream (B1).
+                "assertion": None,
                 "candidates": [
                     {
                         "id": "HP:0002355",
@@ -3806,7 +3815,8 @@ def test_two_phase_pipeline_uses_single_mapping_prompt_for_final_one_item_slice(
                 "phrase": "sleep disturbances",
                 "category": "abnormal",
                 "experiencer": "proband",
-                "assertion": "present",
+                # Model omitted assertion -> unset (None) (B1).
+                "assertion": None,
                 "candidates": [
                     {
                         "id": "HP:0002360",
@@ -3829,7 +3839,8 @@ def test_two_phase_pipeline_uses_single_mapping_prompt_for_final_one_item_slice(
         "phrase": "balance issues",
         "category": "abnormal",
         "experiencer": "proband",
-        "assertion": "present",
+        # Model omitted assertion -> unset (None) (B1).
+        "assertion": None,
         "candidates": [
             {
                 "id": "HP:0001251",

--- a/tests/unit/llm/test_pipeline.py
+++ b/tests/unit/llm/test_pipeline.py
@@ -2128,8 +2128,6 @@ def test_mapping_prompt_uses_compact_grounded_context() -> None:
         ],
         "phrase": "frequent falls",
         "category": "abnormal",
-        "experiencer": None,
-        "assertion": None,
         "candidates": [
             {
                 "id": "HP:0002355",
@@ -2211,8 +2209,6 @@ def test_batch_mapping_prompt_compacts_items_into_payload_list() -> None:
                 "neighbor_chunk_texts": ["The child walks independently."],
                 "phrase": "frequent falls",
                 "category": "abnormal",
-                "experiencer": None,
-                "assertion": None,
                 "candidates": [
                     {
                         "id": "HP:0002355",
@@ -2227,8 +2223,6 @@ def test_batch_mapping_prompt_compacts_items_into_payload_list() -> None:
                 "neighbor_chunk_texts": [],
                 "phrase": "sleep disturbances",
                 "category": "abnormal",
-                "experiencer": None,
-                "assertion": None,
                 "candidates": [
                     {
                         "id": "HP:0002360",
@@ -2295,8 +2289,6 @@ def test_mapping_prompt_keeps_shared_english_template_for_german_language() -> N
         "neighbor_chunk_texts": [],
         "phrase": "deutliche skoliose",
         "category": "abnormal",
-        "experiencer": None,
-        "assertion": None,
         "candidates": [
             {"id": "HP:0002650", "term": "Skoliose", "retrieval_score": 0.89},
         ],
@@ -3164,10 +3156,6 @@ def test_two_phase_pipeline_batch_mapping_disambiguates_duplicate_phrase_text() 
             "neighbor_chunk_texts": ["Intermittent motor issues are also suspected."],
             "phrase": "motor issues",
             "category": "abnormal",
-            "experiencer": "proband",
-            # Model omitted assertion for this item -> unset (None); category
-            # fallback still resolves the final term to present (B1).
-            "assertion": None,
             "candidates": [
                 {
                     "id": "HP:0001251",
@@ -3189,8 +3177,6 @@ def test_two_phase_pipeline_batch_mapping_disambiguates_duplicate_phrase_text() 
             "neighbor_chunk_texts": ["The patient has motor issues."],
             "phrase": "motor issues",
             "category": "suspected",
-            "experiencer": "proband",
-            "assertion": "uncertain",
             "candidates": [
                 {
                     "id": "HP:0033894",
@@ -3815,10 +3801,6 @@ def test_two_phase_pipeline_uses_single_mapping_prompt_for_final_one_item_slice(
                 "neighbor_chunk_texts": ["Sleep disturbances were reported."],
                 "phrase": "frequent falls",
                 "category": "abnormal",
-                "experiencer": "proband",
-                # Model omitted assertion -> unset (None); category fallback
-                # resolves the final term to present downstream (B1).
-                "assertion": None,
                 "candidates": [
                     {
                         "id": "HP:0002355",
@@ -3837,9 +3819,6 @@ def test_two_phase_pipeline_uses_single_mapping_prompt_for_final_one_item_slice(
                 ],
                 "phrase": "sleep disturbances",
                 "category": "abnormal",
-                "experiencer": "proband",
-                # Model omitted assertion -> unset (None) (B1).
-                "assertion": None,
                 "candidates": [
                     {
                         "id": "HP:0002360",
@@ -3861,9 +3840,6 @@ def test_two_phase_pipeline_uses_single_mapping_prompt_for_final_one_item_slice(
         "neighbor_chunk_texts": ["Sleep disturbances were reported."],
         "phrase": "balance issues",
         "category": "abnormal",
-        "experiencer": "proband",
-        # Model omitted assertion -> unset (None) (B1).
-        "assertion": None,
         "candidates": [
             {
                 "id": "HP:0001251",

--- a/tests/unit/llm/test_pipeline.py
+++ b/tests/unit/llm/test_pipeline.py
@@ -124,6 +124,36 @@ class FakeToolExecutor:
         return list(self.batch_results)
 
 
+class PhraseKeyedToolExecutor:
+    """Retriever stub that returns candidates keyed by the queried phrase.
+
+    Unlike ``FakeToolExecutor`` (which returns the same positional batch for
+    every call), this aligns candidates to the phrase, so a proband retrieval
+    batch and a separate B2 family retrieval batch each receive their OWN
+    candidate sets instead of a mis-aligned shared list.
+    """
+
+    def __init__(self, candidates_by_phrase):
+        self.candidates_by_phrase = candidates_by_phrase
+        self.queries = []
+
+    def query_batch_hpo_terms(self, *, phrases, language, n_results):
+        self.queries.append(
+            {
+                "phrases": list(phrases),
+                "language": language,
+                "n_results": n_results,
+            }
+        )
+        return [
+            {
+                "phrase": phrase,
+                "candidates": list(self.candidates_by_phrase.get(phrase, [])),
+            }
+            for phrase in phrases
+        ]
+
+
 class FailingStructuredProvider(LLMProvider):
     def complete(self, messages):
         raise RuntimeError("unused")
@@ -3235,64 +3265,39 @@ def test_two_phase_pipeline_excludes_family_history_and_preserves_assertions():
             }
         ]
     )
-    tool_executor = FakeToolExecutor(
-        batch_results=[
-            {
-                "phrase": "recurrent seizures",
-                "original_sentence": "Patient had recurrent seizures since infancy.",
-                "candidates": [
-                    {
-                        "hpo_id": "HP:0001250",
-                        "term_name": "Recurrent seizures",
-                        "score": 0.95,
-                    }
-                ],
-            },
-            {
-                "phrase": "nystagmus",
-                "original_sentence": "Nystagmus was suspected clinically.",
-                "candidates": [
-                    {
-                        "hpo_id": "HP:0000639",
-                        "term_name": "Nystagmus",
-                        "score": 0.95,
-                    }
-                ],
-            },
-            {
-                "phrase": "skeletal anomalies",
-                "original_sentence": "No skeletal anomalies were noted.",
-                "candidates": [
-                    {
-                        "hpo_id": "HP:0000924",
-                        "term_name": "skeletal anomalies",
-                        "score": 0.95,
-                    }
-                ],
-            },
-            {
-                "phrase": "hearing loss",
-                "original_sentence": "The mother has hearing loss.",
-                "candidates": [
-                    {
-                        "hpo_id": "HP:0000365",
-                        "term_name": "hearing loss",
-                        "score": 0.95,
-                    }
-                ],
-            },
-            {
-                "phrase": "onset in infancy",
-                "original_sentence": "Symptoms began in infancy.",
-                "candidates": [
-                    {
-                        "hpo_id": "HP:0003593",
-                        "term_name": "onset in infancy",
-                        "score": 0.95,
-                    }
-                ],
-            },
-        ]
+    # Phrase-keyed retrieval so the proband batch and the separate B2 family
+    # batch ("hearing loss") each receive their OWN candidates. Every candidate
+    # is an exact term match so all phrases resolve locally (no mapping call).
+    tool_executor = PhraseKeyedToolExecutor(
+        {
+            "recurrent seizures": [
+                {
+                    "hpo_id": "HP:0001250",
+                    "term_name": "Recurrent seizures",
+                    "score": 0.95,
+                }
+            ],
+            "nystagmus": [
+                {"hpo_id": "HP:0000639", "term_name": "Nystagmus", "score": 0.95}
+            ],
+            "skeletal anomalies": [
+                {
+                    "hpo_id": "HP:0000924",
+                    "term_name": "skeletal anomalies",
+                    "score": 0.95,
+                }
+            ],
+            "hearing loss": [
+                {"hpo_id": "HP:0000365", "term_name": "hearing loss", "score": 0.95}
+            ],
+            "onset in infancy": [
+                {
+                    "hpo_id": "HP:0003593",
+                    "term_name": "onset in infancy",
+                    "score": 0.95,
+                }
+            ],
+        }
     )
     pipeline = TwoPhaseLLMPipeline(provider=provider, tool_executor=tool_executor)
 
@@ -3319,8 +3324,11 @@ def test_two_phase_pipeline_excludes_family_history_and_preserves_assertions():
         config=LLMPipelineConfig(model="gemini-2.5-flash", mode="two_phase"),
     )
 
-    # LLM-1: family-history mentions ("hearing loss" belongs to the mother) are
-    # no longer actionable, so they are never retrieved as proband candidates.
+    # LLM-1 + B2: family-history mentions ("hearing loss" belongs to the mother)
+    # are partitioned off the proband set, so they are NEVER retrieved as proband
+    # candidates -- the first (proband) retrieval batch excludes them. Under B2
+    # they ARE resolved, through a SEPARATE family retrieval batch, into the
+    # ``resolved_family`` set (never ``result.terms``).
     assert tool_executor.queries == [
         {
             "phrases": [
@@ -3330,7 +3338,12 @@ def test_two_phase_pipeline_excludes_family_history_and_preserves_assertions():
             ],
             "language": "en",
             "n_results": 50,
-        }
+        },
+        {
+            "phrases": ["hearing loss"],
+            "language": "en",
+            "n_results": 50,
+        },
     ]
     assert result.terms == [
         LLMPhenotype(
@@ -3387,6 +3400,15 @@ def test_two_phase_pipeline_excludes_family_history_and_preserves_assertions():
     ]
     assert result.meta.phase_counts["extracted_phrases"] == 5
     assert result.meta.phase_counts["actionable_phrases"] == 3
+    # B2: the family finding is resolved into resolved_family (NOT result.terms)
+    # with a family_history experiencer, and never leaks into the proband set.
+    assert "HP:0000365" not in {term.term_id for term in result.terms}
+    resolved_family = pipeline._last_resolved_family
+    assert {term.term_id for term in resolved_family} == {"HP:0000365"}
+    assert resolved_family[0].experiencer == "family_history"
+    assert resolved_family[0].category == "family_history"
+    assert result.meta.phase_counts["family_phrases"] == 1
+    assert result.meta.phase_counts["family_local_matches"] == 1
 
 
 def test_two_phase_pipeline_accumulates_usage_and_logs_phases(caplog):

--- a/tests/unit/llm/test_pipeline.py
+++ b/tests/unit/llm/test_pipeline.py
@@ -3400,10 +3400,11 @@ def test_two_phase_pipeline_excludes_family_history_and_preserves_assertions():
     ]
     assert result.meta.phase_counts["extracted_phrases"] == 5
     assert result.meta.phase_counts["actionable_phrases"] == 3
-    # B2: the family finding is resolved into resolved_family (NOT result.terms)
-    # with a family_history experiencer, and never leaks into the proband set.
+    # B2: the family finding is resolved into result.family_history_findings
+    # (NOT result.terms) with a family_history experiencer, and never leaks
+    # into the proband set.
     assert "HP:0000365" not in {term.term_id for term in result.terms}
-    resolved_family = pipeline._last_resolved_family
+    resolved_family = result.family_history_findings
     assert {term.term_id for term in resolved_family} == {"HP:0000365"}
     assert resolved_family[0].experiencer == "family_history"
     assert resolved_family[0].category == "family_history"

--- a/tests/unit/llm/test_pipeline.py
+++ b/tests/unit/llm/test_pipeline.py
@@ -743,6 +743,8 @@ def test_grouped_phase1_debug_capture_is_additive_and_opt_in() -> None:
             "evidence_text": "recurrent seizures",
             "start_char": None,
             "end_char": None,
+            "experiencer": "proband",
+            "assertion": "present",
         }
     ]
 
@@ -2084,6 +2086,8 @@ def test_mapping_prompt_uses_compact_grounded_context() -> None:
         ],
         "phrase": "frequent falls",
         "category": "abnormal",
+        "experiencer": None,
+        "assertion": None,
         "candidates": [
             {
                 "id": "HP:0002355",
@@ -2165,6 +2169,8 @@ def test_batch_mapping_prompt_compacts_items_into_payload_list() -> None:
                 "neighbor_chunk_texts": ["The child walks independently."],
                 "phrase": "frequent falls",
                 "category": "abnormal",
+                "experiencer": None,
+                "assertion": None,
                 "candidates": [
                     {
                         "id": "HP:0002355",
@@ -2179,6 +2185,8 @@ def test_batch_mapping_prompt_compacts_items_into_payload_list() -> None:
                 "neighbor_chunk_texts": [],
                 "phrase": "sleep disturbances",
                 "category": "abnormal",
+                "experiencer": None,
+                "assertion": None,
                 "candidates": [
                     {
                         "id": "HP:0002360",
@@ -2245,6 +2253,8 @@ def test_mapping_prompt_keeps_shared_english_template_for_german_language() -> N
         "neighbor_chunk_texts": [],
         "phrase": "deutliche skoliose",
         "category": "abnormal",
+        "experiencer": None,
+        "assertion": None,
         "candidates": [
             {"id": "HP:0002650", "term": "Skoliose", "retrieval_score": 0.89},
         ],
@@ -3107,6 +3117,8 @@ def test_two_phase_pipeline_batch_mapping_disambiguates_duplicate_phrase_text() 
             "neighbor_chunk_texts": ["Intermittent motor issues are also suspected."],
             "phrase": "motor issues",
             "category": "abnormal",
+            "experiencer": "proband",
+            "assertion": "present",
             "candidates": [
                 {
                     "id": "HP:0001251",
@@ -3128,6 +3140,8 @@ def test_two_phase_pipeline_batch_mapping_disambiguates_duplicate_phrase_text() 
             "neighbor_chunk_texts": ["The patient has motor issues."],
             "phrase": "motor issues",
             "category": "suspected",
+            "experiencer": "proband",
+            "assertion": "present",
             "candidates": [
                 {
                     "id": "HP:0033894",
@@ -3755,6 +3769,8 @@ def test_two_phase_pipeline_uses_single_mapping_prompt_for_final_one_item_slice(
                 "neighbor_chunk_texts": ["Sleep disturbances were reported."],
                 "phrase": "frequent falls",
                 "category": "abnormal",
+                "experiencer": "proband",
+                "assertion": "present",
                 "candidates": [
                     {
                         "id": "HP:0002355",
@@ -3773,6 +3789,8 @@ def test_two_phase_pipeline_uses_single_mapping_prompt_for_final_one_item_slice(
                 ],
                 "phrase": "sleep disturbances",
                 "category": "abnormal",
+                "experiencer": "proband",
+                "assertion": "present",
                 "candidates": [
                     {
                         "id": "HP:0002360",
@@ -3794,6 +3812,8 @@ def test_two_phase_pipeline_uses_single_mapping_prompt_for_final_one_item_slice(
         "neighbor_chunk_texts": ["Sleep disturbances were reported."],
         "phrase": "balance issues",
         "category": "abnormal",
+        "experiencer": "proband",
+        "assertion": "present",
         "candidates": [
             {
                 "id": "HP:0001251",

--- a/tests/unit/llm/test_pipeline.py
+++ b/tests/unit/llm/test_pipeline.py
@@ -165,13 +165,20 @@ def grounded_phenotype(
     *,
     chunk_ids: list[int] | None = None,
     evidence_text: str | None = None,
+    assertion: str | None = None,
 ) -> dict[str, object]:
-    return {
+    phenotype: dict[str, object] = {
         "phrase": phrase,
         "category": category,
         "chunk_ids": list(chunk_ids or [1]),
         "evidence_text": evidence_text or phrase,
     }
+    # Under the v2 extraction contract the model emits the assertion axis
+    # explicitly (present | absent | uncertain); when supplied it is the source
+    # of truth for polarity. Omitting it lets the schema default to "present".
+    if assertion is not None:
+        phenotype["assertion"] = assertion
+    return phenotype
 
 
 def test_grounded_extracted_phenotype_requires_chunk_ids() -> None:
@@ -3043,7 +3050,12 @@ def test_two_phase_pipeline_batch_mapping_disambiguates_duplicate_phrase_text() 
                 "parsed": {
                     "phenotypes": [
                         grounded_phenotype("motor issues", "Abnormal", chunk_ids=[1]),
-                        grounded_phenotype("motor issues", "Suspected", chunk_ids=[2]),
+                        grounded_phenotype(
+                            "motor issues",
+                            "Suspected",
+                            chunk_ids=[2],
+                            assertion="uncertain",
+                        ),
                     ]
                 },
             },
@@ -3141,7 +3153,7 @@ def test_two_phase_pipeline_batch_mapping_disambiguates_duplicate_phrase_text() 
             "phrase": "motor issues",
             "category": "suspected",
             "experiencer": "proband",
-            "assertion": "present",
+            "assertion": "uncertain",
             "candidates": [
                 {
                     "id": "HP:0033894",
@@ -3203,8 +3215,12 @@ def test_two_phase_pipeline_excludes_family_history_and_preserves_assertions():
                 "parsed": {
                     "phenotypes": [
                         grounded_phenotype("recurrent seizures", "Abnormal"),
-                        grounded_phenotype("nystagmus", "Suspected"),
-                        grounded_phenotype("skeletal anomalies", "Normal"),
+                        grounded_phenotype(
+                            "nystagmus", "Suspected", assertion="uncertain"
+                        ),
+                        grounded_phenotype(
+                            "skeletal anomalies", "Normal", assertion="absent"
+                        ),
                         grounded_phenotype("hearing loss", "Family_History"),
                         grounded_phenotype("onset in infancy", "Other"),
                     ]

--- a/tests/unit/llm/test_pipeline.py
+++ b/tests/unit/llm/test_pipeline.py
@@ -4049,11 +4049,27 @@ def test_two_phase_pipeline_carries_negated_qualifier_through_to_term():
         config=LLMPipelineConfig(model="gemini-2.5-flash", mode="two_phase"),
     )
 
-    assert len(result.terms) == 1
-    term = result.terms[0]
+    # The source finding stays present and still carries the negated qualifier
+    # metadata string threaded from the grounded extraction.
+    present_terms = [t for t in result.terms if t.assertion == "present"]
+    assert len(present_terms) == 1
+    term = present_terms[0]
     assert term.term_id == "HP:0010864"
     assert term.assertion == "present"
     assert term.negated_qualifier == "regression"
+
+    # B3 (Task 10): the qualifier Y ("regression") is now retrieved and, when it
+    # maps at or above the similarity floor, a GENERATED excluded finding is
+    # emitted. This stub's retriever returns the same fixed candidate for every
+    # query, so the generated term resolves to the same HPO id under the negated
+    # assertion (a distinct dedup key from the present source term).
+    generated = [
+        t for t in result.terms if t.match_method == "negated_qualifier_derived"
+    ]
+    assert len(generated) == 1
+    assert generated[0].assertion == "negated"
+    assert generated[0].experiencer == "proband"
+    assert generated[0].qualifier_surface_text == "regression"
 
 
 def test_phase1_failure_is_recorded_in_trace_not_silenced(caplog):

--- a/tests/unit/llm/test_pipeline_characterization.py
+++ b/tests/unit/llm/test_pipeline_characterization.py
@@ -119,7 +119,10 @@ def test_phase1_extraction_shape_preserves_grounding_fields() -> None:
             "start_char": 8,
             "end_char": 26,
             "experiencer": "proband",
-            "assertion": "present",
+            # The wire payload omitted assertion, so the parsed shape threads
+            # None (unset) rather than the schema default "present"; the category
+            # fallback re-engages downstream (B1).
+            "assertion": None,
         }
     ]
     assert usage == {"prompt_tokens": 20, "completion_tokens": 7, "total_tokens": 27}

--- a/tests/unit/llm/test_pipeline_characterization.py
+++ b/tests/unit/llm/test_pipeline_characterization.py
@@ -118,6 +118,8 @@ def test_phase1_extraction_shape_preserves_grounding_fields() -> None:
             "evidence_text": "recurrent seizures since infancy",
             "start_char": 8,
             "end_char": 26,
+            "experiencer": "proband",
+            "assertion": "present",
         }
     ]
     assert usage == {"prompt_tokens": 20, "completion_tokens": 7, "total_tokens": 27}

--- a/tests/unit/llm/test_qualifier_excluded_term.py
+++ b/tests/unit/llm/test_qualifier_excluded_term.py
@@ -1,0 +1,283 @@
+"""Qualifier-derived excluded finding tests (extraction contract v2, block B3).
+
+These tests pin Task 10's requirement: after proband resolution, a resolved
+proband finding that carries a truthy ``negated_qualifier`` (the ``Y`` of an
+"X without Y" phrase) triggers a SECOND retrieval on ``Y``. When ``Y`` maps
+above ``self.similarity_threshold`` the pipeline emits a GENERATED excluded
+``LLMPhenotype`` for ``Y`` (``assertion == "negated"``,
+``match_method == "negated_qualifier_derived"``,
+``qualifier_surface_text == Y``, ``experiencer == "proband"``). Below the floor
+(or when nothing is retrieved) NO term is generated and the source finding's
+``negated_qualifier`` metadata string is retained unchanged.
+
+Critical (F5): the generated term MUST inherit the SOURCE proband finding's
+evidence records so it carries valid ``chunk_ids``. A generated excluded term
+whose evidence references no valid chunk is silently dropped at the aggregation
+service boundary (``full_text_service.py``); the "X without Y" span lives in the
+same chunk as X, so inheriting X's evidence records is correct.
+
+The retriever and the phase-2 LLM mapping provider are stubbed, so no model /
+Gemini / network is required (mirrors the existing tests/unit/llm pipeline
+stubs).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import phentrieve.llm.pipeline as pipeline_module
+from phentrieve.llm.provider import LLMProvider
+from phentrieve.llm.types import (
+    LLMExtractionResult,
+    LLMPipelineConfig,
+)
+
+TwoPhaseLLMPipeline = pipeline_module.TwoPhaseLLMPipeline
+
+
+class FakeProvider(LLMProvider):
+    """Structured-prompt provider stub (mirrors tests/unit/llm/test_pipeline)."""
+
+    def __init__(self, responses: list[dict[str, Any]]) -> None:
+        super().__init__()
+        self.responses = list(responses)
+        self.structured_calls: list[dict[str, Any]] = []
+        self.last_request_count = 0
+
+    def complete(self, messages):  # pragma: no cover - never invoked here
+        raise AssertionError("provider.complete must not be called")
+
+    def run_structured_prompt(
+        self,
+        *,
+        system_prompt,
+        user_prompt,
+        response_model,
+        max_output_tokens=None,
+    ):
+        self.structured_calls.append(
+            {
+                "system_prompt": system_prompt,
+                "user_prompt": user_prompt,
+                "response_model": response_model,
+                "max_output_tokens": max_output_tokens,
+            }
+        )
+        response = self.responses.pop(0)
+        self.last_usage = response.get(
+            "usage",
+            {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        )
+        self.last_request_count = int(response.get("request_count", 1))
+        if "exception" in response:
+            raise response["exception"]
+        parsed = response_model.model_validate(response["parsed"])
+        self.last_structured_payload = parsed.model_dump(mode="json")
+        return parsed
+
+    def count_tokens(self, *, system_prompt: str, user_prompt: str) -> dict[str, int]:
+        return {"prompt_tokens": 1, "completion_tokens": 0, "total_tokens": 1}
+
+
+class PhraseAwareToolExecutor:
+    """Retriever stub returning candidates keyed by the queried phrase.
+
+    ``_retrieve_candidates`` aligns the returned batch results positionally to
+    the expanded query list, so returning ``{"phrase": phrase, "candidates":
+    ...}`` per input phrase lets the source phrase (X) and the qualifier phrase
+    (Y) retrieve DIFFERENT candidate sets.
+    """
+
+    def __init__(self, candidates_by_phrase: dict[str, list[dict[str, Any]]]) -> None:
+        self.candidates_by_phrase = candidates_by_phrase
+        self.queries: list[dict[str, Any]] = []
+
+    def query_batch_hpo_terms(self, *, phrases, language, n_results):
+        self.queries.append(
+            {"phrases": list(phrases), "language": language, "n_results": n_results}
+        )
+        return [
+            {
+                "phrase": phrase,
+                "candidates": list(self.candidates_by_phrase.get(phrase, [])),
+            }
+            for phrase in phrases
+        ]
+
+
+def _grounded_phenotype(
+    phrase: str,
+    category: str,
+    *,
+    chunk_id: int,
+    negated_qualifier: str | None = None,
+    experiencer: str = "proband",
+) -> dict[str, Any]:
+    phenotype: dict[str, Any] = {
+        "phrase": phrase,
+        "category": category,
+        "chunk_ids": [chunk_id],
+        "evidence_text": phrase,
+        "experiencer": experiencer,
+    }
+    if negated_qualifier is not None:
+        phenotype["negated_qualifier"] = negated_qualifier
+    return phenotype
+
+
+def _config() -> LLMPipelineConfig:
+    return LLMPipelineConfig(
+        provider="fake",
+        model="fake",
+        mode="two_phase",
+        language="en",
+    )
+
+
+# The source phrase X ("rash") exact-matches its candidate term_name, so it
+# resolves LOCALLY -> no phase-2 mapping LLM call is required.
+RASH_CANDIDATE = {"hpo_id": "HP:0000988", "term_name": "rash", "score": 0.95}
+# The qualifier Y ("fever") maps ABOVE the default floor (0.35).
+FEVER_CANDIDATE_ABOVE = {"hpo_id": "HP:0001945", "term_name": "Fever", "score": 0.9}
+# The qualifier Y ("fever") maps BELOW the default floor (0.35).
+FEVER_CANDIDATE_BELOW = {"hpo_id": "HP:0001945", "term_name": "Fever", "score": 0.2}
+
+
+def _phase1_only_provider() -> FakeProvider:
+    """Phase 1 emits one proband finding X="rash" with negated_qualifier="fever".
+
+    X resolves locally, so no mapping response is needed.
+    """
+    return FakeProvider(
+        responses=[
+            {
+                "parsed": {
+                    "phenotypes": [
+                        _grounded_phenotype(
+                            "rash",
+                            "Abnormal",
+                            chunk_id=1,
+                            negated_qualifier="fever",
+                        ),
+                    ]
+                },
+                "request_count": 1,
+            },
+        ]
+    )
+
+
+def test_qualifier_above_floor_emits_generated_excluded_finding() -> None:
+    """Case A: a resolved proband finding carrying negated_qualifier="fever"
+    where "fever" maps above the floor yields a GENERATED excluded finding.
+
+    The generated finding is present, present in ``result.terms`` alongside the
+    source finding, carries ``assertion == "negated"``,
+    ``match_method == "negated_qualifier_derived"``,
+    ``qualifier_surface_text == "fever"``, ``experiencer == "proband"``, and --
+    critically (F5) -- inherits the source finding's chunk_ids in its evidence
+    records.
+    """
+    provider = _phase1_only_provider()
+    tool_executor = PhraseAwareToolExecutor(
+        {
+            "rash": [RASH_CANDIDATE],
+            "fever": [FEVER_CANDIDATE_ABOVE],
+        }
+    )
+    pipeline = TwoPhaseLLMPipeline(
+        provider=provider,
+        tool_executor=tool_executor,
+        mapping_batch_size=1,
+    )
+
+    result = pipeline.run(
+        text="Patient had a rash without fever.",
+        grounded_chunks=[{"chunk_id": 1, "text": "Patient had a rash without fever."}],
+        config=_config(),
+    )
+
+    assert isinstance(result, LLMExtractionResult)
+
+    # The source proband finding still resolves into result.terms.
+    source = next((t for t in result.terms if t.term_id == "HP:0000988"), None)
+    assert source is not None
+    assert source.experiencer == "proband"
+
+    # A generated excluded finding for the qualifier "fever" appears.
+    generated = next((t for t in result.terms if t.term_id == "HP:0001945"), None)
+    assert generated is not None
+    assert generated.assertion == "negated"
+    assert generated.experiencer == "proband"
+    assert generated.match_method == "negated_qualifier_derived"
+    assert generated.qualifier_surface_text == "fever"
+    assert generated.label == "Fever"
+    assert generated.confidence is not None
+    assert generated.confidence >= pipeline.similarity_threshold
+    assert generated.score == FEVER_CANDIDATE_ABOVE["score"]
+
+    # F5: the generated term inherits the source finding's chunk_ids so it
+    # survives the aggregation service boundary.
+    generated_chunk_ids = [
+        chunk_id
+        for record in generated.evidence_records
+        for chunk_id in record.chunk_ids
+    ]
+    assert 1 in generated_chunk_ids
+
+
+def test_qualifier_below_floor_keeps_metadata_and_emits_no_term() -> None:
+    """Case B: when "fever" maps BELOW the floor, no term is generated and the
+    source finding's ``negated_qualifier`` metadata string is retained."""
+    provider = _phase1_only_provider()
+    tool_executor = PhraseAwareToolExecutor(
+        {
+            "rash": [RASH_CANDIDATE],
+            "fever": [FEVER_CANDIDATE_BELOW],
+        }
+    )
+    pipeline = TwoPhaseLLMPipeline(
+        provider=provider,
+        tool_executor=tool_executor,
+        mapping_batch_size=1,
+    )
+
+    result = pipeline.run(
+        text="Patient had a rash without fever.",
+        grounded_chunks=[{"chunk_id": 1, "text": "Patient had a rash without fever."}],
+        config=_config(),
+    )
+
+    # Only the source finding resolves; no generated excluded term.
+    assert {t.term_id for t in result.terms} == {"HP:0000988"}
+
+    source = next(t for t in result.terms if t.term_id == "HP:0000988")
+    # The metadata string is retained on the source finding.
+    assert source.negated_qualifier == "fever"
+
+
+def test_qualifier_unmappable_keeps_metadata_and_emits_no_term() -> None:
+    """Case B (variant): when the qualifier retrieves NO candidate at all, no
+    term is generated and the source finding's metadata string is retained."""
+    provider = _phase1_only_provider()
+    tool_executor = PhraseAwareToolExecutor(
+        {
+            "rash": [RASH_CANDIDATE],
+            # "fever" intentionally absent -> zero candidates retrieved.
+        }
+    )
+    pipeline = TwoPhaseLLMPipeline(
+        provider=provider,
+        tool_executor=tool_executor,
+        mapping_batch_size=1,
+    )
+
+    result = pipeline.run(
+        text="Patient had a rash without fever.",
+        grounded_chunks=[{"chunk_id": 1, "text": "Patient had a rash without fever."}],
+        config=_config(),
+    )
+
+    assert {t.term_id for t in result.terms} == {"HP:0000988"}
+    source = next(t for t in result.terms if t.term_id == "HP:0000988")
+    assert source.negated_qualifier == "fever"

--- a/tests/unit/llm/test_two_phase_prompt_negation_guard.py
+++ b/tests/unit/llm/test_two_phase_prompt_negation_guard.py
@@ -1,0 +1,87 @@
+"""Guard test: extraction two_phase prompts must keep the negation-scope rule.
+
+This test protects the LLM extraction contract from a silent regression where
+a future localized (or edited) `two_phase` extraction prompt drops either:
+
+  1. the negation-scope rule that tells the model a negation cue (e.g. "X
+     without Y") negates only the noun phrase it directly modifies, not the
+     whole sentence, and
+  2. a `negated_qualifier` few-shot example that demonstrates the rule with a
+     real (non-null) value.
+
+Only true *extraction* templates are checked -- the `*_mapping.yaml` and
+`*_mapping_batch.yaml` templates are a distinct prompt family (mapping
+extracted phrases to HPO terms) and never contained this rule, so they are
+excluded by name.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from phentrieve.llm.prompts.loader import PACKAGE_TEMPLATES_DIR
+
+TWO_PHASE_TEMPLATES_DIR = PACKAGE_TEMPLATES_DIR / "two_phase"
+
+# Excluded suffixes: mapping-phase templates, not extraction-phase templates.
+_MAPPING_SUFFIXES = ("_mapping.yaml", "_mapping_batch.yaml")
+
+# Distinctive negation-scope rule text (en.yaml:28-30). Robust to minor
+# reformatting but specific enough that a template lacking the guidance
+# would fail the check.
+_NEGATION_SCOPE_MARKERS = (
+    "negates ONLY",
+    "X without Y",
+)
+
+# A negated_qualifier few-shot must show a real (non-null, non-empty) value,
+# not just "negated_qualifier": null.
+_NEGATED_QUALIFIER_VALUE_PATTERN = re.compile(r'"negated_qualifier"\s*:\s*"[^"]+"')
+
+
+def _is_extraction_template(path: Path) -> bool:
+    return not path.name.endswith(_MAPPING_SUFFIXES)
+
+
+def _extraction_templates() -> list[Path]:
+    return sorted(
+        path
+        for path in TWO_PHASE_TEMPLATES_DIR.glob("*.yaml")
+        if _is_extraction_template(path)
+    )
+
+
+def test_extraction_template_selection_is_nonempty_and_excludes_mapping() -> None:
+    templates = _extraction_templates()
+
+    assert templates, (
+        "No extraction two_phase templates found -- the glob or exclusion "
+        "filter is likely broken, which would make this guard vacuous."
+    )
+    for path in templates:
+        assert not path.name.endswith(_MAPPING_SUFFIXES)
+
+
+def test_extraction_templates_keep_negation_scope_rule() -> None:
+    templates = _extraction_templates()
+    assert templates, "expected at least one extraction two_phase template"
+
+    for path in templates:
+        text = path.read_text(encoding="utf-8")
+        for marker in _NEGATION_SCOPE_MARKERS:
+            assert marker in text, (
+                f"{path.name} is missing negation-scope guidance "
+                f"(expected marker {marker!r})"
+            )
+
+
+def test_extraction_templates_keep_negated_qualifier_few_shot() -> None:
+    templates = _extraction_templates()
+    assert templates, "expected at least one extraction two_phase template"
+
+    for path in templates:
+        text = path.read_text(encoding="utf-8")
+        assert _NEGATED_QUALIFIER_VALUE_PATTERN.search(text), (
+            f"{path.name} is missing a negated_qualifier few-shot with a non-null value"
+        )

--- a/tests/unit/mcp_server/test_mcp_family_projection.py
+++ b/tests/unit/mcp_server/test_mcp_family_projection.py
@@ -1,0 +1,164 @@
+"""B2 Task 9: family_history_findings + experiencer/excluded on the MCP surface.
+
+Covers projection (family list projected, experiencer/excluded survive), the
+EXTRACT_SCHEMA envelope, the capabilities descriptor documenting the new fields
+(so ``capabilities_version`` rolls), and independent budgeting of the family
+list. The capabilities hash-stability invariants are re-asserted rather than
+pinned to a hard-coded hash (F6).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from api.mcp.capabilities import build_capabilities, capabilities_version
+from api.mcp.projection import (
+    project_aggregated_terms_for_mcp,
+    project_extract_payload,
+)
+from api.mcp.schemas import EXTRACT_SCHEMA
+
+pytestmark = pytest.mark.unit
+
+
+PROBAND_NEGATED = {
+    "id": "HP:0001945",
+    "name": "Fever",
+    "score": 0.7,
+    "status": "negated",
+    "experiencer": "proband",
+    "excluded": True,
+    "evidence_count": 1,
+    "source_chunk_ids": [1],
+}
+FAMILY_TERM = {
+    "id": "HP:0002076",
+    "name": "Migraine",
+    "score": 0.8,
+    "status": "present",
+    "experiencer": "family_history",
+    "excluded": False,
+    "evidence_count": 1,
+    "source_chunk_ids": [1],
+}
+
+
+def test_projection_preserves_experiencer_and_excluded():
+    out = project_aggregated_terms_for_mcp([PROBAND_NEGATED])[0]
+    assert out["experiencer"] == "proband"
+    assert out["excluded"] is True
+    assert out["assertion"] == "negated"
+
+
+def test_project_extract_payload_projects_family_list():
+    payload = {
+        "aggregated_hpo_terms": [PROBAND_NEGATED],
+        "family_history_findings": [FAMILY_TERM],
+        "processed_chunks": [],
+        "meta": {},
+    }
+    out = project_extract_payload(payload)
+
+    assert "family_history_findings" in out
+    fam = out["family_history_findings"][0]
+    assert fam["hpo_id"] == "HP:0002076"
+    assert fam["experiencer"] == "family_history"
+    assert fam["excluded"] is False
+
+    agg = out["aggregated_hpo_terms"][0]
+    assert agg["experiencer"] == "proband"
+    assert agg["excluded"] is True
+
+
+def test_extract_schema_exposes_family_history_findings():
+    props = EXTRACT_SCHEMA["properties"]
+    assert "family_history_findings" in props
+    # No regression: the proband list stays.
+    assert "aggregated_hpo_terms" in props
+
+
+def test_capabilities_descriptor_documents_new_output_fields():
+    caps = build_capabilities()
+    serialized = json.dumps(caps, default=str, sort_keys=True)
+    assert "family_history_findings" in serialized
+    assert "experiencer" in serialized
+    assert "excluded" in serialized
+
+
+def test_capabilities_version_hash_stability_preserved():
+    base = build_capabilities()
+    detailed = build_capabilities(details=["sample_calls", "argument_aliases"])
+    # capabilities_version is a stable warm-cache key across the details expansion.
+    assert base["capabilities_version"] == capabilities_version()
+    assert detailed["capabilities_version"] == capabilities_version()
+    # The detailed descriptor keeps its own distinct content hash.
+    assert detailed["descriptor_hash"] != base["descriptor_hash"]
+
+
+def _call_extract(monkeypatch, service_payload: dict, args: dict) -> dict:
+    monkeypatch.setattr(
+        "api.mcp.tools.retrieval.extract_hpo_terms_service",
+        lambda **_kwargs: service_payload,
+    )
+    from api.mcp.facade import create_phentrieve_mcp
+
+    mcp = create_phentrieve_mcp()
+    result = asyncio.run(mcp.call_tool("phentrieve_extract_hpo_terms", args))
+    return result.structured_content
+
+
+def test_extract_tool_surfaces_family_findings(monkeypatch):
+    payload = {
+        "meta": {"extraction_backend": "standard"},
+        "processed_chunks": [],
+        "aggregated_hpo_terms": [PROBAND_NEGATED],
+        "family_history_findings": [FAMILY_TERM],
+    }
+    data = _call_extract(
+        monkeypatch,
+        payload,
+        {"text": "x", "research_use_acknowledged": True, "response_mode": "compact"},
+    )
+
+    assert data["success"] is True
+    assert "family_history_findings" in data
+    fam = data["family_history_findings"][0]
+    assert fam["hpo_id"] == "HP:0002076"
+    assert fam["experiencer"] == "family_history"
+    assert fam["excluded"] is False
+
+
+def test_family_list_budgeted_independently(monkeypatch):
+    """A large family list is truncated + disclosed, never silently exempted."""
+    big_family = [
+        {
+            "id": f"HP:{i:07d}",
+            "name": f"Some longer phenotype label number {i}",
+            "score": 0.5,
+            "status": "present",
+            "experiencer": "family_history",
+            "excluded": False,
+            "evidence_count": 1,
+            "source_chunk_ids": [1],
+        }
+        for i in range(200)
+    ]
+    payload = {
+        "meta": {"extraction_backend": "standard"},
+        "processed_chunks": [],
+        # aggregated omitted so the family list is the sole budget pressure.
+        "family_history_findings": big_family,
+    }
+    data = _call_extract(
+        monkeypatch,
+        payload,
+        {"text": "x", "research_use_acknowledged": True, "response_mode": "minimal"},
+    )
+
+    assert len(data["family_history_findings"]) < 200
+    trunc = data["_meta"]["family_history_findings_truncated"]
+    assert trunc["field"] == "family_history_findings"
+    assert trunc["total"] == 200

--- a/tests/unit/mcp_server/test_mcp_family_projection.py
+++ b/tests/unit/mcp_server/test_mcp_family_projection.py
@@ -53,6 +53,60 @@ def test_projection_preserves_experiencer_and_excluded():
     assert out["assertion"] == "negated"
 
 
+def test_projection_derives_excluded_for_standard_backend():
+    """Standard backend has no precomputed excluded; projection derives it (B2fix)."""
+    negated = {
+        "id": "HP:0001250",
+        "name": "Seizure",
+        "score": 0.7,
+        "status": "negated",
+        "evidence_count": 1,
+        "source_chunk_ids": [1],
+    }
+    present = {
+        "id": "HP:0001945",
+        "name": "Fever",
+        "score": 0.6,
+        "status": "present",
+        "evidence_count": 1,
+        "source_chunk_ids": [1],
+    }
+    out_neg = project_aggregated_terms_for_mcp([negated])[0]
+    out_pres = project_aggregated_terms_for_mcp([present])[0]
+
+    assert out_neg["excluded"] is True
+    assert out_pres["excluded"] is False
+
+
+def test_projection_excluded_derivation_is_idempotent():
+    """A precomputed excluded bool is never overwritten by the fallback (B2fix)."""
+    # status="present" would derive False, but a precomputed True must survive.
+    preset_true = {
+        "id": "HP:0002076",
+        "name": "Migraine",
+        "score": 0.8,
+        "status": "present",
+        "excluded": True,
+        "evidence_count": 1,
+        "source_chunk_ids": [1],
+    }
+    # status="negated" would derive True, but a precomputed False (LLM path) survives.
+    preset_false = {
+        "id": "HP:0001250",
+        "name": "Seizure",
+        "score": 0.7,
+        "status": "negated",
+        "excluded": False,
+        "evidence_count": 1,
+        "source_chunk_ids": [1],
+    }
+    out_true = project_aggregated_terms_for_mcp([preset_true])[0]
+    out_false = project_aggregated_terms_for_mcp([preset_false])[0]
+
+    assert out_true["excluded"] is True
+    assert out_false["excluded"] is False
+
+
 def test_project_extract_payload_projects_family_list():
     payload = {
         "aggregated_hpo_terms": [PROBAND_NEGATED],

--- a/tests/unit/mcp_server/test_mcp_service_adapters.py
+++ b/tests/unit/mcp_server/test_mcp_service_adapters.py
@@ -203,6 +203,66 @@ def test_export_excludes_family_history_phenotypes():
     assert "HP:0000365" not in feature_ids
 
 
+def test_coerce_drops_family_history_experiencer_even_with_present_assertion():
+    """B2: experiencer, not assertion, now carries family-ness (B1 split them
+    into separate axes). A family-history mention must be dropped even when
+    its assertion is a normal, non-family value like 'present'."""
+    out = _coerce_export_phenotype(
+        ExportPhenotypeRequest,
+        {
+            "hpo_id": "HP:0000365",
+            "label": "Hearing loss",
+            "assertion": "present",
+            "experiencer": "family_history",
+        },
+        0,
+    )
+    assert out is None
+
+
+def test_coerce_keeps_proband_experiencer():
+    """Regression: a proband term (explicit or absent experiencer) is not
+    dropped by the experiencer-based guard."""
+    for experiencer in ("proband", None):
+        p = {"hpo_id": "HP:0001250", "label": "Seizure", "assertion": "present"}
+        if experiencer is not None:
+            p["experiencer"] = experiencer
+        out = _coerce_export_phenotype(ExportPhenotypeRequest, p, 0)
+        assert out is not None
+        assert out.hpo_id == "HP:0001250"
+
+
+def test_export_excludes_family_history_via_experiencer_mixed_proband():
+    """Integration-style: export_phenopacket_service over a mixed
+    proband+family input must yield zero family terms in the subject's
+    PhenotypicFeatures, keyed off experiencer rather than assertion."""
+    out = export_phenopacket_service(
+        case_id="CASE-3",
+        case_label="demo",
+        input_text=None,
+        subject=None,
+        phenotypes=[
+            {
+                "hpo_id": "HP:0001250",
+                "label": "Seizure",
+                "assertion": "present",
+                "experiencer": "proband",
+            },
+            {
+                "hpo_id": "HP:0000365",
+                "label": "Hearing loss",
+                "assertion": "present",
+                "experiencer": "family_history",
+            },
+        ],
+        include_annotation_sidecar=False,
+    )
+    packet = json.loads(out["phenopacket_json"])
+    feature_ids = {feat["type"]["id"] for feat in packet.get("phenotypicFeatures", [])}
+    assert "HP:0001250" in feature_ids
+    assert "HP:0000365" not in feature_ids
+
+
 def test_absent_assertion_exports_as_negated_not_affirmed():
     out = _coerce_export_phenotype(
         ExportPhenotypeRequest, {"hpo_id": "HP:0001250", "assertion": "absent"}, 0

--- a/tests/unit/mcp_server/test_mcp_service_adapters.py
+++ b/tests/unit/mcp_server/test_mcp_service_adapters.py
@@ -270,14 +270,20 @@ def test_absent_assertion_exports_as_negated_not_affirmed():
     assert out is not None and out.assertion_status == "negated"
 
 
-def test_normal_and_uncertain_do_not_crash_and_are_not_excluded():
-    for a in ("normal", "uncertain"):
-        out = _coerce_export_phenotype(
-            ExportPhenotypeRequest, {"hpo_id": "HP:0001250", "assertion": a}, 0
-        )
-        assert (
-            out.assertion_status == "affirmed"
-        )  # not excluded, and no ValidationError
+def test_normal_assertion_exports_as_negated_excluded():
+    # A normalcy verdict is a ruled-out abnormality -> excluded (negated).
+    out = _coerce_export_phenotype(
+        ExportPhenotypeRequest, {"hpo_id": "HP:0001250", "assertion": "normal"}, 0
+    )
+    assert out is not None and out.assertion_status == "negated"
+
+
+def test_uncertain_does_not_crash_and_is_not_excluded():
+    out = _coerce_export_phenotype(
+        ExportPhenotypeRequest, {"hpo_id": "HP:0001250", "assertion": "uncertain"}, 0
+    )
+    # not excluded, and no ValidationError
+    assert out.assertion_status == "affirmed"
 
 
 def test_present_assertion_affirmed():

--- a/tests/unit/mcp_server/test_mcp_service_adapters.py
+++ b/tests/unit/mcp_server/test_mcp_service_adapters.py
@@ -9,11 +9,13 @@ import pytest
 from api.mcp import service_adapters
 from api.mcp.envelope import McpToolError
 from api.mcp.service_adapters import (
+    _coerce_export_phenotype,
     chunk_text_service,
     export_phenopacket_service,
     extract_hpo_terms_llm_service,
     extract_hpo_terms_service,
 )
+from api.schemas.phenopacket_schemas import ExportPhenotypeRequest
 from phentrieve.config import DEFAULT_MODEL
 
 
@@ -199,6 +201,30 @@ def test_export_excludes_family_history_phenotypes():
     feature_ids = {feat["type"]["id"] for feat in packet.get("phenotypicFeatures", [])}
     assert "HP:0001250" in feature_ids
     assert "HP:0000365" not in feature_ids
+
+
+def test_absent_assertion_exports_as_negated_not_affirmed():
+    out = _coerce_export_phenotype(
+        ExportPhenotypeRequest, {"hpo_id": "HP:0001250", "assertion": "absent"}, 0
+    )
+    assert out is not None and out.assertion_status == "negated"
+
+
+def test_normal_and_uncertain_do_not_crash_and_are_not_excluded():
+    for a in ("normal", "uncertain"):
+        out = _coerce_export_phenotype(
+            ExportPhenotypeRequest, {"hpo_id": "HP:0001250", "assertion": a}, 0
+        )
+        assert (
+            out.assertion_status == "affirmed"
+        )  # not excluded, and no ValidationError
+
+
+def test_present_assertion_affirmed():
+    out = _coerce_export_phenotype(
+        ExportPhenotypeRequest, {"hpo_id": "HP:0001250", "assertion": "present"}, 0
+    )
+    assert out.assertion_status == "affirmed"
 
 
 def test_extract_service_resolves_none_language():

--- a/tests/unit/phenopacket_utils/test_phenopacket_utils.py
+++ b/tests/unit/phenopacket_utils/test_phenopacket_utils.py
@@ -266,6 +266,65 @@ class TestPhenopacketUtils:
 
         assert phenopacket["phenotypicFeatures"][0]["excluded"] is True
 
+    def test_status_keyed_negated_maps_to_excluded_true(self):
+        """B0 gap fix: the shared full-text service emits aggregated terms keyed
+        on ``status`` (+ a derived ``excluded`` bool) and carries NEITHER
+        ``assertion`` nor ``assertion_status``. Such a ruled-out term must still
+        export as excluded, not silently default to affirmed (present)."""
+        phenopacket_json = format_as_phenopacket_v2(
+            aggregated_results=[
+                {
+                    "hpo_id": "HP:0001945",
+                    "term_name": "Fever",
+                    "status": "negated",
+                    "excluded": True,
+                    "score": 0.8,
+                }
+            ]
+        )
+        phenopacket = json.loads(phenopacket_json)
+
+        assert phenopacket["phenotypicFeatures"][0]["excluded"] is True
+
+    def test_excluded_flag_only_maps_to_excluded_true(self):
+        """A term carrying only the derived ``excluded`` bool (no assertion/status)
+        must still export as excluded."""
+        phenopacket_json = format_as_phenopacket_v2(
+            aggregated_results=[
+                {
+                    "hpo_id": "HP:0001945",
+                    "term_name": "Fever",
+                    "excluded": True,
+                    "score": 0.8,
+                }
+            ]
+        )
+        phenopacket = json.loads(phenopacket_json)
+
+        assert phenopacket["phenotypicFeatures"][0]["excluded"] is True
+
+    def test_from_legacy_dict_reads_status_and_excluded(self):
+        """Unit-level guard on the normalizer precedence for the B0 gap."""
+        assert (
+            NormalizedPhenotypeExportRecord.from_legacy_dict(
+                {"hpo_id": "HP:1", "label": "x", "status": "negated"}
+            ).assertion
+            == "negated"
+        )
+        assert (
+            NormalizedPhenotypeExportRecord.from_legacy_dict(
+                {"hpo_id": "HP:1", "label": "x", "excluded": True}
+            ).assertion
+            == "negated"
+        )
+        # Canonical fields still win when present.
+        assert (
+            NormalizedPhenotypeExportRecord.from_legacy_dict(
+                {"hpo_id": "HP:1", "label": "x", "assertion": "present"}
+            ).assertion
+            == "affirmed"
+        )
+
     def test_export_phenopacket_bundle_returns_strict_packet_and_optional_sidecar(
         self,
     ) -> None:

--- a/tests/unit/phenopacket_utils/test_phenopacket_utils.py
+++ b/tests/unit/phenopacket_utils/test_phenopacket_utils.py
@@ -286,6 +286,23 @@ class TestPhenopacketUtils:
 
         assert phenopacket["phenotypicFeatures"][0]["excluded"] is True
 
+    def test_status_normal_maps_to_excluded_true(self):
+        """A normalcy verdict (status='normal', e.g. 'structure normal') is a
+        ruled-out abnormality and must export as excluded, not a present feature."""
+        phenopacket_json = format_as_phenopacket_v2(
+            aggregated_results=[
+                {
+                    "hpo_id": "HP:0100543",
+                    "term_name": "Cognitive impairment",
+                    "status": "normal",
+                    "score": 0.8,
+                }
+            ]
+        )
+        phenopacket = json.loads(phenopacket_json)
+
+        assert phenopacket["phenotypicFeatures"][0]["excluded"] is True
+
     def test_excluded_flag_only_maps_to_excluded_true(self):
         """A term carrying only the derived ``excluded`` bool (no assertion/status)
         must still export as excluded."""

--- a/tests/unit/test_assertion_vocab.py
+++ b/tests/unit/test_assertion_vocab.py
@@ -32,11 +32,12 @@ def test_canonicalize(raw, expected):
     assert canonicalize_assertion(raw) == expected
 
 
-@pytest.mark.parametrize("raw", ["absent", "negated", "excluded", "NO"])
+@pytest.mark.parametrize("raw", ["absent", "negated", "excluded", "NO", "normal"])
 def test_is_excluded_true(raw):
+    # ``normal`` is a normalcy verdict (ruled-out abnormality) -> excluded.
     assert is_excluded(raw) is True
 
 
-@pytest.mark.parametrize("raw", ["present", "affirmed", "normal", "uncertain", None])
+@pytest.mark.parametrize("raw", ["present", "affirmed", "uncertain", None])
 def test_is_excluded_false(raw):
     assert is_excluded(raw) is False

--- a/tests/unit/test_assertion_vocab.py
+++ b/tests/unit/test_assertion_vocab.py
@@ -1,0 +1,42 @@
+import pytest
+
+from phentrieve.assertion_vocab import (
+    AFFIRMED,
+    NEGATED,
+    NORMAL,
+    UNCERTAIN,
+    canonicalize_assertion,
+    is_excluded,
+)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("present", AFFIRMED),
+        ("affirmed", AFFIRMED),
+        ("abnormal", AFFIRMED),
+        ("absent", NEGATED),
+        ("negated", NEGATED),
+        ("excluded", NEGATED),
+        ("no", NEGATED),
+        ("normal", NORMAL),
+        ("uncertain", UNCERTAIN),
+        ("suspected", UNCERTAIN),
+        ("  ABSENT  ", NEGATED),
+        (None, AFFIRMED),
+        ("nonsense", AFFIRMED),
+    ],
+)
+def test_canonicalize(raw, expected):
+    assert canonicalize_assertion(raw) == expected
+
+
+@pytest.mark.parametrize("raw", ["absent", "negated", "excluded", "NO"])
+def test_is_excluded_true(raw):
+    assert is_excluded(raw) is True
+
+
+@pytest.mark.parametrize("raw", ["present", "affirmed", "normal", "uncertain", None])
+def test_is_excluded_false(raw):
+    assert is_excluded(raw) is False

--- a/tests/unit/test_llm_benchmark.py
+++ b/tests/unit/test_llm_benchmark.py
@@ -2531,3 +2531,55 @@ def test_run_llm_benchmark_cli_overwrites_existing_output_without_checkpoint(
         json.loads(output_path.read_text(encoding="utf-8"))["llm_model"]
         == "gemini-2.5-flash"
     )
+
+
+def test_assertion_distribution_surfaces_dropped_deliverable():
+    """The present-only projection drops negated/family findings from scoring;
+    the distribution report must count them so the deliverable stays visible."""
+    import types
+
+    def term(assertion: str):
+        return types.SimpleNamespace(
+            term_id="HP:0000001", label="x", assertion=assertion, evidence="e"
+        )
+
+    pipeline_result = types.SimpleNamespace(
+        terms=[term("present"), term("present"), term("negated"), term("uncertain")],
+        family_history_findings=[term("present")],
+    )
+
+    dist = llm_benchmark._assertion_distribution(pipeline_result, dataset="GeneReviews")
+
+    assert dist["proband_by_assertion"] == {"present": 2, "negated": 1, "uncertain": 1}
+    # GeneReviews keeps present+uncertain, drops negated.
+    assert dist["proband_scored"] == 3
+    assert dist["proband_dropped_by_projection"] == 1
+    assert dist["family_history_findings"] == 1
+
+
+def test_aggregate_assertion_distribution_sums_records():
+    records = [
+        {
+            "assertion_distribution": {
+                "proband_by_assertion": {"present": 2, "negated": 1},
+                "proband_scored": 2,
+                "proband_dropped_by_projection": 1,
+                "family_history_findings": 1,
+            }
+        },
+        {
+            "assertion_distribution": {
+                "proband_by_assertion": {"present": 3},
+                "proband_scored": 3,
+                "proband_dropped_by_projection": 0,
+                "family_history_findings": 0,
+            }
+        },
+    ]
+
+    agg = llm_benchmark._aggregate_assertion_distribution(records)
+
+    assert agg["proband_by_assertion"] == {"present": 5, "negated": 1}
+    assert agg["proband_scored"] == 5
+    assert agg["proband_dropped_by_projection"] == 1
+    assert agg["family_history_findings"] == 1

--- a/tests/unit/test_llm_benchmark.py
+++ b/tests/unit/test_llm_benchmark.py
@@ -2575,6 +2575,8 @@ def test_aggregate_assertion_distribution_sums_records():
                 "family_history_findings": 0,
             }
         },
+        # A checkpoint-restored record from before the field existed: no block.
+        {"doc_id": "legacy-doc"},
     ]
 
     agg = llm_benchmark._aggregate_assertion_distribution(records)
@@ -2583,3 +2585,6 @@ def test_aggregate_assertion_distribution_sums_records():
     assert agg["proband_scored"] == 5
     assert agg["proband_dropped_by_projection"] == 1
     assert agg["family_history_findings"] == 1
+    # Undercount is visible: 2 of 3 records contributed.
+    assert agg["documents_counted"] == 2
+    assert agg["documents_total"] == 3

--- a/tests/unit/text_processing/test_full_text_service.py
+++ b/tests/unit/text_processing/test_full_text_service.py
@@ -268,6 +268,8 @@ def test_run_llm_backend_adapts_grounded_chunks_and_text_attributions(mocker):
             "name": "Recurrent seizures",
             "evidence": "recurrent seizures",
             "status": "present",
+            "experiencer": "proband",
+            "excluded": False,
             "evidence_records": [
                 {
                     "phrase": "recurrent seizures",

--- a/uv.lock
+++ b/uv.lock
@@ -3402,7 +3402,7 @@ wheels = [
 
 [[package]]
 name = "phentrieve"
-version = "0.24.1"
+version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Summary

Phase 2 of **extraction contract v2** (blocks B0–B3: canonical `absent→excluded`
vocabulary, model assertion/experiencer made load-bearing, family-history
partition, `negated_qualifier→excluded`), **plus a deep review pass** that
root-caused and fixed a real precision regression the original benchmark call had
missed, hardened the benchmark, and closed a B0 export gap.

Base: `feat/extraction-contract-v2` (the 17 B0–B3 commits + 6 review-driven fixes).

## The regression, root-caused and fixed

The deterministic LLM benchmark (10 GeneReviews docs, gemini-3.1-flash-lite, seed
123) actually showed a small **real** precision drop (micro P −0.0149, F1 −0.0071,
recall flat; paired p=0.0156) — not "no regression". Two root causes, **both fixed
and verified to restore baseline EXACTLY** (P 0.8482 / R 0.8017 / F1 0.8243, **0
scored-prediction diffs vs baseline**):

1. **Dead mapping-payload keys** — `compact_mapping_item` serialized
   `experiencer`/`assertion` into the phase-2b mapping LLM prompt. The mapping
   templates never reference them and the axes already reach the resolver via the
   original item, so they only perturbed Gemini's near-deterministic pick, flipping
   bare fragments toward top-scored **modifier** nodes (HP:0012836 Spatial pattern,
   HP:0003677 Slowly progressive). Removed from the payload.
2. **`normal`→`present` contradiction** — `phenotype_from_candidate` let a model
   `assertion=present` override a `normal` category ("normal intellectual abilities"
   → Cognitive impairment PRESENT). A normalcy verdict can no longer be promoted to
   present; model negated/uncertain still honored. All B1 pinned tests unchanged.
   (Also *improves* the contract: that phrase now correctly exports as **excluded**.)

## Other review-driven fixes

- **B0 phenopacket gap** — the CLI aggregated phenopacket/sidecar export read only
  `assertion`/`assertion_status` and defaulted `absent→affirmed`; it now reads the
  shared service's `status`/`excluded` keys so a ruled-out finding exports excluded.
- **`assert-no-regression` failed OPEN** — defaulted a missing baseline metric to
  0.0 (passed any candidate) and skipped the `scoring_mode` guard when either file
  omitted it; both now fail closed.
- **Ontology guard** (`llm/ontology_guard.py`) — drops resolved terms known to sit
  outside Phenotypic abnormality (HP:0000118); fail-open on unknown ancestry;
  validated **0/197** benchmark gold terms dropped. Kills the B3 `"normal"→"Mild"`
  qualifier-exclusion leak on the REST/MCP surface.
- **Benchmark blindness** — the LLM benchmark projected `negated`/`absent`/`family`
  → None before scoring, so the phase's deliverable was unmeasured. Added an
  additive `assertion_distribution` report (no scoring change).
- **Fail-open observability** — `canonicalize_assertion` now logs unknown assertion
  strings that fall through to affirmed.

## Verification

- End-to-end benchmark with all fixes: **identical to baseline** (0 scored diffs),
  recall untouched, modifier leak gone, deliverable now reported.
- `make check` ✅ · `make typecheck-fast` ✅ (mypy clean, 170 files) ·
  `make ci-python-quality` ✅ (**1994 passed, 43 skipped**, 76.8% coverage) ·
  `make security-python` ✅.

## Deliberately not changed (decisions, not defects)

- Cross-backend `normal` polarity (deterministic exports present, LLM excluded).
- Wiring the regression fence into a data-dependent CI lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121dztXrJ9ZSQmWT7Q145PY
