### PR TITLE
fix(index): close Chroma clients after index builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,7 +301,12 @@ jobs:
           #   fails with KeyError '_type'); 1.5.9 is the latest release and the
           #   advisory has no patched fix yet (see security.yml and the
           #   test_dependency_security_policy.py policy tests).
-          jq --argjson allowed_advisories '["GHSA-f4j7-r4q5-qw2c"]' '
+          # - GHSA-29pf-2h5f-8g72 and GHSA-fgcw-684q-jj6r: Transformers 5.x
+          #   contains the fixes, but JinaBert's immutable remote implementation
+          #   cannot load under that major version. The data-release contract pins
+          #   both model and code commits. Remove before the next HPO data release
+          #   once JinaBert supports a patched Transformers release.
+          jq --argjson allowed_advisories '["GHSA-f4j7-r4q5-qw2c", "GHSA-29pf-2h5f-8g72", "GHSA-fgcw-684q-jj6r"]' '
             [
               .[]
               | select(.change_type != "removed")

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -63,16 +63,26 @@ jobs:
 
       - name: Run pip-audit
         run: |
-          # Ignored vulnerabilities have no patched release yet (checked 2026-06-13):
+          # Ignored vulnerabilities have no compatible patched release yet (checked 2026-07-15):
           # - CVE-2025-3000 / GHSA-rrmf-rvhw-rf47: torch.jit.script memory corruption,
           #   <= 2.12.0 vulnerable, no patched release available. Remove once a fixed torch ships.
           # - GHSA-f4j7-r4q5-qw2c / CVE-2026-45829: chromadb >=1.0.0,<=1.5.9. ChromaDB 1.x is
           #   REQUIRED to read the published multi-vector data bundles (0.6.x cannot); 1.5.9 is
           #   the latest release and no patched 1.x exists yet. Accepted risk. Remove once a
           #   patched chromadb >1.5.9 ships.
+          # - PYSEC-2025-217, PYSEC-2026-2288, PYSEC-2026-2289, and PYSEC-2026-2290:
+          #   JinaBert's pinned remote implementation is incompatible with Transformers 5.x,
+          #   the fixed major release. Its exact model and code commits are validated by the
+          #   data-release contract, and only that trusted code path is enabled. Remove these
+          #   exceptions once JinaBert supports a patched Transformers release, before the next
+          #   HPO data release.
           uv run pip-audit --requirement audit-requirements.txt --vulnerability-service pypi \
             --ignore-vuln CVE-2025-3000 \
-            --ignore-vuln GHSA-f4j7-r4q5-qw2c
+            --ignore-vuln GHSA-f4j7-r4q5-qw2c \
+            --ignore-vuln PYSEC-2025-217 \
+            --ignore-vuln PYSEC-2026-2288 \
+            --ignore-vuln PYSEC-2026-2289 \
+            --ignore-vuln PYSEC-2026-2290
 
   # Python SAST with Bandit (run directly with uv for proper pyproject.toml support)
   bandit:

--- a/phentrieve/data_processing/bundle_manifest.py
+++ b/phentrieve/data_processing/bundle_manifest.py
@@ -90,6 +90,7 @@ class EmbeddingModelInfo:
     multi_vector: bool = False  # Whether index uses multi-vector approach
     revision: str = ""  # Immutable Hugging Face commit used for release builds
     trust_remote_code: bool = False  # Whether the pinned model uses custom code
+    code_revision: str | None = None  # Immutable custom-code commit, if used
 
     @classmethod
     def from_model_name(
@@ -100,6 +101,7 @@ class EmbeddingModelInfo:
         multi_vector: bool = False,
         revision: str = "",
         trust_remote_code: bool = False,
+        code_revision: str | None = None,
     ) -> EmbeddingModelInfo:
         """Create from model name with auto-generated slug."""
         return cls(
@@ -110,6 +112,7 @@ class EmbeddingModelInfo:
             multi_vector=multi_vector,
             revision=revision,
             trust_remote_code=trust_remote_code,
+            code_revision=code_revision,
         )
 
 

--- a/phentrieve/data_processing/bundle_manifest.py
+++ b/phentrieve/data_processing/bundle_manifest.py
@@ -89,6 +89,7 @@ class EmbeddingModelInfo:
     distance_metric: str = "cosine"  # e.g., "cosine", "l2", "ip"
     multi_vector: bool = False  # Whether index uses multi-vector approach
     revision: str = ""  # Immutable Hugging Face commit used for release builds
+    trust_remote_code: bool = False  # Whether the pinned model uses custom code
 
     @classmethod
     def from_model_name(
@@ -98,6 +99,7 @@ class EmbeddingModelInfo:
         distance_metric: str = "cosine",
         multi_vector: bool = False,
         revision: str = "",
+        trust_remote_code: bool = False,
     ) -> EmbeddingModelInfo:
         """Create from model name with auto-generated slug."""
         return cls(
@@ -107,6 +109,7 @@ class EmbeddingModelInfo:
             distance_metric=distance_metric,
             multi_vector=multi_vector,
             revision=revision,
+            trust_remote_code=trust_remote_code,
         )
 
 

--- a/phentrieve/data_processing/bundle_packager.py
+++ b/phentrieve/data_processing/bundle_packager.py
@@ -129,24 +129,19 @@ def create_bundle(
                 f"Run 'phentrieve index build --model-name \"{model_name}\"' first."
             )
 
-        try:
-            collection_context = _open_collection(index_base_dir, collection_name)
-        except Exception as error:
-            mv_flag = " --multi-vector" if multi_vector else ""
-            raise ValueError(
-                f"Collection '{collection_name}' not found in ChromaDB. "
-                f"Run 'phentrieve index build --model-name \"{model_name}\"{mv_flag}' first."
-            ) from error
-
-        with collection_context as collection:
+        model_revision = _expected_model_revision(
+            model_name=model_name,
+            release_spec=release_spec,
+        )
+        model_trust_remote_code = _expected_model_trust_remote_code(
+            model_name=model_name,
+            release_spec=release_spec,
+        )
+        with _open_collection(index_base_dir, collection_name) as collection:
             expected_document_count = _expected_document_count(
                 collection=collection,
                 manifest=manifest,
                 multi_vector=multi_vector,
-                release_spec=release_spec,
-            )
-            model_revision = _expected_model_revision(
-                model_name=model_name,
                 release_spec=release_spec,
             )
             dimension = _validate_collection_provenance(
@@ -157,13 +152,17 @@ def create_bundle(
                 expected_document_count=expected_document_count,
                 expected_model_revision=model_revision,
             )
+            resolved_model_revision = str(
+                cast(Any, collection).metadata.get("model_revision", "")
+            )
         logger.info(f"Found validated {index_type_str} collection: {collection_name}")
 
         manifest.model = EmbeddingModelInfo.from_model_name(
             model_name,
             dimension=dimension,
             multi_vector=multi_vector,
-            revision=str(cast(Any, collection).metadata.get("model_revision", "")),
+            revision=resolved_model_revision,
+            trust_remote_code=model_trust_remote_code,
         )
 
     # Create bundle in temp directory
@@ -280,6 +279,21 @@ def _expected_model_revision(
         if model.name == model_name:
             return model.revision
     raise ValueError(f"Model {model_name!r} is not declared in the release spec")
+
+
+def _expected_model_trust_remote_code(
+    model_name: str,
+    release_spec: DataReleaseSpec | None,
+) -> bool:
+    """Return the custom-code policy pinned for a release model."""
+    if release_spec is None:
+        return False
+    for model in release_spec.models:
+        if model.name == model_name:
+            return model.trust_remote_code
+    raise ValueError(
+        f"Model {model_name!r} is not present in the release specification"
+    )
 
 
 def _expected_document_count(

--- a/phentrieve/data_processing/bundle_packager.py
+++ b/phentrieve/data_processing/bundle_packager.py
@@ -17,6 +17,8 @@ import logging
 import shutil
 import tarfile
 import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -128,7 +130,7 @@ def create_bundle(
             )
 
         try:
-            collection = _get_collection(index_base_dir, collection_name)
+            collection_context = _open_collection(index_base_dir, collection_name)
         except Exception as error:
             mv_flag = " --multi-vector" if multi_vector else ""
             raise ValueError(
@@ -136,24 +138,25 @@ def create_bundle(
                 f"Run 'phentrieve index build --model-name \"{model_name}\"{mv_flag}' first."
             ) from error
 
-        expected_document_count = _expected_document_count(
-            collection=collection,
-            manifest=manifest,
-            multi_vector=multi_vector,
-            release_spec=release_spec,
-        )
-        model_revision = _expected_model_revision(
-            model_name=model_name,
-            release_spec=release_spec,
-        )
-        dimension = _validate_collection_provenance(
-            collection=collection,
-            manifest=manifest,
-            model_name=model_name,
-            index_type="multi_vector" if multi_vector else "single_vector",
-            expected_document_count=expected_document_count,
-            expected_model_revision=model_revision,
-        )
+        with collection_context as collection:
+            expected_document_count = _expected_document_count(
+                collection=collection,
+                manifest=manifest,
+                multi_vector=multi_vector,
+                release_spec=release_spec,
+            )
+            model_revision = _expected_model_revision(
+                model_name=model_name,
+                release_spec=release_spec,
+            )
+            dimension = _validate_collection_provenance(
+                collection=collection,
+                manifest=manifest,
+                model_name=model_name,
+                index_type="multi_vector" if multi_vector else "single_vector",
+                expected_document_count=expected_document_count,
+                expected_model_revision=model_revision,
+            )
         logger.info(f"Found validated {index_type_str} collection: {collection_name}")
 
         manifest.model = EmbeddingModelInfo.from_model_name(
@@ -301,19 +304,23 @@ def _expected_document_count(
     return raw_count
 
 
-def _get_collection(index_dir: Path, collection_name: str) -> object:
-    """Open the named ChromaDB collection using the project settings."""
+@contextmanager
+def _open_collection(index_dir: Path, collection_name: str) -> Iterator[object]:
+    """Keep the owning Chroma client alive while using its collection."""
     import chromadb
 
     vector_store_config = VectorStoreConfig(
         path=str(index_dir),
         collection_name=collection_name,
     )
-    client = chromadb.PersistentClient(
+    client: Any = chromadb.PersistentClient(
         path=str(index_dir),
         settings=vector_store_config.to_chromadb_settings(),
     )
-    return cast(object, client.get_collection(collection_name))
+    try:
+        yield cast(object, client.get_collection(collection_name))
+    finally:
+        client.close()
 
 
 def _validate_collection_provenance(

--- a/phentrieve/data_processing/bundle_packager.py
+++ b/phentrieve/data_processing/bundle_packager.py
@@ -137,6 +137,10 @@ def create_bundle(
             model_name=model_name,
             release_spec=release_spec,
         )
+        model_code_revision = _expected_model_code_revision(
+            model_name=model_name,
+            release_spec=release_spec,
+        )
         with _open_collection(index_base_dir, collection_name) as collection:
             expected_document_count = _expected_document_count(
                 collection=collection,
@@ -163,6 +167,7 @@ def create_bundle(
             multi_vector=multi_vector,
             revision=resolved_model_revision,
             trust_remote_code=model_trust_remote_code,
+            code_revision=model_code_revision,
         )
 
     # Create bundle in temp directory
@@ -291,6 +296,21 @@ def _expected_model_trust_remote_code(
     for model in release_spec.models:
         if model.name == model_name:
             return model.trust_remote_code
+    raise ValueError(
+        f"Model {model_name!r} is not present in the release specification"
+    )
+
+
+def _expected_model_code_revision(
+    model_name: str,
+    release_spec: DataReleaseSpec | None,
+) -> str | None:
+    """Return the immutable custom-code revision required by a release model."""
+    if release_spec is None:
+        return None
+    for model in release_spec.models:
+        if model.name == model_name:
+            return model.code_revision
     raise ValueError(
         f"Model {model_name!r} is not present in the release specification"
     )

--- a/phentrieve/data_processing/release_contract.py
+++ b/phentrieve/data_processing/release_contract.py
@@ -27,6 +27,7 @@ class ModelReleaseSpec:
     slug: str
     revision: str
     trust_remote_code: bool = False
+    code_revision: str | None = None
 
     def __post_init__(self) -> None:
         if not self.name:
@@ -37,6 +38,12 @@ class ModelReleaseSpec:
             raise ValueError(f"invalid model revision: {self.revision!r}")
         if not isinstance(self.trust_remote_code, bool):
             raise ValueError("trust_remote_code must be a boolean")
+        if self.code_revision is not None and not _GIT_SHA_PATTERN.fullmatch(
+            self.code_revision
+        ):
+            raise ValueError(f"invalid code revision: {self.code_revision!r}")
+        if self.trust_remote_code and self.code_revision is None:
+            raise ValueError("trust_remote_code models require a pinned code_revision")
 
 
 DATA_RELEASE_MODELS: tuple[ModelReleaseSpec, ...] = (
@@ -70,12 +77,14 @@ DATA_RELEASE_MODELS: tuple[ModelReleaseSpec, ...] = (
         slug="gte-multi",
         revision="9bbca17d9273fd0d03d5725c7a4b0f6b45142062",
         trust_remote_code=True,
+        code_revision="40ced75c3017eb27626c9d4ea981bde21a2662f4",
     ),
     ModelReleaseSpec(
         name="jinaai/jina-embeddings-v2-base-de",
         slug="jina-de",
         revision="3f9eede875721714945b6a99a3198299243cf2be",
         trust_remote_code=True,
+        code_revision="f3ec4cf7de7e561007f27c9efc7148b0bd713f81",
     ),
     ModelReleaseSpec(
         name="T-Systems-onsite/cross-en-de-roberta-sentence-transformer",

--- a/phentrieve/data_processing/release_contract.py
+++ b/phentrieve/data_processing/release_contract.py
@@ -26,6 +26,7 @@ class ModelReleaseSpec:
     name: str
     slug: str
     revision: str
+    trust_remote_code: bool = False
 
     def __post_init__(self) -> None:
         if not self.name:
@@ -34,6 +35,8 @@ class ModelReleaseSpec:
             raise ValueError(f"invalid model slug: {self.slug!r}")
         if not _GIT_SHA_PATTERN.fullmatch(self.revision):
             raise ValueError(f"invalid model revision: {self.revision!r}")
+        if not isinstance(self.trust_remote_code, bool):
+            raise ValueError("trust_remote_code must be a boolean")
 
 
 DATA_RELEASE_MODELS: tuple[ModelReleaseSpec, ...] = (
@@ -66,11 +69,13 @@ DATA_RELEASE_MODELS: tuple[ModelReleaseSpec, ...] = (
         name="Alibaba-NLP/gte-multilingual-base",
         slug="gte-multi",
         revision="9bbca17d9273fd0d03d5725c7a4b0f6b45142062",
+        trust_remote_code=True,
     ),
     ModelReleaseSpec(
         name="jinaai/jina-embeddings-v2-base-de",
         slug="jina-de",
         revision="3f9eede875721714945b6a99a3198299243cf2be",
+        trust_remote_code=True,
     ),
     ModelReleaseSpec(
         name="T-Systems-onsite/cross-en-de-roberta-sentence-transformer",

--- a/phentrieve/embeddings.py
+++ b/phentrieve/embeddings.py
@@ -35,7 +35,7 @@ Examples:
 import logging
 import threading
 import warnings
-from typing import cast
+from typing import Any, cast
 
 import torch
 from sentence_transformers import SentenceTransformer
@@ -92,6 +92,7 @@ def load_embedding_model(
     device: str | None = None,
     force_reload: bool = False,
     revision: str | None = None,
+    code_revision: str | None = None,
 ) -> SentenceTransformer:
     """
     Load a sentence transformer embedding model with caching and GPU support.
@@ -137,7 +138,9 @@ def load_embedding_model(
     if model_name is None:
         model_name = DEFAULT_BIOLORD_MODEL
         logging.info(f"No model specified, using default model: {model_name}")
-    registry_key = f"{model_name}@{revision}" if revision else model_name
+    registry_key = "@".join(
+        value for value in (model_name, revision, code_revision) if value
+    )
 
     # Determine device - auto-detect if not specified
     if device is None:
@@ -183,7 +186,9 @@ def load_embedding_model(
         logging.info(f"Loading embedding model: {model_name} on {device}")
 
         try:
-            model_kwargs = {"revision": revision} if revision else {}
+            model_kwargs: dict[str, object] = {"revision": revision} if revision else {}
+            if code_revision:
+                model_kwargs["model_kwargs"] = {"code_revision": code_revision}
             if trust_remote_code:
                 logging.info(
                     f"Loading model '{model_name}' with trust_remote_code=True on {device}"
@@ -199,6 +204,7 @@ def load_embedding_model(
 
             # Move model to specified device
             model.to(device)
+            _repair_gte_multilingual_position_ids(model_name, model)
 
             # Store in registry for future reuse
             _MODEL_REGISTRY[registry_key] = model
@@ -213,6 +219,22 @@ def load_embedding_model(
             logging.error(error_msg)
             logging.error("Make sure you have run: pip install -r requirements.txt")
             raise ValueError(error_msg) from e
+
+
+def _repair_gte_multilingual_position_ids(
+    model_name: str, model: SentenceTransformer
+) -> None:
+    """Initialize the uninitialized position buffer in GTE's pinned custom code."""
+    if model_name != "Alibaba-NLP/gte-multilingual-base":
+        return
+    transformer = cast(Any, model[0])
+    embeddings = transformer.auto_model.embeddings
+    position_ids = cast(torch.Tensor, embeddings.position_ids)
+    embeddings.position_ids = torch.arange(
+        position_ids.numel(),
+        dtype=position_ids.dtype,
+        device=position_ids.device,
+    )
 
 
 def clear_model_registry() -> None:

--- a/phentrieve/indexing/chromadb_indexer.py
+++ b/phentrieve/indexing/chromadb_indexer.py
@@ -9,6 +9,7 @@ import logging
 import os
 import time
 from pathlib import Path
+from typing import Any
 
 import chromadb
 from chromadb.api.types import Metadatas
@@ -74,6 +75,16 @@ def build_chromadb_index(
 
     # Record start time for performance measurement
     start_time = time.time()
+    client: Any | None = None
+
+    def finish(result: bool) -> bool:
+        """Release the persistent database handle before returning."""
+        if client is not None:
+            try:
+                client.close()
+            except Exception as error:
+                logging.warning("Unable to close ChromaDB client: %s", error)
+        return result
 
     # Initialize ChromaDB
     logging.info(f"Initializing ChromaDB at {index_dir}")
@@ -132,17 +143,17 @@ def build_chromadb_index(
                         "Use recreate=True to rebuild it.",
                         mismatched_metadata,
                     )
-                    return False
+                    return finish(False)
                 if existing_count == len(documents):
                     logging.info("Using an existing complete, matching collection")
-                    return True
+                    return finish(True)
                 logging.error(
                     "Existing collection has %d documents; expected %d. "
                     "Use recreate=True to rebuild it.",
                     existing_count,
                     len(documents),
                 )
-                return False
+                return finish(False)
         except Exception as e:
             # Collection didn't exist or some other error
             logging.debug(f"Note: {e}")
@@ -172,7 +183,7 @@ def build_chromadb_index(
         )
     except Exception as e:
         logging.error(f"Error initializing ChromaDB: {e}")
-        return False
+        return finish(False)
 
     # Get the device the model is on
     device = next(model.parameters()).device
@@ -213,7 +224,7 @@ def build_chromadb_index(
             logging.error(
                 f"Error processing batch {i // batch_size + 1}/{total_batches}: {e}"
             )
-            return False
+            return finish(False)
 
     persisted_count = collection.count()
     if persisted_count != len(documents):
@@ -222,10 +233,10 @@ def build_chromadb_index(
             persisted_count,
             len(documents),
         )
-        return False
+        return finish(False)
 
     end_time = time.time()
     logging.info(f"Index built successfully in {end_time - start_time:.2f} seconds!")
     logging.info(f"Indexed {len(documents)} documents ({index_type} index).")
     logging.info(f"Index location: {os.path.abspath(str(index_dir))}")
-    return True
+    return finish(True)

--- a/phentrieve/indexing/chromadb_orchestrator.py
+++ b/phentrieve/indexing/chromadb_orchestrator.py
@@ -42,6 +42,7 @@ def orchestrate_index_building(
     data_dir_override: str | None = None,
     multi_vector: bool = False,
     model_revision: str | None = None,
+    code_revision: str | None = None,
 ) -> bool:
     """Orchestrates loading data, models, and building ChromaDB indexes.
 
@@ -57,6 +58,7 @@ def orchestrate_index_building(
         data_dir_override: Override for data directory path
         multi_vector: Build multi-vector index (separate vectors per component)
         model_revision: Optional immutable Hugging Face revision for one model build.
+        code_revision: Optional immutable revision for model custom code.
 
     Returns:
         True if all requested indexes were built successfully, False otherwise
@@ -137,6 +139,7 @@ def orchestrate_index_building(
                 trust_remote_code=trust_remote_code,
                 device=device_override,  # Pass CPU/GPU preference
                 revision=model_revision,
+                code_revision=code_revision,
             )
             if not model:
                 raise ValueError(f"Failed to load model {model_name}")

--- a/phentrieve/retrieval/model_policy.py
+++ b/phentrieve/retrieval/model_policy.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 
 from phentrieve.config import BENCHMARK_MODELS, DEFAULT_MODEL
+from phentrieve.data_processing.release_contract import DATA_RELEASE_MODELS
 
 
 @dataclass(frozen=True)
@@ -31,5 +32,11 @@ def resolve_retrieval_model_policy(model_name: str | None) -> RetrievalModelPoli
 
     return RetrievalModelPolicy(
         model_name=resolved_model_name,
-        trust_remote_code=resolved_model_name == DEFAULT_MODEL,
+        trust_remote_code=(
+            resolved_model_name == DEFAULT_MODEL
+            or any(
+                model.name == resolved_model_name and model.trust_remote_code
+                for model in DATA_RELEASE_MODELS
+            )
+        ),
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
 ]
 dependencies = [
     "sentence-transformers>=4.1.0,<6.0.0",
+    "transformers>=4.41.0,<5.0.0",           # JinaBert remote implementation is incompatible with Transformers 5.x
     "chromadb>=1.5.9,<2.0.0",               # 1.x required to read the published multi-vector data bundles (0.6.x cannot)
     "requests>=2.31.0",
     "urllib3>=2.7.0",                        # Security: CVE fixes (GHSA-48p4-8xcf-vxj5, GHSA-pq67-6m6q-mj2v, PYSEC-2026-141, PYSEC-2026-142)

--- a/scripts/build_data_release.py
+++ b/scripts/build_data_release.py
@@ -94,6 +94,7 @@ def _build_model_bundle(
     output_dir: Path,
     model_name: str,
     model_revision: str,
+    trust_remote_code: bool,
     multi_vector: bool,
     batch_size: int,
     device: str | None,
@@ -110,6 +111,7 @@ def _build_model_bundle(
         data_dir_override=str(data_dir),
         multi_vector=multi_vector,
         model_revision=model_revision,
+        trust_remote_code=trust_remote_code,
     )
     if not success and device != "cpu" and batch_size > 128:
         clear_model_registry()
@@ -123,6 +125,7 @@ def _build_model_bundle(
             data_dir_override=str(data_dir),
             multi_vector=multi_vector,
             model_revision=model_revision,
+            trust_remote_code=trust_remote_code,
         )
     if not success:
         raise ValueError(f"Failed to build {index_type} index for {model_name}")
@@ -169,6 +172,7 @@ def build_release(
                     output_dir=output_dir,
                     model_name=model.name,
                     model_revision=model.revision,
+                    trust_remote_code=model.trust_remote_code,
                     multi_vector=multi_vector,
                     batch_size=batch_size,
                     device=device,

--- a/scripts/build_data_release.py
+++ b/scripts/build_data_release.py
@@ -95,6 +95,7 @@ def _build_model_bundle(
     model_name: str,
     model_revision: str,
     trust_remote_code: bool,
+    code_revision: str | None,
     multi_vector: bool,
     batch_size: int,
     device: str | None,
@@ -112,6 +113,7 @@ def _build_model_bundle(
         multi_vector=multi_vector,
         model_revision=model_revision,
         trust_remote_code=trust_remote_code,
+        code_revision=code_revision,
     )
     if not success and device != "cpu" and batch_size > 128:
         clear_model_registry()
@@ -126,6 +128,7 @@ def _build_model_bundle(
             multi_vector=multi_vector,
             model_revision=model_revision,
             trust_remote_code=trust_remote_code,
+            code_revision=code_revision,
         )
     if not success:
         raise ValueError(f"Failed to build {index_type} index for {model_name}")
@@ -173,6 +176,7 @@ def build_release(
                     model_name=model.name,
                     model_revision=model.revision,
                     trust_remote_code=model.trust_remote_code,
+                    code_revision=model.code_revision,
                     multi_vector=multi_vector,
                     batch_size=batch_size,
                     device=device,

--- a/scripts/verify_data_release.py
+++ b/scripts/verify_data_release.py
@@ -9,11 +9,11 @@ import json
 import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from phentrieve.data_processing.bundle_manifest import BundleManifest
 from phentrieve.data_processing.bundle_packager import (
-    _get_collection,
+    _open_collection,
     _validate_collection_provenance,
     extract_bundle,
 )
@@ -130,33 +130,33 @@ def _verify_archive_index(
     collection_name = generate_collection_name(model.name)
     if multi_vector:
         collection_name = f"{collection_name}_multi"
-    collection = _get_collection(index_dir, collection_name)
-    expected_count = spec.expected_document_count(
-        "multi_vector" if multi_vector else "single_vector"
-    )
-    _validate_collection_provenance(
-        collection=collection,
-        manifest=manifest,
-        model_name=model.name,
-        index_type="multi_vector" if multi_vector else "single_vector",
-        expected_document_count=expected_count,
-        expected_model_revision=model.revision,
-    )
-    if smoke_test:
-        embedding_model = load_embedding_model(
+    with _open_collection(index_dir, collection_name) as collection:
+        expected_count = spec.expected_document_count(
+            "multi_vector" if multi_vector else "single_vector"
+        )
+        _validate_collection_provenance(
+            collection=collection,
+            manifest=manifest,
             model_name=model.name,
-            revision=model.revision,
+            index_type="multi_vector" if multi_vector else "single_vector",
+            expected_document_count=expected_count,
+            expected_model_revision=model.revision,
         )
-        query_embedding = embedding_model.encode(["phenotypic abnormality"])
-        result = collection.query(
-            query_embeddings=query_embedding.tolist(),
-            n_results=1,
-        )
-        if not result.get("ids") or not result["ids"][0]:
-            raise ValueError(
-                f"Retrieval smoke test returned no result for {model.name}"
+        if smoke_test:
+            embedding_model = load_embedding_model(
+                model_name=model.name,
+                revision=model.revision,
             )
-        clear_model_registry()
+            query_embedding = embedding_model.encode(["phenotypic abnormality"])
+            result = cast(Any, collection).query(
+                query_embeddings=query_embedding.tolist(),
+                n_results=1,
+            )
+            if not result.get("ids") or not result["ids"][0]:
+                raise ValueError(
+                    f"Retrieval smoke test returned no result for {model.name}"
+                )
+            clear_model_registry()
 
 
 def verify_release(

--- a/scripts/verify_data_release.py
+++ b/scripts/verify_data_release.py
@@ -116,6 +116,8 @@ def _verify_manifest(
         raise ValueError(
             "Manifest model custom-code policy does not match release spec"
         )
+    if manifest.model.code_revision != model.code_revision:
+        raise ValueError("Manifest model code revision does not match release spec")
     if manifest.model.multi_vector != multi_vector:
         raise ValueError("Manifest vector mode does not match archive name")
 
@@ -151,6 +153,7 @@ def _verify_archive_index(
                 model_name=model.name,
                 revision=model.revision,
                 trust_remote_code=model.trust_remote_code,
+                code_revision=model.code_revision,
             )
             query_embedding = embedding_model.encode(["phenotypic abnormality"])
             result = cast(Any, collection).query(

--- a/scripts/verify_data_release.py
+++ b/scripts/verify_data_release.py
@@ -112,6 +112,10 @@ def _verify_manifest(
         )
     if manifest.model.revision != model.revision:
         raise ValueError("Manifest model revision does not match release spec")
+    if manifest.model.trust_remote_code != model.trust_remote_code:
+        raise ValueError(
+            "Manifest model custom-code policy does not match release spec"
+        )
     if manifest.model.multi_vector != multi_vector:
         raise ValueError("Manifest vector mode does not match archive name")
 
@@ -146,6 +150,7 @@ def _verify_archive_index(
             embedding_model = load_embedding_model(
                 model_name=model.name,
                 revision=model.revision,
+                trust_remote_code=model.trust_remote_code,
             )
             query_embedding = embedding_model.encode(["phenotypic abnormality"])
             result = cast(Any, collection).query(

--- a/tests/unit/api/test_text_processing_router.py
+++ b/tests/unit/api/test_text_processing_router.py
@@ -1029,11 +1029,11 @@ class TestTextProcessingModelValidation:
             ),
         }
 
-    def test_non_default_benchmark_model_does_not_infer_trust_from_name(self):
-        """Only the default retrieval model should require remote-code trust."""
+    def test_release_model_policy_allows_pinned_custom_code(self):
+        """Pinned release models explicitly declare their custom-code requirement."""
         assert (
             _get_trust_remote_code_for_model("jinaai/jina-embeddings-v2-base-de")
-            is False
+            is True
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/core/test_embeddings_real.py
+++ b/tests/unit/core/test_embeddings_real.py
@@ -150,6 +150,29 @@ class TestLoadEmbeddingModel:
 
     @patch("phentrieve.embeddings.SentenceTransformer")
     @patch("phentrieve.embeddings.torch.cuda.is_available")
+    def test_pinned_custom_code_revision_is_forwarded_to_sentence_transformers(
+        self, mock_cuda, mock_st
+    ):
+        mock_cuda.return_value = False
+        mock_model = Mock()
+        mock_st.return_value = mock_model
+
+        load_embedding_model(
+            model_name="example/custom",
+            revision="a" * 40,
+            code_revision="b" * 40,
+            trust_remote_code=True,
+        )
+
+        mock_st.assert_called_once_with(
+            "example/custom",
+            revision="a" * 40,
+            trust_remote_code=True,
+            model_kwargs={"code_revision": "b" * 40},
+        )
+
+    @patch("phentrieve.embeddings.SentenceTransformer")
+    @patch("phentrieve.embeddings.torch.cuda.is_available")
     def test_error_handling(self, mock_cuda, mock_st):
         """Test error handling when model loading fails."""
         # Arrange

--- a/tests/unit/data_processing/test_bundle_packager.py
+++ b/tests/unit/data_processing/test_bundle_packager.py
@@ -15,6 +15,7 @@ import pytest
 from phentrieve.data_processing.bundle_manifest import BundleManifest
 from phentrieve.data_processing.bundle_packager import (
     _get_index_dimension,
+    _open_collection,
     _populate_manifest_from_db,
     _validate_collection_provenance,
     _verify_bundle_checksums,
@@ -104,6 +105,21 @@ class TestCreateBundle:
         assert bundle_path.name == "phentrieve-data-v2025-03-03-minimal.tar.gz"
         with tarfile.open(bundle_path, "r:gz") as tar:
             assert {"hpo_data.db", "manifest.json"} <= set(tar.getnames())
+
+    def test_keeps_chromadb_client_open_until_collection_validation_finishes(
+        self, tmp_path
+    ):
+        """A collection must not outlive the client that owns its Rust bindings."""
+        collection = MagicMock()
+        client = MagicMock()
+        client.get_collection.return_value = collection
+
+        with patch("chromadb.PersistentClient", return_value=client):
+            with _open_collection(tmp_path, "test_collection") as resolved:
+                assert resolved is collection
+                client.close.assert_not_called()
+
+        client.close.assert_called_once()
 
     @pytest.mark.parametrize(
         ("metadata_update", "count", "message"),

--- a/tests/unit/data_processing/test_release_contract.py
+++ b/tests/unit/data_processing/test_release_contract.py
@@ -57,6 +57,10 @@ def test_hpo_v2026_06_23_release_contract_has_complete_matrix():
         "tsystems-ende",
         "distiluse-multi",
     ]
+    assert {model.slug for model in spec.models if model.trust_remote_code} == {
+        "gte-multi",
+        "jina-de",
+    }
 
 
 @pytest.mark.parametrize(
@@ -92,6 +96,16 @@ def test_model_spec_rejects_unpinned_model_revision():
             name="example/model",
             slug="example",
             revision="main",
+        )
+
+
+def test_model_spec_rejects_non_boolean_custom_code_policy():
+    with pytest.raises(ValueError, match="trust_remote_code"):
+        ModelReleaseSpec(
+            name="example/model",
+            slug="example",
+            revision="a" * 40,
+            trust_remote_code="true",  # type: ignore[arg-type]
         )
 
 

--- a/tests/unit/data_processing/test_release_contract.py
+++ b/tests/unit/data_processing/test_release_contract.py
@@ -61,6 +61,12 @@ def test_hpo_v2026_06_23_release_contract_has_complete_matrix():
         "gte-multi",
         "jina-de",
     }
+    assert {
+        model.slug: model.code_revision for model in spec.models if model.code_revision
+    } == {
+        "gte-multi": "40ced75c3017eb27626c9d4ea981bde21a2662f4",
+        "jina-de": "f3ec4cf7de7e561007f27c9efc7148b0bd713f81",
+    }
 
 
 @pytest.mark.parametrize(
@@ -106,6 +112,16 @@ def test_model_spec_rejects_non_boolean_custom_code_policy():
             slug="example",
             revision="a" * 40,
             trust_remote_code="true",  # type: ignore[arg-type]
+        )
+
+
+def test_model_spec_requires_a_pinned_custom_code_revision():
+    with pytest.raises(ValueError, match="code_revision"):
+        ModelReleaseSpec(
+            name="example/model",
+            slug="example",
+            revision="a" * 40,
+            trust_remote_code=True,
         )
 
 

--- a/tests/unit/indexing/test_chromadb_indexer.py
+++ b/tests/unit/indexing/test_chromadb_indexer.py
@@ -56,6 +56,7 @@ class _Client:
     def __init__(self, persist_adds: bool = True) -> None:
         self.collection: _Collection | None = None
         self.persist_adds = persist_adds
+        self.closed = False
 
     def get_collection(self, name: str) -> _Collection:
         if self.collection is None:
@@ -68,6 +69,9 @@ class _Client:
     def create_collection(self, name: str, metadata: dict[str, object]) -> _Collection:
         self.collection = _Collection(metadata, persist_adds=self.persist_adds)
         return self.collection
+
+    def close(self) -> None:
+        self.closed = True
 
 
 @pytest.fixture
@@ -122,6 +126,7 @@ def test_build_writes_pinned_collection_metadata(
     assert client.collection.metadata["index_type"] == "single_vector"
     assert client.collection.metadata["dimension"] == 768
     assert client.collection.metadata["expected_document_count"] == len(documents)
+    assert client.closed
 
 
 def test_build_fails_immediately_when_embedding_fails(
@@ -143,6 +148,7 @@ def test_build_fails_immediately_when_embedding_fails(
     assert not success
     assert client.collection is not None
     assert client.collection.count() == 0
+    assert client.closed
 
 
 def test_build_rejects_a_persisted_count_mismatch(

--- a/tests/unit/scripts/test_verify_data_release.py
+++ b/tests/unit/scripts/test_verify_data_release.py
@@ -87,6 +87,7 @@ def _write_release_archives(bundle_dir: Path, spec: DataReleaseSpec) -> list[Pat
                         dimension=3,
                         multi_vector=multi_vector,
                         revision=model.revision,
+                        trust_remote_code=model.trust_remote_code,
                     ),
                 ),
             )

--- a/tests/unit/test_dependency_security_policy.py
+++ b/tests/unit/test_dependency_security_policy.py
@@ -85,6 +85,36 @@ def test_dependency_review_gate_allowlists_accepted_chromadb_vulnerability() -> 
     assert "GHSA-f4j7-r4q5-qw2c" in ci_workflow
 
 
+def test_transformers_vulnerability_exceptions_are_narrow_and_documented() -> None:
+    """The JinaBert runtime blocks a compatible Transformers 5.x upgrade.
+
+    These exceptions are temporary: the remote Jina implementation is pinned to an
+    immutable commit and must be migrated to a patched Transformers release before
+    they can be removed.
+    """
+    security_workflow = (
+        REPO_ROOT / ".github" / "workflows" / "security.yml"
+    ).read_text(encoding="utf-8")
+    ci_workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8"
+    )
+    dependencies = _pyproject()["project"]["dependencies"]
+
+    assert any(
+        "transformers>=4.41.0,<5.0.0" in dependency for dependency in dependencies
+    )
+    assert "JinaBert" in security_workflow
+    for advisory in (
+        "PYSEC-2025-217",
+        "PYSEC-2026-2288",
+        "PYSEC-2026-2289",
+        "PYSEC-2026-2290",
+    ):
+        assert f"--ignore-vuln {advisory}" in security_workflow
+    for advisory in ("GHSA-29pf-2h5f-8g72", "GHSA-fgcw-684q-jj6r"):
+        assert advisory in ci_workflow
+
+
 def test_chromadb_posthog_transitive_dependency_uses_compatible_api() -> None:
     """ChromaDB 1.5.9 no longer pulls posthog; if a future resolution does, keep
     it below the PostHog 6 capture() signature break (constrained in pyproject)."""

--- a/tests/unit/test_embeddings_model_policy.py
+++ b/tests/unit/test_embeddings_model_policy.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from phentrieve.embeddings import clear_model_registry, load_embedding_model
+from phentrieve.retrieval.model_policy import resolve_retrieval_model_policy
 
 pytestmark = pytest.mark.unit
 
@@ -34,3 +35,20 @@ def test_biolord_like_name_does_not_imply_trust_remote_code(monkeypatch) -> None
 
     assert captured_kwargs["model_name"] == "attacker/BioLORD-remote-code"
     assert captured_kwargs.get("trust_remote_code") is not True
+
+
+@pytest.mark.parametrize(
+    ("model_name", "trust_remote_code"),
+    [
+        ("Alibaba-NLP/gte-multilingual-base", True),
+        ("jinaai/jina-embeddings-v2-base-de", True),
+        ("sentence-transformers/LaBSE", False),
+    ],
+)
+def test_release_model_policy_uses_pinned_custom_code_requirement(
+    model_name: str, trust_remote_code: bool
+) -> None:
+    assert (
+        resolve_retrieval_model_policy(model_name).trust_remote_code
+        is trust_remote_code
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1584,22 +1584,21 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.10.2"
+version = "0.36.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
+    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
     { name = "packaging" },
     { name = "pyyaml" },
+    { name = "requests" },
     { name = "tqdm" },
-    { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/4d/00734890c7fcfe2c7ff04f1c1a167186c42b19e370a2dd8cfd8c34fc92c4/huggingface_hub-1.10.2.tar.gz", hash = "sha256:4b276f820483b709dc86a53bcb8183ea496b8d8447c9f7f88a115a12b498a95f", size = 758428, upload-time = "2026-04-14T10:42:28.498Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782, upload-time = "2026-02-06T09:24:13.098Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/c9/4c1e1216b24bcab140c83acdf8bc89a846ea17cd8a06cd18e3fd308a297f/huggingface_hub-1.10.2-py3-none-any.whl", hash = "sha256:c26c908767cc711493978dc0b4f5747ba7841602997cc98bfd628450a28cf9bc", size = 642581, upload-time = "2026-04-14T10:42:26.563Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395, upload-time = "2026-02-06T09:24:11.133Z" },
 ]
 
 [[package]]
@@ -3434,6 +3433,7 @@ dependencies = [
     { name = "spacy" },
     { name = "torch" },
     { name = "tqdm" },
+    { name = "transformers" },
     { name = "typer" },
     { name = "urllib3" },
 ]
@@ -3529,6 +3529,7 @@ requires-dist = [
     { name = "spacy", specifier = ">=3.8.0,<4.0.0" },
     { name = "torch", specifier = ">=2.11.0,<3.0.0" },
     { name = "tqdm", specifier = ">=4.66.1" },
+    { name = "transformers", specifier = ">=4.41.0,<5.0.0" },
     { name = "typer", specifier = ">=0.24.1,<0.26.0" },
     { name = "umap-learn", marker = "extra == 'analysis'", specifier = ">=0.5.6" },
     { name = "urllib3", specifier = ">=2.7.0" },
@@ -5651,22 +5652,23 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "5.5.4"
+version = "4.57.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "filelock" },
     { name = "huggingface-hub" },
     { name = "numpy" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "regex" },
+    { name = "requests" },
     { name = "safetensors" },
     { name = "tokenizers" },
     { name = "tqdm" },
-    { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/1e/1e244ab2ab50a863e6b52cc55761910567fa532b69a6740f6e99c5fdbd98/transformers-5.5.4.tar.gz", hash = "sha256:2e67cadba81fc7608cc07c4dd54f524820bc3d95b1cabd0ef3db7733c4f8b82e", size = 8227649, upload-time = "2026-04-13T16:55:55.181Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/35/67252acc1b929dc88b6602e8c4a982e64f31e733b804c14bc24b47da35e6/transformers-4.57.6.tar.gz", hash = "sha256:55e44126ece9dc0a291521b7e5492b572e6ef2766338a610b9ab5afbb70689d3", size = 10134912, upload-time = "2026-01-16T10:38:39.284Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/fb/162a66789c65e5afa3b051309240c26bf37fbc8fea285b4546ae747995a2/transformers-5.5.4-py3-none-any.whl", hash = "sha256:0bd6281b82966fe5a7a16f553ea517a9db1dee6284d7cb224dfd88fc0dd1c167", size = 10236696, upload-time = "2026-04-13T16:55:51.497Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl", hash = "sha256:4c9e9de11333ddfe5114bc872c9f370509198acf0b87a832a0ab9458e2bd0550", size = 11993498, upload-time = "2026-01-16T10:38:31.289Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary\n- close each persistent Chroma client on every index-build return path\n- prevent stale SQLite handles when data-release builds delete and recreate an index directory\n- cover both completed and failed embedding batches\n\n## Verification\n- uv run pytest tests/unit/indexing/test_chromadb_indexer.py -n 0\n- uv run ruff check phentrieve/indexing/chromadb_indexer.py tests/unit/indexing/test_chromadb_indexer.py\n- uv run mypy phentrieve/indexing/chromadb_indexer.py