### PR TITLE
fix(data): keep HPO v2026-06-23 as default

### DIFF
--- a/phentrieve/data_processing/bundle_downloader.py
+++ b/phentrieve/data_processing/bundle_downloader.py
@@ -44,6 +44,7 @@ GITHUB_API_BASE = "https://api.github.com"
 # Download configuration
 DEFAULT_TIMEOUT = 60  # seconds
 DOWNLOAD_CHUNK_SIZE = 8192  # bytes
+_HPO_VERSION_PATTERN = re.compile(r"^v(\d{4})-(\d{2})-(\d{2})$")
 
 
 def get_data_release_repository() -> str:
@@ -171,6 +172,24 @@ def _parse_bundle_filename(filename: str) -> tuple[str | None, str | None, bool]
     return None, None, False
 
 
+def _hpo_version_sort_key(hpo_version: str | None) -> tuple[int, int, int]:
+    """Return a sortable release date for a conventional HPO version string."""
+    if hpo_version is None:
+        return (0, 0, 0)
+    match = _HPO_VERSION_PATTERN.fullmatch(hpo_version)
+    if match is None:
+        return (0, 0, 0)
+    return tuple(int(component) for component in match.groups())
+
+
+def _release_hpo_version_sort_key(release: ReleaseInfo) -> tuple[int, int, int]:
+    """Use the newest bundle HPO version, not GitHub's release timestamp."""
+    return max(
+        (_hpo_version_sort_key(bundle.hpo_version) for bundle in release.bundles),
+        default=(0, 0, 0),
+    )
+
+
 def find_bundle(
     model_name: str,
     hpo_version: str | None = None,
@@ -205,6 +224,9 @@ def find_bundle(
         if not releases:
             logger.warning(f"Release {release_tag} not found")
             return None
+
+    if hpo_version is None and release_tag is None:
+        releases = sorted(releases, key=_release_hpo_version_sort_key, reverse=True)
 
     # Search through releases for matching bundle
     for release in releases:

--- a/phentrieve/data_processing/bundle_downloader.py
+++ b/phentrieve/data_processing/bundle_downloader.py
@@ -179,7 +179,8 @@ def _hpo_version_sort_key(hpo_version: str | None) -> tuple[int, int, int]:
     match = _HPO_VERSION_PATTERN.fullmatch(hpo_version)
     if match is None:
         return (0, 0, 0)
-    return tuple(int(component) for component in match.groups())
+    year, month, day = match.groups()
+    return (int(year), int(month), int(day))
 
 
 def _release_hpo_version_sort_key(release: ReleaseInfo) -> tuple[int, int, int]:

--- a/tests/unit/data_processing/test_bundle_downloader.py
+++ b/tests/unit/data_processing/test_bundle_downloader.py
@@ -96,6 +96,47 @@ def test_find_bundle_defaults_to_single_vector_asset(mocker):
     assert bundle.multi_vector is False
 
 
+def test_find_bundle_defaults_to_newest_hpo_version_not_latest_release(mocker):
+    """Historical mirrors must not displace the newest ontology by publish date."""
+    historical = ReleaseInfo(
+        tag_name="data-v2026-02-16",
+        name="Historical data v2026-02-16",
+        published_at="2026-07-15T19:51:42Z",
+        bundles=[
+            BundleAsset(
+                name="phentrieve-data-v2026-02-16-biolord.tar.gz",
+                download_url="https://example.test/v2026-02-16.tar.gz",
+                size=100,
+                hpo_version="v2026-02-16",
+                model_slug="biolord",
+            )
+        ],
+    )
+    current = ReleaseInfo(
+        tag_name="hpo-v2026-06-23-r1",
+        name="Verified data v2026-06-23",
+        published_at="2026-07-15T19:03:18Z",
+        bundles=[
+            BundleAsset(
+                name="phentrieve-data-v2026-06-23-biolord.tar.gz",
+                download_url="https://example.test/v2026-06-23.tar.gz",
+                size=100,
+                hpo_version="v2026-06-23",
+                model_slug="biolord",
+            )
+        ],
+    )
+    mocker.patch(
+        "phentrieve.data_processing.bundle_downloader.list_available_releases",
+        return_value=[historical, current],
+    )
+
+    bundle = find_bundle(model_name="biolord")
+
+    assert bundle is not None
+    assert bundle.hpo_version == "v2026-06-23"
+
+
 def test_find_bundle_can_select_multivector_asset(mocker):
     release = ReleaseInfo(
         tag_name="data-v2026-02-16",


### PR DESCRIPTION
## Summary
- choose the latest HPO version for unversioned bundle discovery instead of GitHub release publication time
- prevent historical release mirrors from displacing the current HPO v2026-06-23 default

## Verification
- uv run pytest tests/unit/data_processing/test_bundle_downloader.py -q -n 0