### PR TITLE
feat(release): ship v0.27.0 HPO data defaults

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -38,7 +38,7 @@ ARG SQLITE_SHA3_256=9b2b1e73f577def1d5b75c5541555a7f42e6e073ad19f7a9118478389c9b
 
 # Pre-built data bundle URL (Mode 1)
 # Default: BioLORD multivector bundle - recommended model/index.
-ARG BUNDLE_URL="https://github.com/berntpopp/phentrieve/releases/download/data-v2026-02-16/phentrieve-data-v2026-02-16-biolord-multivec.tar.gz"
+ARG BUNDLE_URL="https://github.com/berntpopp/phentrieve-data/releases/download/hpo-v2026-06-23-r1/phentrieve-data-v2026-06-23-biolord-multivec.tar.gz"
 
 # Build indexes from scratch (Mode 2) - requires BUNDLE_URL=""
 ARG BUILD_INDEXES="false"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "phentrieve"
-version = "0.26.0"
+version = "0.27.0"
 description = "A CLI tool for retrieving Human Phenotype Ontology (HPO) terms from clinical text using multilingual embeddings."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/unit/test_docker_data_release_policy.py
+++ b/tests/unit/test_docker_data_release_policy.py
@@ -1,0 +1,25 @@
+"""Policy checks for the Docker image's embedded HPO data release."""
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_BUNDLE_URL = (
+    "https://github.com/berntpopp/phentrieve-data/releases/download/"
+    "hpo-v2026-06-23-r1/"
+    "phentrieve-data-v2026-06-23-biolord-multivec.tar.gz"
+)
+
+
+def test_docker_builds_default_to_the_current_verified_data_release() -> None:
+    """Standalone and published API images must embed the same verified bundle."""
+    api_dockerfile = (REPO_ROOT / "api" / "Dockerfile").read_text(encoding="utf-8")
+    publish_workflow = (
+        REPO_ROOT / ".github" / "workflows" / "docker-publish.yml"
+    ).read_text(encoding="utf-8")
+
+    assert f'ARG BUNDLE_URL="{DEFAULT_BUNDLE_URL}"' in api_dockerfile
+    assert f"BUNDLE_URL={DEFAULT_BUNDLE_URL}" in publish_workflow

--- a/uv.lock
+++ b/uv.lock
@@ -3410,7 +3410,7 @@ wheels = [
 
 [[package]]
 name = "phentrieve"
-version = "0.26.0"
+version = "0.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Summary
- Default standalone API Docker builds to the verified HPO v2026-06-23 data release in berntpopp/phentrieve-data.
- Keep Docker publishing and standalone builds pinned to the same BioLORD multi-vector asset.
- Bump the Phentrieve package version to 0.27.0.

## Verification
- uv run pytest tests/unit/test_docker_data_release_policy.py -q -n 0
- uv lock

This is a minor release because it changes the default data bundle embedded by standalone Docker builds.